### PR TITLE
fix: skip onboarding when UI configuration is disabled

### DIFF
--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -77,13 +77,18 @@ func InitializeApp() (*App, error) {
 	}
 	utils.InitEncryption(cfg)
 
-	// Ensure default settings but skip user bootstrap in agent mode
 	slog.InfoContext(appCtx, "Ensuring default settings are initialized")
 	if cfg.AgentMode || cfg.UIConfigurationDisabled {
 		if err := appServices.Settings.PersistEnvSettingsIfMissing(appCtx); err != nil {
 			slog.WarnContext(appCtx, "Failed to persist env-driven settings", slog.String("error", err.Error()))
 		} else {
 			slog.DebugContext(appCtx, "Persisted env-driven settings if missing")
+		}
+
+		if err := appServices.Settings.SetBoolSetting(appCtx, "onboardingCompleted", true); err != nil {
+			slog.WarnContext(appCtx, "Failed to mark onboarding as completed", slog.String("error", err.Error()))
+		} else {
+			slog.InfoContext(appCtx, "Onboarding automatically completed (UI configuration disabled)")
 		}
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/ofkm/arcane/issues/564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically marks onboarding as completed when running in agent mode or with UI configuration disabled, enabling immediate use.
- Bug Fixes
  - Environment-based settings are now reliably detected and applied at startup, reducing cases where configuration from env variables was missed.
- Chores
  - Improved logging around environment-driven settings application and onboarding completion to aid observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->