### PR TITLE
feat: global compose and env default configuration

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1195,5 +1195,15 @@
 	"apply": "Apply",
 	"terminal_websocket_error": "WebSocket error occurred",
 	"terminal_connection_closed": "Connection closed",
-	"shell": "Shell"
+	"shell": "Shell",
+	"customize_defaults_title": "Customize Default Templates",
+	"customize_defaults_heading": "Default Templates Configuration",
+	"customize_defaults_description": "Customize the default Docker Compose and environment templates used when creating new projects. These templates will be pre-populated in the new project form.",
+	"customize_compose_template_label": "Docker Compose Template (YAML)",
+	"customize_env_template_label": "Environment Template (.env)",
+	"customize_validation_error": "Please fix validation errors before saving",
+	"customize_save_failed": "Failed to save default templates",
+	"customize_save_success": "Default templates saved successfully",
+	"customize_reset_success": "Changes reset",
+	"default_templates": "Default Templates"
 }

--- a/frontend/src/lib/config/navigation-config.ts
+++ b/frontend/src/lib/config/navigation-config.ts
@@ -14,6 +14,7 @@ import ComputerIcon from '@lucide/svelte/icons/computer';
 import LockKeyholeIcon from '@lucide/svelte/icons/lock-keyhole';
 import AlarmClockIcon from '@lucide/svelte/icons/alarm-clock';
 import NavigationIcon from '@lucide/svelte/icons/navigation';
