### PR TITLE
fix: use correct response messages for container registry test

### DIFF
--- a/backend/internal/api/container_registry_handler.go
+++ b/backend/internal/api/container_registry_handler.go
@@ -207,7 +207,7 @@ func (h *ContainerRegistryHandler) TestRegistry(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"success": true,
+		"success": false,
 		"data":    testResult,
 	})
 }

--- a/frontend/src/lib/components/sheets/container-registry-sheet.svelte
+++ b/frontend/src/lib/components/sheets/container-registry-sheet.svelte
@@ -23,7 +23,7 @@
 	let isEditMode = $derived(!!registryToEdit);
 
 	const formSchema = z.object({
-		url: z.url().min(1, m.registries_url_required()),
+		url: z.string().min(1, m.registries_url_required()),
 		username: z.string().min(1, m.common_username_required()),
 		token: z.string().optional(),
 		description: z.string().optional(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Container registry test now returns clearer pass/fail messages with consistent HTTP 200 responses.
  * Improved handling of invalid registry URLs and connectivity failures with more helpful errors.
  * More robust authentication flow with token-based auth discovery and fallback to basic auth.

* Refactor
  * Simplified registry test flow to a binary authentication check and reduced verbose result details.

* Style
  * Form validation for the registry URL now requires a syntactically valid URL, preventing submission of malformed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->