### PR TITLE
fix: env not being loaded for stacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "codemirror": "^6.0.1",
         "dockerode": "^4.0.6",
         "dockerode-compose": "^1.4.0",
+        "dotenv": "^16.5.0",
         "js-yaml": "^4.1.0",
         "nanoid": "^5.1.5",
         "prettier": "^3.5.3",
@@ -3312,6 +3313,18 @@
         "dockerode": "^4.0.0",
         "js-yaml": "^4.0.0",
         "tar-fs": "^2.1.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "codemirror": "^6.0.1",
     "dockerode": "^4.0.6",
     "dockerode-compose": "^1.4.0",
+    "dotenv": "^16.5.0",
     "js-yaml": "^4.1.0",
     "nanoid": "^5.1.5",
     "prettier": "^3.5.3",


### PR DESCRIPTION
Fixes: https://github.com/ofkm/arcane/issues/146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Environment variables from `.env` files are now automatically injected into Docker Compose services when starting, restarting, or redeploying stacks.

- **Chores**
  - Added a new dependency to improve environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->