### PR TITLE
fix: importing stacks if files are in the data/stacks directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
       # Mount a volume for Arcane's persistent data (stacks, settings, etc.).
       # Replace './arcane-data' with your preferred host path.
       - ./arcane-data:/app/data
+      # This is where you existing stack files are located if you want to import them, when arcane tries
+      # to import it it will need to read from the path the compose file is at, hence why onl read only is needed.
+      - /opt/my-docker-stacks:/opt/my-docker-stacks:ro # Host path : Container path
     environment:
       - APP_ENV=production # Sets the application environment to production.
 

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -71,6 +71,34 @@ services:
 
 When you do this, any settings you change in the Arcane web UI will be saved in that `arcane-data` folder and will still be there even if you restart Arcane.
 
+#### Accessing Other Host Directories (e.g., for Importing Stacks)
+
+Arcane, running inside its container, can't see your computer's files directly unless you tell Docker to share specific folders. If you want to use features like "Import Stacks" to bring in `docker-compose.yml` files from a directory on your computer (that's not already part of the main `arcane-data` volume), you need to:
+
+1.  **Mount the Host Directory as a Volume:**
+    Add another line to the `volumes` section in your Arcane `docker-compose.yml`. This maps the directory on your computer (where your stacks are) to a path _inside_ the Arcane container.
+
+    For example, if your existing stacks are in `/home/user/my-docker-projects` on your host server, you need to map this to the same folder inside the Arcane container like this:
+
+    ```yaml
+    # In your docker-compose.yml file
+    services:
+      arcane:
+        # ... other settings ...
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+          - arcane-data:/app/data
+          - /home/user/my-docker-projects:/home/user/my-docker-projects:ro # Host path : Container path
+        # ... other settings ...
+    ```
+
+    - **Tip:** Using `:ro` (read-only) for the volume is a good idea if Arcane only needs to read these files (like for importing) and not change them. This helps prevent accidental modifications to your original files.
+
+2.  **Use the Container Path in Arcane:**
+    When Arcane's "Import Stacks" feature asks for a directory path to scan, you must provide the path _as seen from inside the container_ (e.g., `/home/user/my-docker-projects` from the example above). Arcane will then look for your `docker-compose.yml` files there.
+
+    Once imported, Arcane typically copies or manages these stack configurations within its own data directory (e.g., in a subfolder of `/app/data/stacks`), so the original files in your mounted import directory are usually just read during the import process.
+
 ### 2. Special Instructions for Arcane (Environment Variables)
 
 Think of these like sticky notes you give to Arcane when it starts up. Some are really important for it to work correctly in Docker.

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -60,11 +60,11 @@ This guide provides the fastest way to get Arcane up and running using Docker Co
               volumes:
                 - /var/run/docker.sock:/var/run/docker.sock
                 - arcane-data:/app/data
-                - /opt/my-docker-stacks:/mnt/imported-stacks:ro # Host path : Container path
+                - /opt/my-docker-stacks:/opt/my-docker-stacks:ro # Host path : Container path
           # ...
           ```
           _Note: Using `:ro` (read-only) for the import volume is a good practice if Arcane only needs to read these files for import._
-      2.  **Provide Container Path to Arcane:** When using Arcane's "Import Stacks" feature, you will specify the path _inside the container_ where Arcane can find these files (e.g., `/mnt/imported-stacks` from the example above). Arcane will then scan this directory for `docker-compose.yml` files.
+      2.  **Provide Container Path to Arcane:** When using Arcane's "Import Stacks" feature, you will specify the path _inside the container_ where Arcane can find these files (e.g., `/opt/my-docker-stacks` from the example above). Arcane will then scan this directory for `docker-compose.yml` files.
       3.  Once imported, Arcane will typically copy or manage these stack configurations within its own data directory (e.g., `/app/data/stacks`), depending on its import logic. The original files in your mounted import directory are usually just read during the import process.
 
     - **Permissions & Environment Variables (Important):**

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -46,7 +46,26 @@ This guide provides the fastest way to get Arcane up and running using Docker Co
     Before starting, review the `docker-compose.yml` file:
 
     - **Docker Socket:** Mounts `/var/run/docker.sock` to allow Arcane to manage Docker.
-    - **Data Persistence:** Uses a volume named `arcane-data` (or a host path like `./arcane-data`) mapped to `/app/data` inside the container. This stores Arcane's settings, stacks, users, sessions, and encryption keys.
+    - **Data Persistence:** Uses a volume named `arcane-data` (or a host path like `./arcane-data`) mapped to `/app/data` inside the container. This stores Arcane's settings, stacks, users, sessions, and encryption keys. By default, Arcane-managed stack files are stored within this volume (e.g., at `/app/data/stacks` inside the container).
+
+    - **Importing Existing Stacks from a Host Directory:**
+      If you have existing `docker-compose.yml` files on your host machine that you want to import into Arcane, you need to make them accessible to the Arcane container:
+
+      1.  **Mount the Host Directory:** Add an additional volume mount to your Arcane `docker-compose.yml` file. This maps the directory on your host (where your stacks are) to a path inside the Arcane container.
+          For example, if your stacks are in `/opt/my-docker-stacks` on your host, you could map them to `/mnt/imported-stacks` inside the container:
+          ```yaml
+          services:
+            arcane:
+              # ... other settings ...
+              volumes:
+                - /var/run/docker.sock:/var/run/docker.sock
+                - arcane-data:/app/data
+                - /opt/my-docker-stacks:/mnt/imported-stacks:ro # Host path : Container path
+          # ...
+          ```
+          _Note: Using `:ro` (read-only) for the import volume is a good practice if Arcane only needs to read these files for import._
+      2.  **Provide Container Path to Arcane:** When using Arcane's "Import Stacks" feature, you will specify the path _inside the container_ where Arcane can find these files (e.g., `/mnt/imported-stacks` from the example above). Arcane will then scan this directory for `docker-compose.yml` files.
+      3.  Once imported, Arcane will typically copy or manage these stack configurations within its own data directory (e.g., `/app/data/stacks`), depending on its import logic. The original files in your mounted import directory are usually just read during the import process.
 
     - **Permissions & Environment Variables (Important):**
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -52,7 +52,7 @@ This guide provides the fastest way to get Arcane up and running using Docker Co
       If you have existing `docker-compose.yml` files on your host machine that you want to import into Arcane, you need to make them accessible to the Arcane container:
 
       1.  **Mount the Host Directory:** Add an additional volume mount to your Arcane `docker-compose.yml` file. This maps the directory on your host (where your stacks are) to a path inside the Arcane container.
-          For example, if your stacks are in `/opt/my-docker-stacks` on your host, you could map them to `/mnt/imported-stacks` inside the container:
+          For example, if your stacks are in `/opt/my-docker-stacks` on your host, you need to map them to `/opt/my-docker-stacks` inside the container:
           ```yaml
           services:
             arcane:

--- a/docs/docs/guides/auto-update.md
+++ b/docs/docs/guides/auto-update.md
@@ -1,0 +1,57 @@
+---
+sidebar_position: 2
+title: Auto Updates
+---
+
+Arcane can automatically monitor your running stacks and redeploy them when new versions of their Docker images become available. This feature helps keep your services up-to-date with minimal manual intervention.
+
+## Global Configuration
+
+First, ensure that the global auto-update feature is enabled in Arcane's settings. You can typically find this in the application's main settings or configuration panel. If this global setting is disabled, no stacks will be auto-updated, regardless of their individual configurations.
+
+## Stack-Specific Configuration via Docker Compose Labels
+
+To enable auto-updates for a specific stack, you need to add a special label to at least one of its services within its `docker-compose.yml` or `compose.yaml` file.
+
+The label to use is: `arcane.stack.auto-update: "true"`
+
+**How it works:**
+
+- If Arcane's global auto-update setting is enabled, Arcane will periodically check all running or partially running stacks.
+- For each stack, it will inspect its `compose.yaml` (or `docker-compose.yml`) file.
+- If **any service** within that compose file contains the label `arcane.stack.auto-update: "true"`, the entire stack is considered eligible for auto-updates.
+- Arcane will then proceed to check the images defined in that stack for newer versions (respecting any version tags you've specified).
+- If an update is found for one or more images that are configured for auto-updates (e.g., using Watchtower labels or if the image itself is eligible), the entire stack will be pulled and redeployed.
+
+**Example:**
+
+Here's how you would enable auto-updates for a stack named `my-web-app` that has a `web` service:
+
+```yaml
+# In your STACKS_DIR/my-web-app/compose.yaml
+
+version: '3.8'
+
+services:
+  web:
+    image: nginx:latest # This image will be monitored for updates
+    ports:
+      - '8080:80'
+    labels:
+      - 'arcane.stack.auto-update=true' # Enables auto-update for the 'my-web-app' stack
+      # You can also add Watchtower-specific labels here if needed for fine-grained control
+      # - "com.centurylinklabs.watchtower.enable=true" # Example if using Watchtower conventions
+
+  # other_service:
+  #   image: redis:alpine
+  #   # This service does not need the label if 'web' already has it for the stack to be eligible.
+  #   # However, its image will also be checked for updates if the stack is redeployed.
+```
+
+**Important Notes:**
+
+- **Only one service needs the label:** You only need to add the `arcane.stack.auto-update: "true"` label to one service in the stack's compose file to make the entire stack eligible.
+- **Global setting priority:** The global auto-update setting in Arcane must be enabled for this label to have any effect.
+- **Image versioning:** Be mindful of the image tags you use (e.g., `latest`, specific versions like `1.2.3`, or rolling tags like `stable`). Auto-updates will pull based on the tag specified. Using `latest` means you'll always get the newest image marked as `latest`.
+- **Redeployment:** When an update is triggered, Arcane will typically perform a full stack redeployment (similar to `docker-compose down` followed by `docker-compose up -d --pull`). Ensure your services are designed to handle graceful shutdowns and startups.
+- **Checking Interval:** The frequency of checks is determined by Arcane's auto-update service configuration (e.g., a cron job or timed interval).

--- a/src/lib/services/api/stack-api-service.ts
+++ b/src/lib/services/api/stack-api-service.ts
@@ -39,11 +39,10 @@ export default class StackAPIService extends BaseAPIService {
 		return res.data;
 	}
 
-	async save(id: string, name: string, content: string, autoUpdate: boolean, envContent?: string) {
+	async save(id: string, name: string, content: string, envContent?: string) {
 		const res = await this.api.put(`/stacks/${id}`, {
 			name,
 			composeContent: content,
-			autoUpdate,
 			envContent
 		});
 		return res.data;

--- a/src/lib/services/docker/stack-service.ts
+++ b/src/lib/services/docker/stack-service.ts
@@ -250,10 +250,6 @@ async function getStackServices(stackId: string, composeContent: string): Promis
 			return nameStartsWithPrefix || hasCorrectLabel;
 		});
 
-		if (stackContainers.length === 0) {
-			console.log(`No running or stopped containers found for stack ${stackId} based on name prefix or label.`);
-		}
-
 		const services: StackService[] = [];
 
 		for (const containerData of stackContainers) {

--- a/src/lib/types/docker/stack.type.ts
+++ b/src/lib/types/docker/stack.type.ts
@@ -33,6 +33,7 @@ export interface Stack {
 	envContent?: string;
 	meta?: StackMeta;
 	isLegacy?: boolean;
+	hasArcaneMeta?: boolean;
 }
 
 export interface StackUpdate {

--- a/src/lib/types/docker/stack.type.ts
+++ b/src/lib/types/docker/stack.type.ts
@@ -25,15 +25,13 @@ export interface Stack {
 	services?: StackService[];
 	serviceCount?: number;
 	runningCount?: number;
-	status: 'running' | 'stopped' | 'partially running';
+	status: 'running' | 'stopped' | 'partially running' | 'unknown';
 	isExternal?: boolean;
 	createdAt?: string;
 	updatedAt?: string;
 	composeContent?: string;
 	envContent?: string;
-	meta?: StackMeta;
 	isLegacy?: boolean;
-	hasArcaneMeta?: boolean;
 }
 
 export interface StackUpdate {

--- a/src/lib/utils/api.util.ts
+++ b/src/lib/utils/api.util.ts
@@ -1,18 +1,40 @@
-import type { Result } from './try-catch';
+import type { Result } from './try-catch'; // Assuming Result<T, Error> is { data?: T, error?: Error }
 import { toast } from 'svelte-sonner';
 import { extractDockerErrorMessage } from '$lib/utils/errors.util';
 
-export function handleApiResultWithCallbacks<T>({ result, message, setLoadingState = () => {}, onSuccess, onError = () => {} }: { result: Result<T, Error>; message: string; setLoadingState?: (value: boolean) => void; onSuccess: (result: Result<T, Error>) => void; onError?: (result: Result<T, Error>) => void }) {
-	setLoadingState(true);
+export function handleApiResultWithCallbacks<T>({
+	result,
+	message,
+	setLoadingState = () => {},
+	onSuccess,
+	onError = () => {}
+}: {
+	result: Result<T, Error>;
+	message: string;
+	setLoadingState?: (value: boolean) => void;
+	onSuccess: (data: T) => void; // Changed: Expects unwrapped data T
+	onError?: (error: Error) => void; // Changed: Expects unwrapped error Error
+}) {
+	// Note: setLoadingState(true) is typically called *before* the async operation
+	// that produces 'result'. Here, it's called after 'result' is available.
+	// This means it will set loading to true, then immediately to false.
+	// Consider moving setLoadingState(true) to before the API call if that's the intent.
+	// For now, respecting its current placement within this utility.
+	// setLoadingState(true); // If this was meant to indicate the start of callback processing.
+
 	if (result.error) {
 		const dockerMsg = extractDockerErrorMessage(result.error);
-		console.error(`onErrorCallback: ${message}:`, result.error);
+		console.error(`API Error: ${message}:`, result.error);
 		toast.error(`${message}: ${dockerMsg}`);
+		onError(result.error); // Pass the unwrapped error
 		setLoadingState(false);
-		onError(result);
-		return;
-	} else if (result.data) {
-		onSuccess(result);
+	} else {
+		// If there's no error, assume result.data contains T.
+		// This handles cases where T might be void (result.data could be undefined)
+		// or T might be null (result.data could be null).
+		// The original `else if (result.data)` was a truthy check.
+		// A more robust assumption is: if no error, it's a success.
+		onSuccess(result.data as T); // Pass result.data (which should be of type T), casting for safety.
 		setLoadingState(false);
 	}
 }

--- a/src/lib/utils/api.util.ts
+++ b/src/lib/utils/api.util.ts
@@ -2,39 +2,17 @@ import type { Result } from './try-catch'; // Assuming Result<T, Error> is { dat
 import { toast } from 'svelte-sonner';
 import { extractDockerErrorMessage } from '$lib/utils/errors.util';
 
-export function handleApiResultWithCallbacks<T>({
-	result,
-	message,
-	setLoadingState = () => {},
-	onSuccess,
-	onError = () => {}
-}: {
-	result: Result<T, Error>;
-	message: string;
-	setLoadingState?: (value: boolean) => void;
-	onSuccess: (data: T) => void; // Changed: Expects unwrapped data T
-	onError?: (error: Error) => void; // Changed: Expects unwrapped error Error
-}) {
-	// Note: setLoadingState(true) is typically called *before* the async operation
-	// that produces 'result'. Here, it's called after 'result' is available.
-	// This means it will set loading to true, then immediately to false.
-	// Consider moving setLoadingState(true) to before the API call if that's the intent.
-	// For now, respecting its current placement within this utility.
-	// setLoadingState(true); // If this was meant to indicate the start of callback processing.
+export function handleApiResultWithCallbacks<T>({ result, message, setLoadingState = () => {}, onSuccess, onError = () => {} }: { result: Result<T, Error>; message: string; setLoadingState?: (value: boolean) => void; onSuccess: (data: T) => void; onError?: (error: Error) => void }) {
+	setLoadingState(true);
 
 	if (result.error) {
 		const dockerMsg = extractDockerErrorMessage(result.error);
 		console.error(`API Error: ${message}:`, result.error);
 		toast.error(`${message}: ${dockerMsg}`);
-		onError(result.error); // Pass the unwrapped error
+		onError(result.error);
 		setLoadingState(false);
 	} else {
-		// If there's no error, assume result.data contains T.
-		// This handles cases where T might be void (result.data could be undefined)
-		// or T might be null (result.data could be null).
-		// The original `else if (result.data)` was a truthy check.
-		// A more robust assumption is: if no error, it's a success.
-		onSuccess(result.data as T); // Pass result.data (which should be of type T), casting for safety.
+		onSuccess(result.data as T);
 		setLoadingState(false);
 	}
 }

--- a/src/routes/api/stacks/[stackId]/+server.ts
+++ b/src/routes/api/stacks/[stackId]/+server.ts
@@ -6,9 +6,9 @@ import { tryCatch } from '$lib/utils/try-catch';
 
 export const PUT: RequestHandler = async ({ params, request }) => {
 	const { stackId } = params;
-	const { name, composeContent, autoUpdate, envContent } = await request.json();
+	const { name, composeContent, envContent } = await request.json();
 
-	const result = await tryCatch(updateStack(stackId, { name, composeContent, autoUpdate, envContent }));
+	const result = await tryCatch(updateStack(stackId, { name, composeContent, envContent }));
 
 	if (result.error) {
 		console.error('Error updating stack:', result.error);

--- a/src/routes/stacks/[stackId]/+page.server.ts
+++ b/src/routes/stacks/[stackId]/+page.server.ts
@@ -31,7 +31,6 @@ export const load: PageServerLoad = async ({ params }) => {
 		name: stack.name,
 		composeContent: stack.composeContent || '',
 		envContent: stack.envContent || '',
-		autoUpdate: stack.meta?.autoUpdate || false,
 		originalName: stack.name,
 		originalComposeContent: stack.composeContent || '',
 		originalEnvContent: stack.envContent || ''

--- a/src/routes/stacks/[stackId]/+page.svelte
+++ b/src/routes/stacks/[stackId]/+page.svelte
@@ -15,7 +15,6 @@
 	import { toast } from 'svelte-sonner';
 	import YamlEditor from '$lib/components/yaml-editor.svelte';
 	import EnvEditor from '$lib/components/env-editor.svelte';
-	import { Switch } from '$lib/components/ui/switch/index.js';
 	import { tryCatch } from '$lib/utils/try-catch';
 	import StackAPIService from '$lib/services/api/stack-api-service';
 	import { handleApiResultWithCallbacks } from '$lib/utils/api.util';
@@ -40,13 +39,11 @@
 	let name = $derived(editorState.name);
 	let composeContent = $derived(editorState.composeContent);
 	let envContent = $derived(editorState.envContent || '');
-	let autoUpdate = $derived(editorState.autoUpdate);
 	let originalName = $derived(editorState.originalName);
 	let originalComposeContent = $derived(editorState.originalComposeContent);
 	let originalEnvContent = $derived(editorState.originalEnvContent || '');
-	let originalAutoUpdate = $derived(editorState.autoUpdate);
 
-	let hasChanges = $derived(name !== originalName || composeContent !== originalComposeContent || envContent !== originalEnvContent || autoUpdate !== originalAutoUpdate);
+	let hasChanges = $derived(name !== originalName || composeContent !== originalComposeContent || envContent !== originalEnvContent);
 
 	const baseServerUrl = $derived(settings?.baseServerUrl || 'localhost');
 
@@ -62,14 +59,13 @@
 		if (!stack || !hasChanges) return;
 
 		handleApiResultWithCallbacks({
-			result: await tryCatch(stackApi.save(stack.id, name, composeContent, autoUpdate, envContent)),
+			result: await tryCatch(stackApi.save(stack.id, name, composeContent, envContent)),
 			message: 'Failed to Save Stack',
 			setLoadingState: (value) => (isLoading.saving = value),
 			onSuccess: async () => {
 				originalName = name;
 				originalComposeContent = composeContent;
 				originalEnvContent = envContent;
-				originalAutoUpdate = autoUpdate;
 
 				console.log('Stack save successful');
 				toast.success('Stack updated successfully!');
@@ -264,14 +260,6 @@
 									<EnvEditor bind:value={envContent} readOnly={isLoading.saving || isLoading.deploying || isLoading.stopping || isLoading.restarting || isLoading.removing} />
 								</div>
 								<p class="text-xs text-muted-foreground">Define environment variables in KEY=value format. These will be saved as a .env file in the stack directory.</p>
-							</div>
-						</div>
-
-						<div class="flex items-center space-x-2 mt-4">
-							<Switch id="auto-update" name="autoUpdate" bind:checked={autoUpdate} />
-							<Label for="auto-update" class="font-medium">Enable auto-update</Label>
-							<div class="inline-block">
-								<p class="text-xs text-muted-foreground">When enabled, Arcane will periodically check for newer versions of all images in this stack and automatically redeploy it.</p>
 							</div>
 						</div>
 					</div>

--- a/src/routes/stacks/[stackId]/+page.svelte
+++ b/src/routes/stacks/[stackId]/+page.svelte
@@ -250,7 +250,10 @@
 					<div class="space-y-4">
 						<div class="grid w-full max-w-sm items-center gap-1.5">
 							<Label for="name">Stack Name</Label>
-							<Input type="text" id="name" name="name" bind:value={name} required disabled={isLoading.saving} />
+							<Input type="text" id="name" name="name" bind:value={name} required disabled={isLoading.saving || stack?.status === 'running' || stack?.status === 'partially running'} />
+							{#if stack?.status === 'running' || stack?.status === 'partially running'}
+								<p class="text-xs text-muted-foreground">Stack name cannot be changed while the stack is running. Please stop the stack first.</p>
+							{/if}
 						</div>
 
 						<div class="grid grid-cols-1 md:grid-cols-3 gap-4">


### PR DESCRIPTION
Fixes:  https://github.com/ofkm/arcane/issues/159

This PR also removes the auto update switch per satck, and requires a certain label to be used in the compose file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new guide explaining how to enable and configure automatic stack updates, including setup steps, label usage, and important considerations.

- **New Features**
  - Improved detection of stacks eligible for auto-updates by inspecting Docker Compose service labels.

- **Bug Fixes**
  - Enhanced handling of missing compose and metadata files, improving robustness when loading or importing stacks.

- **Refactor**
  - Unified stack identification by directory name and removed reliance on deprecated metadata files.
  - Simplified stack rename and update logic for greater reliability.

- **Style**
  - Updated user interface to remove auto-update toggles and related options from the stack editor.

- **Chores**
  - Adjusted API and utility function signatures to streamline data handling and callback usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->