### PR TITLE
chore: Auto close VSCode terminals when tasks are finished

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,7 @@
       },
       "presentation": {
         "reveal": "silent",
-        "close": false,
+        "close": true,
         "clear": false,
         "echo": false,
         "focus": false,
@@ -46,7 +46,7 @@
       "group": "build",
       "presentation": {
         "reveal": "silent",
-        "close": false,
+        "close": true,
         "clear": false,
         "echo": false,
         "focus": false,
@@ -63,7 +63,7 @@
       "group": "build",
       "presentation": {
         "reveal": "silent",
-        "close": false,
+        "close": true,
         "clear": false,
         "echo": false,
         "focus": false,


### PR DESCRIPTION
I accidentally disabled the auto-closing feature of the terminals after completing their specific tasks. (I mistakenly believed it prevented error states from displaying, but it wasn’t.) This can clutter up your integrated terminal if you execute multiple tasks, and this addresses that issue.