### PR TITLE
fix: don't override env vars with default settings

### DIFF
--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -78,6 +78,14 @@ func InitializeApp() (*App, error) {
 
 	// Ensure default settings but skip user bootstrap in agent mode
 	slog.InfoContext(appCtx, "Ensuring default settings are initialized")
+	if cfg.AgentMode || cfg.UIConfigurationDisabled {
+		if err := appServices.Settings.PersistEnvSettingsIfMissing(appCtx); err != nil {
+			slog.WarnContext(appCtx, "Failed to persist env-driven settings", slog.String("error", err.Error()))
+		} else {
+			slog.DebugContext(appCtx, "Persisted env-driven settings if missing")
+		}
+	}
+
 	if err := appServices.Settings.EnsureDefaultSettings(appCtx); err != nil {
 		slog.WarnContext(appCtx, "Failed to initialize default settings", slog.String("error", err.Error()))
 	} else {

--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"reflect"
 	"strings"
@@ -98,6 +99,9 @@ func (s *SettingsService) getDefaultSettings() *models.Settings {
 func (s *SettingsService) loadDatabaseSettingsInternal(ctx context.Context, db *database.DB) (*models.Settings, error) {
 
 	if config.Load().UIConfigurationDisabled || config.Load().AgentMode {
+		// debug: show why we're using env path
+		slog.DebugContext(ctx, "loadDatabaseSettingsInternal: using env path", "UIConfigurationDisabled", config.Load().UIConfigurationDisabled, "AgentMode", config.Load().AgentMode, "Environment", config.Load().Environment)
+
 		dst, err := s.loadDatabaseConfigFromEnv(ctx, db)
 
 		if config.Load().Environment != "testing" {
@@ -163,12 +167,25 @@ func (s *SettingsService) loadDatabaseConfigFromEnv(ctx context.Context, db *dat
 
 		envVarName := utils.CamelCaseToScreamingSnakeCase(key)
 
-		value, ok := os.LookupEnv(envVarName)
-		if ok {
-			rv.Field(i).FieldByName("Value").SetString(value)
+		// debug: log each env name checked and whether a value exists
+		if val, ok := os.LookupEnv(envVarName); ok {
+			slog.DebugContext(ctx, "loadDatabaseConfigFromEnv: env override found", "key", key, "env", envVarName, "value", val)
+			rv.Field(i).FieldByName("Value").SetString(val)
 			continue
+		} else {
+			slog.DebugContext(ctx, "loadDatabaseConfigFromEnv: env not set", "key", key, "env", envVarName)
 		}
 	}
+
+	// debug: final snapshot (only show which fields are non-empty)
+	count := 0
+	for i := range rt.NumField() {
+		v := rv.Field(i).FieldByName("Value").String()
+		if v != "" {
+			count++
+		}
+	}
+	slog.DebugContext(ctx, "loadDatabaseConfigFromEnv: completed env load", "loadedFields", count)
 
 	return dest, nil
 }
@@ -377,6 +394,41 @@ func (s *SettingsService) EnsureDefaultSettings(ctx context.Context) error {
 				}
 			} else if err != nil {
 				return fmt.Errorf("failed to check for existing setting %s: %w", defaultSetting.Key, err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *SettingsService) PersistEnvSettingsIfMissing(ctx context.Context) error {
+	settings := s.GetSettingsConfig()
+	vars := settings.ToSettingVariableSlice(true, false)
+
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for _, v := range vars {
+			if v.Value == "" {
+				continue
+			}
+
+			var existing models.SettingVariable
+			err := tx.Where("key = ?", v.Key).First(&existing).Error
+			switch {
+			case errors.Is(err, gorm.ErrRecordNotFound):
+				if err := tx.Create(&v).Error; err != nil {
+					return fmt.Errorf("persist env setting %s: %w", v.Key, err)
+				}
+			case err != nil:
+				return fmt.Errorf("check setting %s: %w", v.Key, err)
+			default:
+				if existing.Value != v.Value {
+					if err := tx.Model(&existing).Update("value", v.Value).Error; err != nil {
+						return fmt.Errorf("update env setting %s: %w", v.Key, err)
+					}
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
Fixes: https://github.com/ofkm/arcane/issues/551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically persists environment-based settings when running in Agent Mode or with UI configuration disabled, ensuring configurations are saved and retained across restarts.
- Chores
  - Expanded startup and settings-loading diagnostics with clearer logs around environment-sourced values to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->