### PR TITLE
fix: use uid/gid 200 in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /app
 
 # Set up environment variables early for better caching
 # These will serve as defaults if not overridden in docker-compose.yml
-ENV DOCKER_GID=998 PUID=1000 PGID=1000
+ENV DOCKER_GID=998 PUID=2000 PGID=2000
 
 # Set up directories and permissions
 RUN mkdir -p /app/data && chmod 755 /app/data

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -11,8 +11,8 @@ fi
 echo "Entrypoint: Setting up user and permissions..."
 
 # Default PUID/PGID if not provided
-PUID=${PUID:-1000}
-PGID=${PGID:-1000}
+PUID=${PUID:-2000}
+PGID=${PGID:-2000}
 DOCKER_GID=${DOCKER_GID:-998}
 APP_USER="arcane"
 APP_GROUP_FALLBACK="arcane" # Fallback group name if PGID group exists with different name


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated default user and group IDs for container environments from 1000 to 2000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->