### PR TITLE
feat: use stack names as folder names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arcane",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arcane",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@codemirror/lang-yaml": "^6.1.2",
         "@codemirror/legacy-modes": "^6.5.1",
@@ -21,6 +21,7 @@
         "prettier": "^3.5.3",
         "prettier-plugin-svelte": "^3.3.3",
         "proper-lockfile": "^4.1.2",
+        "slugify": "^1.6.6",
         "svelte-codemirror-editor": "^1.4.1",
         "svelte-kit-cookie-session": "^4.1.1",
         "thememirror": "^2.0.1"
@@ -6194,6 +6195,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "prettier": "^3.5.3",
     "prettier-plugin-svelte": "^3.3.3",
     "proper-lockfile": "^4.1.2",
+    "slugify": "^1.6.6",
     "svelte-codemirror-editor": "^1.4.1",
     "svelte-kit-cookie-session": "^4.1.1",
     "thememirror": "^2.0.1"

--- a/src/lib/services/api/stack-api-service.ts
+++ b/src/lib/services/api/stack-api-service.ts
@@ -58,6 +58,11 @@ export default class StackAPIService extends BaseAPIService {
 		return res.data;
 	}
 
+	async migrate(id: string) {
+		const res = await this.api.post(`/stacks/${id}/migrate`);
+		return res.data;
+	}
+
 	async list() {
 		const res = await this.api.get('');
 		return res.data;

--- a/src/lib/services/docker/stack-migration-service.ts
+++ b/src/lib/services/docker/stack-migration-service.ts
@@ -1,0 +1,59 @@
+import fs from 'fs/promises';
+import path from 'path';
+import slugify from 'slugify';
+import { ensureStacksDir } from './stack-service';
+
+export async function migrateStacksToNameFolders() {
+	const stacksDir = await ensureStacksDir();
+	const dirs = await fs.readdir(stacksDir);
+
+	for (const dir of dirs) {
+		const oldDirPath = path.join(stacksDir, dir);
+
+		// Only process directories
+		const stat = await fs.stat(oldDirPath);
+		if (!stat.isDirectory()) continue;
+
+		const metaPath = path.join(oldDirPath, 'meta.json');
+		const newMetaPath = path.join(oldDirPath, '.stack.json');
+
+		// Only migrate if meta.json exists and .stack.json does not
+		try {
+			await fs.access(metaPath);
+		} catch {
+			continue; // No meta.json, skip
+		}
+		try {
+			await fs.access(newMetaPath);
+			continue; // Already migrated
+		} catch {}
+
+		// Read and parse meta.json
+		const metaRaw = await fs.readFile(metaPath, 'utf8');
+		const meta = JSON.parse(metaRaw);
+
+		// Generate new directory name
+		const slug = slugify(meta.name, { lower: true, strict: true, trim: true });
+		let newDirName = slug;
+		let counter = 1;
+		while (dirs.includes(newDirName) && newDirName !== dir) {
+			newDirName = `${slug}-${counter++}`;
+		}
+		const newDirPath = path.join(stacksDir, newDirName);
+
+		// Rename directory if needed
+		if (newDirName !== dir) {
+			await fs.rename(oldDirPath, newDirPath);
+		}
+
+		// Update and write .stack.json
+		meta.dirName = newDirName;
+		meta.path = newDirPath;
+		await fs.writeFile(path.join(newDirPath, '.stack.json'), JSON.stringify(meta, null, 2), 'utf8');
+
+		// Remove old meta.json
+		await fs.rm(path.join(newDirPath, 'meta.json'));
+
+		console.log(`Migrated stack "${meta.name}" to folder "${newDirName}"`);
+	}
+}

--- a/src/lib/services/docker/stack-migration-service.ts
+++ b/src/lib/services/docker/stack-migration-service.ts
@@ -1,7 +1,7 @@
-import fs from 'fs/promises';
-import path from 'path';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import slugify from 'slugify';
-import { ensureStacksDir } from './stack-service';
+import { ensureStacksDir, stopStack } from './stack-service';
 
 export async function migrateStacksToNameFolders() {
 	const stacksDir = await ensureStacksDir();
@@ -27,6 +27,14 @@ export async function migrateStacksToNameFolders() {
 			await fs.access(newMetaPath);
 			continue; // Already migrated
 		} catch {}
+
+		// Stop the stack before migration
+		try {
+			await stopStack(dir);
+			console.log(`Stopped stack "${dir}" before migration.`);
+		} catch (err) {
+			console.warn(`Failed to stop stack "${dir}" before migration:`, err);
+		}
 
 		// Read and parse meta.json
 		const metaRaw = await fs.readFile(metaPath, 'utf8');
@@ -56,4 +64,64 @@ export async function migrateStacksToNameFolders() {
 
 		console.log(`Migrated stack "${meta.name}" to folder "${newDirName}"`);
 	}
+}
+
+export async function migrateStackToNameFolder(stackId: string): Promise<void> {
+	const stacksDir = await ensureStacksDir();
+	const oldDirPath = path.join(stacksDir, stackId);
+
+	// Only process if directory exists
+	const stat = await fs.stat(oldDirPath);
+	if (!stat.isDirectory()) throw new Error(`Stack directory "${stackId}" does not exist`);
+
+	const metaPath = path.join(oldDirPath, 'meta.json');
+	const newMetaPath = path.join(oldDirPath, '.stack.json');
+
+	// Only migrate if meta.json exists and .stack.json does not
+	try {
+		await fs.access(metaPath);
+	} catch {
+		throw new Error(`No meta.json found for stack "${stackId}"`);
+	}
+	try {
+		await fs.access(newMetaPath);
+		throw new Error(`Stack "${stackId}" is already migrated`);
+	} catch {}
+
+	// Stop the stack before migration
+	try {
+		await stopStack(stackId);
+		console.log(`Stopped stack "${stackId}" before migration.`);
+	} catch (err) {
+		console.warn(`Failed to stop stack "${stackId}" before migration:`, err);
+	}
+
+	// Read and parse meta.json
+	const metaRaw = await fs.readFile(metaPath, 'utf8');
+	const meta = JSON.parse(metaRaw);
+
+	// Generate new directory name
+	const slug = slugify(meta.name, { lower: true, strict: true, trim: true });
+	let newDirName = slug;
+	let counter = 1;
+	const dirs = await fs.readdir(stacksDir);
+	while (dirs.includes(newDirName) && newDirName !== stackId) {
+		newDirName = `${slug}-${counter++}`;
+	}
+	const newDirPath = path.join(stacksDir, newDirName);
+
+	// Rename directory if needed
+	if (newDirName !== stackId) {
+		await fs.rename(oldDirPath, newDirPath);
+	}
+
+	// Update and write .stack.json
+	meta.dirName = newDirName;
+	meta.path = newDirPath;
+	await fs.writeFile(path.join(newDirPath, '.stack.json'), JSON.stringify(meta, null, 2), 'utf8');
+
+	// Remove old meta.json
+	await fs.rm(path.join(newDirPath, 'meta.json'));
+
+	console.log(`Migrated stack "${meta.name}" to folder "${newDirName}"`);
 }

--- a/src/lib/services/docker/stack-service.ts
+++ b/src/lib/services/docker/stack-service.ts
@@ -350,6 +350,11 @@ export async function loadComposeStacks(): Promise<Stack[]> {
 					status = 'partially running';
 				}
 
+				const isLegacy = !(await fs.access(join(stackDir, '.stack.json')).then(
+					() => true,
+					() => false
+				));
+
 				stacks.push({
 					id: dir,
 					name: meta.name,
@@ -357,7 +362,8 @@ export async function loadComposeStacks(): Promise<Stack[]> {
 					runningCount,
 					status,
 					createdAt: meta.createdAt,
-					updatedAt: meta.updatedAt
+					updatedAt: meta.updatedAt,
+					isLegacy
 				});
 			} catch (err) {
 				console.warn(`Error loading stack ${dir}:`, err);

--- a/src/lib/services/docker/stack-service.ts
+++ b/src/lib/services/docker/stack-service.ts
@@ -317,8 +317,18 @@ export async function loadComposeStacks(): Promise<Stack[]> {
 		const stacks: Stack[] = [];
 
 		for (const dir of stackDirs) {
+			const stackDir = path.join(stacksDir, dir);
+
+			// Skip if not a directory (e.g., .DS_Store or other files)
+			let stat;
 			try {
-				const stackDir = path.join(stacksDir, dir);
+				stat = await fs.stat(stackDir);
+			} catch {
+				continue;
+			}
+			if (!stat.isDirectory()) continue;
+
+			try {
 				const newMetaPath = path.join(stackDir, '.stack.json');
 				const newComposePath = path.join(stackDir, 'compose.yaml');
 
@@ -350,7 +360,7 @@ export async function loadComposeStacks(): Promise<Stack[]> {
 					status = 'partially running';
 				}
 
-				const isLegacy = !(await fs.access(join(stackDir, '.stack.json')).then(
+				const isLegacy = !(await fs.access(path.join(stackDir, '.stack.json')).then(
 					() => true,
 					() => false
 				));

--- a/src/lib/types/actions.type.ts
+++ b/src/lib/types/actions.type.ts
@@ -1,3 +1,3 @@
-export type StackActions = 'start' | 'stop' | 'restart' | 'redeploy' | 'import' | 'destroy' | 'pull';
+export type StackActions = 'start' | 'stop' | 'restart' | 'redeploy' | 'import' | 'destroy' | 'pull' | 'migrate';
 export type ContainerActions = 'start' | 'stop' | 'restart' | 'pull' | 'remove';
 export type PruneType = 'containers' | 'images' | 'networks' | 'volumes';

--- a/src/lib/types/docker/stack.type.ts
+++ b/src/lib/types/docker/stack.type.ts
@@ -19,16 +19,17 @@ export interface StackService {
 export interface Stack {
 	id: string;
 	name: string;
+	dirName?: string;
+	path?: string;
 	services?: StackService[];
-	serviceCount: number;
-	runningCount: number;
-	status: 'running' | 'partially running' | 'stopped';
-	createdAt: string;
-	updatedAt: string;
+	serviceCount?: number;
+	runningCount?: number;
+	status?: 'running' | 'stopped' | 'partially running';
+	isExternal?: boolean;
+	createdAt?: string;
+	updatedAt?: string;
 	composeContent?: string;
 	envContent?: string;
-	isExternal?: boolean;
-	compose?: any;
 	meta?: StackMeta;
 }
 

--- a/src/lib/types/docker/stack.type.ts
+++ b/src/lib/types/docker/stack.type.ts
@@ -32,6 +32,7 @@ export interface Stack {
 	composeContent?: string;
 	envContent?: string;
 	meta?: StackMeta;
+	isLegacy?: boolean;
 }
 
 export interface StackUpdate {

--- a/src/lib/types/docker/stack.type.ts
+++ b/src/lib/types/docker/stack.type.ts
@@ -1,8 +1,11 @@
 export interface StackMeta {
+	id: string;
 	name: string;
 	createdAt: string;
 	updatedAt: string;
 	autoUpdate?: boolean;
+	dirName?: string;
+	path: string;
 }
 
 export interface StackService {
@@ -19,12 +22,10 @@ export interface StackService {
 export interface Stack {
 	id: string;
 	name: string;
-	dirName?: string;
-	path?: string;
 	services?: StackService[];
 	serviceCount?: number;
 	runningCount?: number;
-	status?: 'running' | 'stopped' | 'partially running';
+	status: 'running' | 'stopped' | 'partially running';
 	isExternal?: boolean;
 	createdAt?: string;
 	updatedAt?: string;

--- a/src/lib/utils/fs.utils.ts
+++ b/src/lib/utils/fs.utils.ts
@@ -1,0 +1,22 @@
+import { promises as fs } from 'node:fs';
+
+/**
+ * Helper function to check if a file exists
+ */
+export async function fileExists(filePath: string): Promise<boolean> {
+	try {
+		const stats = await fs.stat(filePath);
+		return stats.isFile();
+	} catch (err) {
+		return false;
+	}
+}
+
+export async function directoryExists(dir: string): Promise<boolean> {
+	try {
+		const stats = await fs.stat(dir);
+		return stats.isDirectory();
+	} catch (err) {
+		return false;
+	}
+}

--- a/src/routes/api/stacks/[stackId]/migrate/+server.ts
+++ b/src/routes/api/stacks/[stackId]/migrate/+server.ts
@@ -1,0 +1,19 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { error, json } from '@sveltejs/kit';
+import { migrateStackToNameFolder } from '$lib/services/docker/stack-migration-service';
+
+export const POST: RequestHandler = async ({ params }) => {
+	const { stackId } = params;
+
+	if (!stackId) {
+		throw error(400, 'Missing stackId');
+	}
+
+	try {
+		await migrateStackToNameFolder(stackId);
+		return json({ success: true, message: `Stack "${stackId}" migrated successfully.` });
+	} catch (err: any) {
+		console.error(err);
+		throw error(500, err?.message || 'Failed to migrate stack');
+	}
+};

--- a/src/routes/stacks/+page.svelte
+++ b/src/routes/stacks/+page.svelte
@@ -29,7 +29,8 @@
 		import: false,
 		redeploy: false,
 		destroy: false,
-		pull: false
+		pull: false,
+		migrate: false
 	});
 	const isAnyLoading = $derived(Object.values(isLoading).some((loading) => loading));
 
@@ -112,6 +113,16 @@
 					}
 				}
 			});
+		} else if (action === 'migrate') {
+			// handleApiReponse(
+			// 	await tryCatch(stackApi.migrate(id)),
+			// 	'Failed to Migrate Stack',
+			// 	(value) => (isLoading.migrate = value),
+			// 	async () => {
+			// 		toast.success('Stack Migrated Successfully.');
+			// 		await invalidateAll();
+			// 	}
+			// );
 		} else {
 			console.error('An Unknown Error Occurred');
 			toast.error('An Unknown Error Occurred');
@@ -229,7 +240,18 @@
 				>
 					{#snippet rows({ item })}
 						{@const stateVariant = statusVariantMap[item.status.toLowerCase()]}
-						<Table.Cell><a class="font-medium hover:underline" href="/stacks/{item.id}/">{item.name}</a></Table.Cell>
+						<Table.Cell>
+							<div class="flex items-center gap-2">
+								<a class="font-medium hover:underline" href="/stacks/{item.id}/">
+									{item.name}
+								</a>
+								{#if item.isLegacy}
+									<span title="This stack uses the legacy layout. Migrate to the new layout from the dropdown menu." class="ml-1 flex items-center" style="filter: drop-shadow(0 0 4px #fbbf24);">
+										<AlertCircle class="w-4 h-4 text-amber-400 animate-pulse" />
+									</span>
+								{/if}
+							</div>
+						</Table.Cell>
 						<Table.Cell>{item.serviceCount}</Table.Cell>
 						<Table.Cell><StatusBadge variant={stateVariant} text={capitalizeFirstLetter(item.status)} /></Table.Cell>
 						<Table.Cell><StatusBadge variant={item.isExternal ? 'amber' : 'green'} text={item.isExternal ? 'External' : 'Managed'} /></Table.Cell>
@@ -287,6 +309,15 @@
 														<StopCircle class="w-4 h-4" />
 													{/if}
 													Stop
+												</DropdownMenu.Item>
+											{/if}
+
+											{#if item.isLegacy}
+												<DropdownMenu.Item onclick={() => performStackAction('migrate', item.id)} class="text-amber-600 hover:text-amber-800 flex items-center">
+													<span title="This stack uses the legacy layout. Migrate to the new layout." class="mr-2 flex items-center">
+														<AlertCircle class="w-4 h-4 text-amber-500" />
+													</span>
+													Migrate
 												</DropdownMenu.Item>
 											{/if}
 

--- a/src/routes/stacks/+page.svelte
+++ b/src/routes/stacks/+page.svelte
@@ -2,7 +2,7 @@
 	import type { PageData } from './$types';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import { Plus, AlertCircle, Layers, Upload, FileStack, Loader2, Play, RotateCcw, StopCircle, Trash2, Ellipsis, Pen, Import } from '@lucide/svelte';
+	import { Plus, AlertCircle, Layers, FileStack, Loader2, Play, RotateCcw, StopCircle, Trash2, Ellipsis, Pen, Import } from '@lucide/svelte';
 	import UniversalTable from '$lib/components/universal-table.svelte';
 	import { openConfirmDialog } from '$lib/components/confirm-dialog';
 	import * as Table from '$lib/components/ui/table';
@@ -114,15 +114,15 @@
 				}
 			});
 		} else if (action === 'migrate') {
-			// handleApiReponse(
-			// 	await tryCatch(stackApi.migrate(id)),
-			// 	'Failed to Migrate Stack',
-			// 	(value) => (isLoading.migrate = value),
-			// 	async () => {
-			// 		toast.success('Stack Migrated Successfully.');
-			// 		await invalidateAll();
-			// 	}
-			// );
+			handleApiReponse(
+				await tryCatch(stackApi.migrate(id)),
+				'Failed to Migrate Stack',
+				(value) => (isLoading.migrate = value),
+				async () => {
+					toast.success('Stack Migrated Successfully.');
+					await invalidateAll();
+				}
+			);
 		} else {
 			console.error('An Unknown Error Occurred');
 			toast.error('An Unknown Error Occurred');

--- a/src/routes/stacks/[stackId]/+page.svelte
+++ b/src/routes/stacks/[stackId]/+page.svelte
@@ -224,7 +224,7 @@
 					<div>
 						<p class="text-sm font-medium text-muted-foreground">Created</p>
 						<p class="text-lg font-medium">
-							{new Date(stack.createdAt).toLocaleString()}
+							{new Date(stack.createdAt ?? '').toLocaleString()}
 						</p>
 					</div>
 					<div class="bg-blue-500/10 p-2 rounded-full">

--- a/src/routes/stacks/new/+page.svelte
+++ b/src/routes/stacks/new/+page.svelte
@@ -32,7 +32,7 @@
 			async (data) => {
 				toast.success(`Stack "${data.stack.name}" created with environment file.`);
 				await invalidateAll();
-				goto(`/stacks/${data.stack.id}`);
+				goto(`/stacks/${data.stack.name}`);
 			}
 		);
 	}


### PR DESCRIPTION
Fixes: https://github.com/ofkm/arcane/issues/140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to migrate legacy stacks to a new standardized folder and file naming format directly from the stacks page.
  - Legacy stacks are now indicated with an alert icon, and a "Migrate" option is available in their action menu.

- **Improvements**
  - Stack directories and metadata now use human-readable, slugified names for better organization.
  - Stack creation and loading support both new and legacy file formats, ensuring backward compatibility.
  - Added visual cues and tooltips to highlight legacy stacks and migration availability.

- **Bug Fixes**
  - Improved validation and error handling during stack migration and creation processes.

- **Chores**
  - Introduced utility functions for checking file and directory existence.
  - Updated dependencies to include slugification support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->