### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - arcane-data:/app/data
-      - /host/path/to/stacks:/app/data/stacks
+      - /host/path/to/stacks:/app/data/projects
     environment:
       - PUID=1000
       - PGID=1000


### PR DESCRIPTION
/app/data/stacks doesn't import existing stacks. Requires internal directory to be set to /app/data/projects

Not sure is this is by design and I am misunderstanding. However, changing to /projects imports existing stacks and new projects are created there as well