+import PaletteIcon from '@lucide/svelte/icons/palette';
 import { m } from '$lib/paraglide/messages';
 
 export type NavigationItem = {
@@ -33,6 +34,11 @@ export const navigationItems: Record<string, NavigationItem[]> = {
 		{ title: m.volumes_title(), url: '/volumes', icon: HardDriveIcon }
 	],
 	customizationItems: [
+		{
+			title: m.default_templates(),
+			url: '/customize/defaults',
+			icon: PaletteIcon
+		},
 		{
 			title: m.templates_title(),
 			url: '/customize/templates',

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,18 +1,1 @@
-export const defaultComposeTemplate = `services:
-  nginx:
-    image: nginx:alpine
-    container_name: nginx_service
-    env_file:
-      - .env
-    ports:
-      - "8080:80"
-    volumes:
-      - nginx_data:/usr/share/nginx/html
-    restart: unless-stopped
-
-volumes:
-  nginx_data:
-    driver: local
-`;
-
 export const DEFAULT_NETWORK_NAMES = new Set(['host', 'bridge', 'none', 'ingress']);

--- a/frontend/src/lib/services/template-service.ts
+++ b/frontend/src/lib/services/template-service.ts
@@ -27,13 +27,20 @@ export default class TemplateService extends BaseAPIService {
 		return response.data?.data;
 	}
 
-	async getEnvTemplate(): Promise<string> {
-		const response = await this.api.get('/templates/env/default');
-		return response.data?.data?.content ?? response.data?.content;
+	async getDefaultTemplates(): Promise<{ composeTemplate: string; envTemplate: string }> {
+		const response = await this.api.get('/templates/default');
+		const data = response.data?.data;
+		return {
+			composeTemplate: data?.composeTemplate ?? '',
+			envTemplate: data?.envTemplate ?? ''
+		};
 	}
 
-	async saveEnvTemplate(content: string): Promise<void> {
-		await this.api.post('/templates/env/default', { content });
+	async saveDefaultTemplates(composeContent: string, envContent: string): Promise<void> {
+		await this.api.post('/templates/default', {
+			composeContent,
+			envContent
+		});
 	}
 
 	async getRegistries(): Promise<TemplateRegistry[]> {

--- a/frontend/src/routes/customize/defaults/+page.svelte
+++ b/frontend/src/routes/customize/defaults/+page.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { toast } from 'svelte-sonner';
+	import CodeEditor from '$lib/components/code-editor/editor.svelte';
+	import { createForm } from '$lib/utils/form.utils';
+	import { tryCatch } from '$lib/utils/try-catch';
+	import { handleApiResultWithCallbacks } from '$lib/utils/api.util';
+	import { m } from '$lib/paraglide/messages';
+	import { templateService } from '$lib/services/template-service';
+	import { z } from 'zod/v4';
+	import { ResourcePageLayout, type ActionButton } from '$lib/layouts/index.js';
+
+	let { data } = $props();
+
+	let saving = $state(false);
+	let originalComposeContent = $state(data.composeTemplate);
+	let originalEnvContent = $state(data.envTemplate);
+
+	const formSchema = z.object({
+		composeContent: z.string().min(1, m.compose_compose_content_required()),
+		envContent: z.string().optional().default('')
+	});
+
+	let formData = $derived({
+		composeContent: originalComposeContent,
+		envContent: originalEnvContent
+	});
+
+	let { inputs, ...form } = $derived(createForm<typeof formSchema>(formSchema, formData));
+
+	const hasChanges = $derived(
+		$inputs.composeContent.value !== originalComposeContent || $inputs.envContent.value !== originalEnvContent
+	);
+
+	async function handleSave() {
+		const validated = form.validate();
+		if (!validated) {
+			toast.error(m.customize_validation_error());
+			return;
+		}
+
+		const { composeContent, envContent } = validated;
+
+		handleApiResultWithCallbacks({
+			result: await tryCatch(templateService.saveDefaultTemplates(composeContent, envContent)),
+			message: m.customize_save_failed(),
+			setLoadingState: (value) => (saving = value),
+			onSuccess: async () => {
+				toast.success(m.customize_save_success());
+				originalComposeContent = $inputs.composeContent.value;
+				originalEnvContent = $inputs.envContent.value;
+			}
+		});
+	}
+
+	async function handleReset() {
+		$inputs.composeContent.value = originalComposeContent;
+		$inputs.envContent.value = originalEnvContent;
+		toast.info(m.customize_reset_success());
+	}
+
+	const actionButtons = $derived<ActionButton[]>([
+		{
+			id: 'reset',
+			action: 'restart',
+			label: m.common_reset(),
+			onclick: handleReset,
+			disabled: !hasChanges
+		},
+		{
+			id: 'save',
+			action: 'save',
+			label: m.common_save(),
+			loadingLabel: m.common_saving(),
+			loading: saving,
+			disabled: saving || !hasChanges,
+			onclick: handleSave
+		}
+	]);
+</script>
+
+<ResourcePageLayout title={m.customize_defaults_title()} subtitle={m.customize_defaults_description()} {actionButtons}>
+	{#snippet mainContent()}
+		<div class="space-y-6">
+			<form class="space-y-6">
+				<div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+					<div class="lg:col-span-2">
+						<div class="space-y-2">
+							<Label for="compose" class="text-sm font-medium">
+								{m.customize_compose_template_label()}
+							</Label>
+							<div
+								class="border-input focus-within:border-primary focus-within:ring-ring relative rounded-md border bg-transparent transition-colors focus-within:ring-2 focus-within:ring-offset-2"
+								class:border-destructive={$inputs.composeContent.error}
+							>
+								<div class="min-h-[500px] w-full overflow-hidden">
+									<CodeEditor bind:value={$inputs.composeContent.value} language="yaml" height="full" />
+								</div>
+							</div>
+							{#if $inputs.composeContent.error}
+								<p class="text-destructive text-xs">
+									{$inputs.composeContent.error}
+								</p>
+							{/if}
+						</div>
+					</div>
+
+					<div class="lg:col-span-1">
+						<div class="space-y-2">
+							<Label for="env" class="text-sm font-medium">
+								{m.customize_env_template_label()}
+							</Label>
+							<div
+								class="border-input focus-within:border-primary focus-within:ring-ring relative rounded-md border bg-transparent transition-colors focus-within:ring-2 focus-within:ring-offset-2"
+								class:border-destructive={$inputs.envContent.error}
+							>
+								<div class="min-h-[500px] w-full overflow-hidden">
+									<CodeEditor bind:value={$inputs.envContent.value} language="env" height="full" />
+								</div>
+							</div>
+							{#if $inputs.envContent.error}
+								<p class="text-destructive text-xs">
+									{$inputs.envContent.error}
+								</p>
+							{/if}
+						</div>
+					</div>
+				</div>
+			</form>
+		</div>
+	{/snippet}
+</ResourcePageLayout>

--- a/frontend/src/routes/customize/defaults/+page.ts
+++ b/frontend/src/routes/customize/defaults/+page.ts
@@ -1,0 +1,13 @@
+import { templateService } from '$lib/services/template-service';
+
+export const load = async () => {
+	const defaultTemplates = await templateService.getDefaultTemplates().catch((err) => {
+		console.warn('Failed to load default templates:', err);
+		return { composeTemplate: '', envTemplate: '' };
+	});
+
+	return {
+		composeTemplate: defaultTemplates.composeTemplate,
+		envTemplate: defaultTemplates.envTemplate
+	};
+};

--- a/frontend/src/routes/projects/new/+page.svelte
+++ b/frontend/src/routes/projects/new/+page.svelte
@@ -14,7 +14,6 @@
 	import { preventDefault, createForm } from '$lib/utils/form.utils';
 	import { tryCatch } from '$lib/utils/try-catch';
 	import { handleApiResultWithCallbacks } from '$lib/utils/api.util';
-	import { defaultComposeTemplate } from '$lib/constants';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
 	import * as Dialog from '$lib/components/ui/dialog/index.js';
 	import TemplateSelectionDialog from '$lib/components/dialogs/template-selection-dialog.svelte';
@@ -46,7 +45,7 @@
 
 	let formData = $derived({
 		name: '',
-		composeContent: data.defaultTemplate || defaultComposeTemplate,
+		composeContent: data.defaultTemplate || '',
 		envContent: data.envTemplate || ''
 	});
 

--- a/frontend/src/routes/projects/new/+page.ts
+++ b/frontend/src/routes/projects/new/+page.ts
@@ -1,21 +1,20 @@
-import { defaultComposeTemplate } from '$lib/constants';
 import { templateService } from '$lib/services/template-service';
 
 export const load = async () => {
-	const [allTemplates, envTemplate] = await Promise.all([
+	const [allTemplates, defaultTemplates] = await Promise.all([
 		templateService.loadAll().catch((err) => {
 			console.warn('Failed to load templates:', err);
 			return [];
 		}),
-		templateService.getEnvTemplate().catch((err) => {
-			console.warn('Failed to load env template:', err);
-			return '';
+		templateService.getDefaultTemplates().catch((err) => {
+			console.warn('Failed to load default templates:', err);
+			return { composeTemplate: '', envTemplate: '' };
 		})
 	]);
 
 	return {
 		composeTemplates: allTemplates,
-		envTemplate,
-		defaultTemplate: defaultComposeTemplate
+		envTemplate: defaultTemplates.envTemplate,
+		defaultTemplate: defaultTemplates.composeTemplate
 	};
 };


### PR DESCRIPTION
Closes: https://github.com/ofkm/arcane/issues/310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “Default Templates” customization page with editors for compose and env templates, including validation, Save/Reset actions, and success/error toasts.
  - New navigation entry under Customization for quick access.

- Improvements
  - Default templates are auto-initialized on first run for a smoother setup.
  - New project creation now uses saved default compose template when available; otherwise starts blank.
  - More resilient loading and error handling for templates.

- Localization
  - Added English translations for the new customization UI and messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->