### PR TITLE
fix: correct display of user label in event details

### DIFF
--- a/frontend/src/lib/components/dialogs/event-details-dialog.svelte
+++ b/frontend/src/lib/components/dialogs/event-details-dialog.svelte
@@ -157,7 +157,7 @@
 				</div>
 
 				<div class="rounded-lg border p-3">
-					<div class="text-muted-foreground text-xs">{m.common_user}</div>
+					<div class="text-muted-foreground text-xs">{m.common_user()}</div>
 					<div class="mt-1 flex items-center gap-2 text-sm">
 						<UserIcon class="text-muted-foreground size-4" />
 						{event?.username ?? m.common_unknown()}


### PR DESCRIPTION
When viewing details of an event in the event log, the **user** label was displaying the function code rather the localised text due to the missing paratheses on `m.common_user()`