### PR TITLE
refactor: use shadcn spinner component

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "@eslint/js": "^9.37.0",
     "@inlang/paraglide-js": "2.4.0",
     "@internationalized/date": "^3.10.0",
-    "@lucide/svelte": "^0.545.0",
+    "@lucide/svelte": "^0.544.0",
     "@sveltejs/kit": "^2.46.4",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@tailwindcss/vite": "^4.1.14",

--- a/frontend/src/lib/components/arcane-button/arcane-button.svelte
+++ b/frontend/src/lib/components/arcane-button/arcane-button.svelte
@@ -37,7 +37,7 @@
 
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import { arcaneButtonVariants, actionConfigs } from './variants';
 	import { m } from '$lib/paraglide/messages';
 
@@ -95,8 +95,8 @@
 	{#if shouldUseInternalContent}
 		{#if type !== undefined && loading}
 			<div class="absolute inset-0 flex place-items-center justify-center bg-inherit">
-				<div class="flex animate-spin place-items-center justify-center">
-					<LoaderCircleIcon class="size-4" />
+				<div class="flex place-items-center justify-center">
+					<Spinner class="size-4" />
 				</div>
 			</div>
 			<span class="sr-only">{m.common_loading_label({ label: displayLoadingLabel })}</span>

--- a/frontend/src/lib/components/dialogs/prune-confirmation-dialog.svelte
+++ b/frontend/src/lib/components/dialogs/prune-confirmation-dialog.svelte
@@ -5,7 +5,7 @@
 	import { Label } from '$lib/components/ui/label/index.js';
 	import AlertCircleIcon from '@lucide/svelte/icons/alert-circle';
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import * as Alert from '$lib/components/ui/alert/index.js';
 	import { m } from '$lib/paraglide/messages';
 
@@ -141,7 +141,7 @@
 				disabled={selectedTypes.length === 0 || isPruning}
 			>
 				{#if isPruning}
-					<LoaderCircleIcon class="mr-2 size-4 animate-spin" /> {m.images_pruning()}
+					<Spinner class="mr-2 size-4" /> {m.images_pruning()}
 				{:else}
 					<Trash2Icon class="mr-2 size-4" /> {m.prune_button({ count: selectedTypes.length })}
 				{/if}

--- a/frontend/src/lib/components/dialogs/template-selection-dialog.svelte
+++ b/frontend/src/lib/components/dialogs/template-selection-dialog.svelte
@@ -8,7 +8,7 @@
 	import FolderOpenIcon from '@lucide/svelte/icons/folder-open';
 	import SettingsIcon from '@lucide/svelte/icons/settings';
 	import DownloadIcon from '@lucide/svelte/icons/download';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 	import { ScrollArea } from '$lib/components/ui/scroll-area/index.js';
@@ -264,7 +264,7 @@
 																			disabled={loadingStates.get(`download-${template.id}`)}
 																		>
 																			{#if loadingStates.get(`download-${template.id}`)}
-																				<LoaderCircleIcon class="mr-1 size-3 animate-spin" />
+																				<Spinner class="mr-1 size-3" />
 																				{m.templates_downloading()}
 																			{:else}
 																				<DownloadIcon class="mr-1 size-3" />
@@ -278,7 +278,7 @@
 																		disabled={loadingStates.get(template.id)}
 																	>
 																		{#if loadingStates.get(template.id)}
-																			<LoaderCircleIcon class="mr-1 size-3 animate-spin" />
+																			<Spinner class="mr-1 size-3" />
 																			{m.templates_loading()}
 																		{:else}
 																			{m.templates_use_now()}
@@ -353,7 +353,7 @@
 													disabled={loadingStates.get(`download-${template.id}`)}
 												>
 													{#if loadingStates.get(`download-${template.id}`)}
-														<LoaderCircleIcon class="mr-1 size-3 animate-spin" />
+														<Spinner class="mr-1 size-3" />
 														{m.templates_downloading()}
 													{:else}
 														<DownloadIcon class="mr-1 size-3" />
@@ -363,7 +363,7 @@
 											{/if}
 											<Button size="sm" onclick={() => handleSelect(template)} disabled={loadingStates.get(template.id)}>
 												{#if loadingStates.get(template.id)}
-													<LoaderCircleIcon class="mr-1 size-3 animate-spin" />
+													<Spinner class="mr-1 size-3" />
 													{m.templates_loading()}
 												{:else}
 													{m.templates_use_now()}

--- a/frontend/src/lib/components/disk-meter.svelte
+++ b/frontend/src/lib/components/disk-meter.svelte
@@ -6,7 +6,6 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Progress } from '$lib/components/ui/progress/index.js';
 	import HardDriveIcon from '@lucide/svelte/icons/hard-drive';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import SettingsIcon from '@lucide/svelte/icons/settings';
 	import { m } from '$lib/paraglide/messages';
 	import bytes from 'bytes';
@@ -75,7 +74,7 @@
 
 <Card.Root class={className}>
 	{#snippet children()}
-		<Card.Header icon={loading ? LoaderCircleIcon : HardDriveIcon} iconVariant="primary" compact>
+		<Card.Header icon={HardDriveIcon} iconVariant="primary" compact {loading}>
 			{#snippet children()}
 				<div class="min-w-0 flex-1">
 					<div class="text-foreground text-sm font-semibold">{m.dashboard_meter_disk()}</div>

--- a/frontend/src/lib/components/docker-overview.svelte
+++ b/frontend/src/lib/components/docker-overview.svelte
@@ -4,7 +4,6 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import InfoIcon from '@lucide/svelte/icons/info';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import DockerIcon from '$lib/icons/docker-icon.svelte';
 	import BoxIcon from '@lucide/svelte/icons/box';
 	import HardDriveIcon from '@lucide/svelte/icons/hard-drive';
@@ -35,7 +34,7 @@
 
 <Card.Root class={className}>
 	{#snippet children()}
-		<Card.Header icon={loading ? LoaderCircleIcon : DockerIcon} iconVariant="primary" class="items-center">
+		<Card.Header icon={DockerIcon} iconVariant="primary" class="items-center" {loading}>
 			{#snippet children()}
 				{#if loading}
 					<div class="flex flex-1 flex-col gap-2">

--- a/frontend/src/lib/components/gradient-frame-card.svelte
+++ b/frontend/src/lib/components/gradient-frame-card.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card/index.js';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import type { Component, Snippet } from 'svelte';
 	import type { IconProps } from '@lucide/svelte';
 
@@ -46,11 +46,11 @@
 </script>
 
 <Card.Root
-	class={`bg-card/80 ring-border/40 supports-[backdrop-filter]:bg-card/60 group relative flex flex-col gap-6 overflow-hidden rounded-xl border py-3 shadow-sm ring-1 backdrop-blur ring-inset
-        before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:[mask-composite:exclude] before:p-[1px]
-        before:content-['']
+	class={`bg-card/80 ring-border/40 supports-[backdrop-filter]:bg-card/60 group relative flex flex-col gap-6 overflow-hidden rounded-xl border py-3 shadow-sm ring-1 ring-inset backdrop-blur
+        before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[1px] before:content-['']
         before:[-webkit-mask-composite:xor]
         before:[-webkit-mask:linear-gradient(#000_0_0)_content-box,linear-gradient(#000_0_0)]
+        before:[mask-composite:exclude]
         before:[mask:linear-gradient(#000_0_0)_content-box,linear-gradient(#000_0_0)]
         ${frameGradientClass} ${className ?? ''}`}
 >
@@ -61,7 +61,7 @@
 				<div class="relative">
 					<div class={`flex size-10 items-center justify-center rounded-lg ${iconBoxClass}`}>
 						{#if loading}
-							<LoaderCircleIcon class={`size-4 ${iconColorClass} motion-safe:animate-spin`} />
+							<Spinner />
 						{:else}
 							<IconComponent class={`size-5 ${iconColorClass}`} />
 						{/if}

--- a/frontend/src/lib/components/image-update-item.svelte
+++ b/frontend/src/lib/components/image-update-item.svelte
@@ -3,7 +3,7 @@
 	import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
 	import CircleFadingArrowUpIcon from '@lucide/svelte/icons/circle-fading-arrow-up';
 	import CircleArrowUpIcon from '@lucide/svelte/icons/circle-arrow-up';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
 	import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
@@ -13,9 +13,11 @@
 	import type { ImageUpdateData } from '$lib/types/image.type';
 	import { m } from '$lib/paraglide/messages';
 	import { imageService } from '$lib/services/image-service';
+	import type { Snippet } from 'svelte';
+	import type { Component } from 'svelte';
 
 	interface Props {
-		updateInfo?: ImageUpdateData | undefined;
+		updateInfo?: ImageUpdateData;
 		isLoadingInBackground?: boolean;
 		imageId: string;
 		repo?: string;
@@ -23,31 +25,21 @@
 		onUpdated?: (data: ImageUpdateData) => void;
 	}
 
-	let { updateInfo = undefined, isLoadingInBackground = false, imageId, repo, tag, onUpdated }: Props = $props();
+	let { updateInfo = $bindable(), isLoadingInBackground = false, imageId, repo, tag, onUpdated }: Props = $props();
 
-	let localUpdateInfo = $state<ImageUpdateData | undefined>(updateInfo);
 	let isChecking = $state(false);
 
-	$effect(() => {
-		localUpdateInfo = updateInfo;
-	});
-
-	function canCheckUpdate() {
-		return !!(repo && tag && repo !== '<none>' && tag !== '<none>');
-	}
-
-	function hasError() {
-		return !!localUpdateInfo?.error && localUpdateInfo.error.trim() !== '';
-	}
+	const canCheckUpdate = $derived(!!(repo && tag && repo !== '<none>' && tag !== '<none>'));
+	const hasError = $derived(!!updateInfo?.error && updateInfo.error.trim() !== '');
 
 	type AuthBadge = { label: string; classes: string };
 
-	function authBadge(): AuthBadge | null {
-		const mth = localUpdateInfo?.authMethod;
+	const authBadge = $derived.by((): AuthBadge | null => {
+		const mth = updateInfo?.authMethod;
 		if (!mth) return null;
 
 		if (mth === 'credential') {
-			const user = localUpdateInfo?.authUsername;
+			const user = updateInfo?.authUsername;
 			return {
 				label: user ? m.image_update_auth_credential_with_user({ username: user }) : m.image_update_auth_credential(),
 				classes: 'border-amber-200/60 text-amber-800 dark:text-amber-300 bg-amber-100 dark:bg-amber-900/30'
@@ -66,34 +58,31 @@
 			};
 		}
 		return null;
-	}
+	});
 
-	function displayCurrentVersion(): string {
-		if (localUpdateInfo?.currentVersion && localUpdateInfo.currentVersion.trim() !== '') {
-			return localUpdateInfo.currentVersion;
-		}
-		return tag || m.common_unknown();
-	}
+	const currentVersion = $derived(
+		updateInfo?.currentVersion && updateInfo.currentVersion.trim() !== '' ? updateInfo.currentVersion : tag || m.common_unknown()
+	);
 
-	function displayLatestVersion(): string | null {
-		if (hasError()) return null;
-		if (localUpdateInfo?.latestVersion && localUpdateInfo.latestVersion.trim() !== '') {
-			return localUpdateInfo.latestVersion;
+	const latestVersion = $derived.by((): string | null => {
+		if (hasError) return null;
+		if (updateInfo?.latestVersion && updateInfo.latestVersion.trim() !== '') {
+			return updateInfo.latestVersion;
 		}
-		if (localUpdateInfo?.updateType === 'digest' && localUpdateInfo?.latestDigest) {
-			return localUpdateInfo.latestDigest.slice(7, 19) + '...';
+		if (updateInfo?.updateType === 'digest' && updateInfo?.latestDigest) {
+			return updateInfo.latestDigest.slice(7, 19) + '...';
 		}
 		return null;
-	}
+	});
 
 	async function checkImageUpdate() {
-		if (!canCheckUpdate() || isChecking) return;
+		if (!canCheckUpdate || isChecking) return;
 
 		isChecking = true;
 		try {
 			const result = await imageService.checkImageUpdateByID(imageId);
 			if (result) {
-				localUpdateInfo = result;
+				updateInfo = result;
 				onUpdated?.(result);
 
 				if (result.error) {
@@ -117,7 +106,7 @@
 				responseTimeMs: 0,
 				error: (error as Error)?.message || m.images_update_check_failed()
 			};
-			localUpdateInfo = errorInfo;
+			updateInfo = errorInfo;
 			onUpdated?.(errorInfo);
 			toast.error(errorInfo.error);
 		} finally {
@@ -125,40 +114,250 @@
 		}
 	}
 
-	function getUpdatePriority(u: ImageUpdateData): {
-		level: string;
-		color: string;
-		description: string;
-	} {
-		if (u.error) return { level: 'Error', color: 'text-red-500', description: m.image_update_could_not_query_registry() };
-		if (!u.hasUpdate) return { level: 'None', color: 'text-green-500', description: m.image_update_up_to_date_desc() };
-		if (u.updateType === 'digest')
+	const updatePriority = $derived.by(() => {
+		if (!updateInfo) return null;
+		if (updateInfo.error)
+			return { level: 'Error', color: 'text-red-500', description: m.image_update_could_not_query_registry() };
+		if (!updateInfo.hasUpdate) return { level: 'None', color: 'text-green-500', description: m.image_update_up_to_date_desc() };
+		if (updateInfo.updateType === 'digest')
 			return {
 				level: m.image_update_digest_title(),
 				color: 'text-blue-500',
 				description: m.image_update_digest_desc()
 			};
-		if (u.updateType === 'tag') {
-			const desc = u.latestVersion
-				? m.image_update_tag_description_new({ version: u.latestVersion })
+		if (updateInfo.updateType === 'tag') {
+			const desc = updateInfo.latestVersion
+				? m.image_update_tag_description_new({ version: updateInfo.latestVersion })
 				: m.image_update_tag_description();
 			return { level: m.image_update_version_title(), color: 'text-yellow-500', description: desc };
 		}
 		return { level: m.common_unknown(), color: 'text-gray-500', description: m.image_update_unknown_type() };
-	}
+	});
 </script>
 
-{#if localUpdateInfo}
-	{@const priority = getUpdatePriority(localUpdateInfo)}
+{#snippet iconCircle(Icon: Component, gradientFrom: string, gradientTo: string, shadowColor: string)}
+	<div
+		class="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br {gradientFrom} {gradientTo} shadow-lg {shadowColor}"
+	>
+		<Icon class="size-5 text-white" />
+	</div>
+{/snippet}
+
+{#snippet authBadgeDisplay()}
+	{#if authBadge}
+		<div class="mt-2">
+			<div
+				class="inline-flex items-center gap-1 whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-medium {authBadge.classes}"
+			>
+				<KeyRoundIcon class="size-3 opacity-80" />
+				<span>{m.image_update_auth({ label: authBadge.label })}</span>
+			</div>
+		</div>
+	{/if}
+{/snippet}
+
+{#snippet versionDisplay(label: string, version: string, bgClass: string, textClass: string = '')}
+	<div class="flex items-center justify-between">
+		<div class="flex items-center gap-1.5 text-gray-500 dark:text-gray-400">
+			{#if label === m.image_update_current_label()}
+				<PackageIcon class="size-3" />
+			{:else}
+				<ArrowRightIcon class="size-3" />
+			{/if}
+			<span>{label}</span>
+		</div>
+		<span class="rounded {bgClass} px-1.5 py-0.5 font-mono font-medium {textClass}">
+			{version}
+		</span>
+	</div>
+{/snippet}
+
+{#snippet recheckButton()}
+	{#if canCheckUpdate}
+		<div class="border-t border-gray-200/50 bg-gray-50/50 p-3 dark:border-gray-800/50 dark:bg-gray-900/50">
+			<button
+				onclick={checkImageUpdate}
+				disabled={isChecking}
+				class="group flex w-full items-center justify-center gap-2 rounded-lg bg-white/80 px-3 py-2 text-xs font-medium text-gray-700 shadow-sm transition-all hover:bg-white hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-800/80 dark:text-gray-300 dark:hover:bg-gray-800"
+			>
+				{#if isChecking}
+					<Spinner class="size-3" />
+					{m.images_checking()}
+				{:else}
+					<RefreshCwIcon class="size-3 transition-transform group-hover:rotate-45" />
+					{m.image_update_recheck_button()}
+				{/if}
+			</button>
+		</div>
+	{/if}
+{/snippet}
+
+{#snippet errorState()}
+	<div class="bg-gradient-to-br from-rose-50 to-red-50/40 p-4 dark:from-rose-950/20 dark:to-red-950/10">
+		<div class="flex items-start gap-3">
+			{@render iconCircle(TriangleAlertIcon, 'from-rose-500', 'to-red-500', 'shadow-red-500/25')}
+			<div class="flex-1">
+				<div class="text-sm font-semibold text-red-900 dark:text-red-100">{m.image_update_check_failed_title()}</div>
+				<div class="text-xs text-red-700/80 dark:text-red-300/80">{m.image_update_could_not_query_registry()}</div>
+				{@render authBadgeDisplay()}
+			</div>
+		</div>
+	</div>
+	<div class="bg-white/90 p-4 dark:bg-gray-950/90">
+		<div class="space-y-3">
+			<div class="text-xs text-gray-600 dark:text-gray-300">
+				<span class="font-medium">{m.image_update_error_label()}</span>
+				<span class="ml-1 break-words">{updateInfo?.error}</span>
+			</div>
+			{#if repo && tag}
+				<div class="text-xs text-gray-500 dark:text-gray-400">
+					{m.image_update_image_label()} <span class="font-mono">{repo}:{tag}</span>
+				</div>
+			{/if}
+		</div>
+	</div>
+	{@render recheckButton()}
+{/snippet}
+
+{#snippet successState()}
+	<div class="bg-gradient-to-br from-emerald-50 to-green-50/30 p-4 dark:from-emerald-950/20 dark:to-green-950/10">
+		<div class="flex items-start gap-3">
+			{@render iconCircle(CircleCheckIcon, 'from-emerald-500', 'to-green-500', 'shadow-emerald-500/25')}
+			<div class="flex-1">
+				<div class="text-sm font-semibold text-emerald-900 dark:text-emerald-100">
+					{m.image_update_up_to_date_title()}
+				</div>
+				<div class="text-xs text-emerald-700/80 dark:text-emerald-300/80">{m.image_update_up_to_date_desc()}</div>
+				{@render authBadgeDisplay()}
+			</div>
+		</div>
+	</div>
+	<div class="bg-white/90 p-4 dark:bg-gray-950/90">
+		<div class="text-center">
+			<div class="mb-2 text-xs text-gray-600 dark:text-gray-400">
+				{m.image_update_running_prefix()}
+				<span class="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs font-medium dark:bg-gray-800">{currentVersion}</span>
+			</div>
+			<div class="text-xs leading-relaxed text-gray-500 dark:text-gray-400">
+				{m.image_update_up_to_date_desc()}
+			</div>
+		</div>
+	</div>
+	{@render recheckButton()}
+{/snippet}
+
+{#snippet digestUpdateState()}
+	<div class="bg-gradient-to-br from-blue-50 to-cyan-50/30 p-4 dark:from-blue-950/20 dark:to-cyan-950/10">
+		<div class="flex items-start gap-3">
+			{@render iconCircle(CircleArrowUpIcon, 'from-blue-500', 'to-cyan-500', 'shadow-blue-500/25')}
+			<div class="flex-1">
+				<div class="text-sm font-semibold text-blue-900 dark:text-blue-100">{m.image_update_digest_title()}</div>
+				<div class="text-xs text-blue-700/80 dark:text-blue-300/80">{m.image_update_digest_desc()}</div>
+				{@render authBadgeDisplay()}
+			</div>
+		</div>
+	</div>
+	<div class="bg-white/90 p-4 dark:bg-gray-950/90">
+		<div class="space-y-3">
+			<div class="space-y-2 text-xs">
+				{@render versionDisplay(m.image_update_current_label(), currentVersion, 'bg-gray-100 dark:bg-gray-800', '')}
+				{#if latestVersion}
+					{@render versionDisplay(
+						m.image_update_latest_digest_label(),
+						latestVersion,
+						'bg-blue-100 dark:bg-blue-900/30',
+						'text-blue-700 dark:text-blue-300'
+					)}
+				{/if}
+			</div>
+			{#if updatePriority}
+				<div class="rounded-lg bg-blue-50 p-3 dark:bg-blue-950/30">
+					<div class="text-center text-xs font-medium leading-relaxed text-blue-700 dark:text-blue-300">
+						{updatePriority.description}
+					</div>
+				</div>
+			{/if}
+		</div>
+	</div>
+	{@render recheckButton()}
+{/snippet}
+
+{#snippet versionUpdateState()}
+	<div class="bg-gradient-to-br from-amber-50 to-yellow-50/30 p-4 dark:from-amber-950/20 dark:to-yellow-950/10">
+		<div class="flex items-start gap-3">
+			{@render iconCircle(CircleFadingArrowUpIcon, 'from-amber-500', 'to-yellow-500', 'shadow-amber-500/25')}
+			<div class="flex-1">
+				<div class="text-sm font-semibold text-amber-900 dark:text-amber-100">{m.image_update_version_title()}</div>
+				<div class="text-xs text-amber-700/80 dark:text-amber-300/80">{m.image_update_version_desc()}</div>
+				{@render authBadgeDisplay()}
+			</div>
+		</div>
+	</div>
+	<div class="bg-white/90 p-4 dark:bg-gray-950/90">
+		<div class="space-y-3">
+			<div class="space-y-2 text-xs">
+				{@render versionDisplay(m.image_update_current_label(), currentVersion, 'bg-gray-100 dark:bg-gray-800', '')}
+				{#if latestVersion}
+					{@render versionDisplay(
+						m.image_update_latest_label(),
+						latestVersion,
+						'bg-amber-100 dark:bg-amber-900/30',
+						'text-amber-700 dark:text-amber-300'
+					)}
+				{/if}
+			</div>
+			{#if updatePriority}
+				<div class="rounded-lg bg-amber-50 p-3 dark:bg-amber-950/30">
+					<div class="text-center text-xs font-medium leading-relaxed text-amber-700 dark:text-amber-300">
+						{updatePriority.description}
+					</div>
+				</div>
+			{/if}
+		</div>
+	</div>
+	{@render recheckButton()}
+{/snippet}
+
+{#snippet loadingState()}
+	<div class="bg-gradient-to-br from-blue-50 to-cyan-50/30 p-4 dark:from-blue-950/20 dark:to-cyan-950/10">
+		<div class="flex items-center gap-3">
+			{@render iconCircle(Spinner, 'from-blue-500', 'to-cyan-500', 'shadow-blue-500/25')}
+			<div>
+				<div class="text-sm font-semibold text-blue-900 dark:text-blue-100">{m.image_update_checking_title()}</div>
+				<div class="text-xs text-blue-700/80 dark:text-blue-300/80">{m.image_update_querying_registry()}</div>
+			</div>
+		</div>
+	</div>
+{/snippet}
+
+{#snippet unknownState()}
+	<div class="bg-gradient-to-br from-gray-50 to-slate-50/30 p-4 dark:from-gray-900/20 dark:to-slate-900/10">
+		<div class="flex items-center gap-3">
+			{@render iconCircle(TriangleAlertIcon, 'from-gray-400', 'to-slate-500', 'shadow-gray-400/25')}
+			<div>
+				<div class="text-sm font-semibold text-gray-900 dark:text-gray-100">{m.image_update_status_unknown()}</div>
+				<div class="text-xs text-gray-700/80 dark:text-gray-300/80">
+					{#if canCheckUpdate}
+						{m.image_update_click_to_check()}
+					{:else}
+						{m.image_update_unable_check_tags()}
+					{/if}
+				</div>
+			</div>
+		</div>
+	</div>
+{/snippet}
+
+{#if updateInfo}
 	<Tooltip.Provider>
 		<Tooltip.Root>
 			<Tooltip.Trigger>
 				<span class="mr-2 inline-flex size-4 items-center justify-center align-middle">
-					{#if hasError()}
+					{#if hasError}
 						<TriangleAlertIcon class="size-4 text-red-500" />
-					{:else if !localUpdateInfo.hasUpdate}
+					{:else if !updateInfo.hasUpdate}
 						<CircleCheckIcon class="size-4 text-green-500" />
-					{:else if localUpdateInfo.updateType === 'digest'}
+					{:else if updateInfo.updateType === 'digest'}
 						<CircleArrowUpIcon class="size-4 text-blue-500" />
 					{:else}
 						<CircleFadingArrowUpIcon class="size-4 text-yellow-500" />
@@ -172,226 +371,14 @@
 				align="center"
 			>
 				<div class="overflow-hidden rounded-xl">
-					{#if hasError()}
-						{@const badge = authBadge()}
-						<!-- Error State -->
-						<div class="bg-gradient-to-br from-rose-50 to-red-50/40 p-4 dark:from-rose-950/20 dark:to-red-950/10">
-							<div class="flex items-start gap-3">
-								<div
-									class="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-rose-500 to-red-500 shadow-lg shadow-red-500/25"
-								>
-									<TriangleAlertIcon class="size-5 text-white" />
-								</div>
-								<div class="flex-1">
-									<div class="text-sm font-semibold text-red-900 dark:text-red-100">{m.image_update_check_failed_title()}</div>
-									<div class="text-xs text-red-700/80 dark:text-red-300/80">{m.image_update_could_not_query_registry()}</div>
-									{#if badge}
-										<div class="mt-2">
-											<div
-												class={'inline-flex items-center gap-1 whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-medium ' +
-													badge.classes}
-											>
-												<KeyRoundIcon class="size-3 opacity-80" />
-												<span>{m.image_update_auth({ label: badge.label })}</span>
-											</div>
-										</div>
-									{/if}
-								</div>
-							</div>
-						</div>
-						<div class="bg-white/90 p-4 dark:bg-gray-950/90">
-							<div class="space-y-3">
-								<div class="text-xs text-gray-600 dark:text-gray-300">
-									<span class="font-medium">{m.image_update_error_label()}</span>
-									<span class="ml-1 break-words">{localUpdateInfo.error}</span>
-								</div>
-								{#if repo && tag}
-									<div class="text-xs text-gray-500 dark:text-gray-400">
-										{m.image_update_image_label()} <span class="font-mono">{repo}:{tag}</span>
-									</div>
-								{/if}
-							</div>
-						</div>
-					{:else if !localUpdateInfo.hasUpdate}
-						{@const badge = authBadge()}
-						<!-- Success State -->
-						<div class="bg-gradient-to-br from-emerald-50 to-green-50/30 p-4 dark:from-emerald-950/20 dark:to-green-950/10">
-							<div class="flex items-start gap-3">
-								<div
-									class="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-emerald-500 to-green-500 shadow-lg shadow-emerald-500/25"
-								>
-									<CircleCheckIcon class="size-5 text-white" />
-								</div>
-								<div class="flex-1">
-									<div class="text-sm font-semibold text-emerald-900 dark:text-emerald-100">
-										{m.image_update_up_to_date_title()}
-									</div>
-									<div class="text-xs text-emerald-700/80 dark:text-emerald-300/80">{m.image_update_up_to_date_desc()}</div>
-									{#if badge}
-										<div class="mt-2">
-											<div
-												class={'inline-flex items-center gap-1 whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-medium ' +
-													badge.classes}
-											>
-												<KeyRoundIcon class="size-3 opacity-80" />
-												<span>{m.image_update_auth({ label: badge.label })}</span>
-											</div>
-										</div>
-									{/if}
-								</div>
-							</div>
-						</div>
-						<div class="bg-white/90 p-4 dark:bg-gray-950/90">
-							<div class="text-center">
-								<div class="mb-2 text-xs text-gray-600 dark:text-gray-400">
-									{m.image_update_running_prefix()}
-									<span class="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs font-medium dark:bg-gray-800"
-										>{displayCurrentVersion()}</span
-									>
-								</div>
-								<div class="text-xs leading-relaxed text-gray-500 dark:text-gray-400">
-									{m.image_update_up_to_date_desc()}
-								</div>
-							</div>
-						</div>
-					{:else if localUpdateInfo.updateType === 'digest'}
-						{@const badge = authBadge()}
-						<!-- Digest Update State -->
-						<div class="bg-gradient-to-br from-blue-50 to-cyan-50/30 p-4 dark:from-blue-950/20 dark:to-cyan-950/10">
-							<div class="flex items-start gap-3">
-								<div
-									class="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-cyan-500 shadow-lg shadow-blue-500/25"
-								>
-									<CircleArrowUpIcon class="size-5 text-white" />
-								</div>
-								<div class="flex-1">
-									<div class="text-sm font-semibold text-blue-900 dark:text-blue-100">{m.image_update_digest_title()}</div>
-									<div class="text-xs text-blue-700/80 dark:text-blue-300/80">{m.image_update_digest_desc()}</div>
-									{#if badge}
-										<div class="mt-2">
-											<div
-												class={'inline-flex items-center gap-1 whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-medium ' +
-													badge.classes}
-											>
-												<KeyRoundIcon class="size-3 opacity-80" />
-												<span>{m.image_update_auth({ label: badge.label })}</span>
-											</div>
-										</div>
-									{/if}
-								</div>
-							</div>
-						</div>
-						<div class="bg-white/90 p-4 dark:bg-gray-950/90">
-							<div class="space-y-3">
-								<div class="space-y-2 text-xs">
-									<div class="flex items-center justify-between">
-										<div class="flex items-center gap-1.5 text-gray-500 dark:text-gray-400">
-											<PackageIcon class="size-3" />
-											<span>{m.image_update_current_label()}</span>
-										</div>
-										<span class="rounded bg-gray-100 px-1.5 py-0.5 font-mono font-medium dark:bg-gray-800"
-											>{displayCurrentVersion()}</span
-										>
-									</div>
-									{#if displayLatestVersion()}
-										<div class="flex items-center justify-between">
-											<div class="flex items-center gap-1.5 text-gray-500 dark:text-gray-400">
-												<ArrowRightIcon class="size-3" />
-												<span>{m.image_update_latest_digest_label()}</span>
-											</div>
-											<span
-												class="rounded bg-blue-100 px-1.5 py-0.5 font-mono font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
-											>
-												{displayLatestVersion()}
-											</span>
-										</div>
-									{/if}
-								</div>
-								<div class="rounded-lg bg-blue-50 p-3 dark:bg-blue-950/30">
-									<div class="text-center text-xs font-medium leading-relaxed text-blue-700 dark:text-blue-300">
-										{priority.description}
-									</div>
-								</div>
-							</div>
-						</div>
+					{#if hasError}
+						{@render errorState()}
+					{:else if !updateInfo.hasUpdate}
+						{@render successState()}
+					{:else if updateInfo.updateType === 'digest'}
+						{@render digestUpdateState()}
 					{:else}
-						{@const badge = authBadge()}
-						<!-- Version Update State -->
-						<div class="bg-gradient-to-br from-amber-50 to-yellow-50/30 p-4 dark:from-amber-950/20 dark:to-yellow-950/10">
-							<div class="flex items-start gap-3">
-								<div
-									class="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-amber-500 to-yellow-500 shadow-lg shadow-amber-500/25"
-								>
-									<CircleFadingArrowUpIcon class="size-5 text-white" />
-								</div>
-								<div class="flex-1">
-									<div class="text-sm font-semibold text-amber-900 dark:text-amber-100">{m.image_update_version_title()}</div>
-									<div class="text-xs text-amber-700/80 dark:text-amber-300/80">{m.image_update_version_desc()}</div>
-									{#if badge}
-										<div class="mt-2">
-											<div
-												class={'inline-flex items-center gap-1 whitespace-nowrap rounded-full border px-2 py-0.5 text-[10px] font-medium ' +
-													badge.classes}
-											>
-												<KeyRoundIcon class="size-3 opacity-80" />
-												<span>{m.image_update_auth({ label: badge.label })}</span>
-											</div>
-										</div>
-									{/if}
-								</div>
-							</div>
-						</div>
-						<div class="bg-white/90 p-4 dark:bg-gray-950/90">
-							<div class="space-y-3">
-								<div class="space-y-2 text-xs">
-									<div class="flex items-center justify-between">
-										<div class="flex items-center gap-1.5 text-gray-500 dark:text-gray-400">
-											<PackageIcon class="size-3" />
-											<span>{m.image_update_current_label()}</span>
-										</div>
-										<span class="rounded bg-gray-100 px-1.5 py-0.5 font-mono font-medium dark:bg-gray-800"
-											>{displayCurrentVersion()}</span
-										>
-									</div>
-									{#if displayLatestVersion()}
-										<div class="flex items-center justify-between">
-											<div class="flex items-center gap-1.5 text-gray-500 dark:text-gray-400">
-												<ArrowRightIcon class="size-3" />
-												<span>{m.image_update_latest_label()}</span>
-											</div>
-											<span
-												class="rounded bg-amber-100 px-1.5 py-0.5 font-mono font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
-											>
-												{displayLatestVersion()}
-											</span>
-										</div>
-									{/if}
-								</div>
-								<div class="rounded-lg bg-amber-50 p-3 dark:bg-amber-950/30">
-									<div class="text-center text-xs font-medium leading-relaxed text-amber-700 dark:text-amber-300">
-										{priority.description}
-									</div>
-								</div>
-							</div>
-						</div>
-					{/if}
-
-					{#if canCheckUpdate()}
-						<div class="border-t border-gray-200/50 bg-gray-50/50 p-3 dark:border-gray-800/50 dark:bg-gray-900/50">
-							<button
-								onclick={checkImageUpdate}
-								disabled={isChecking}
-								class="group flex w-full items-center justify-center gap-2 rounded-lg bg-white/80 px-3 py-2 text-xs font-medium text-gray-700 shadow-sm transition-all hover:bg-white hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-800/80 dark:text-gray-300 dark:hover:bg-gray-800"
-							>
-								{#if isChecking}
-									<LoaderCircleIcon class="size-3 animate-spin" />
-									{m.images_checking()}
-								{:else}
-									<RefreshCwIcon class="size-3 transition-transform group-hover:rotate-45" />
-									{m.image_update_recheck_button()}
-								{/if}
-							</button>
-						</div>
+						{@render versionUpdateState()}
 					{/if}
 				</div>
 			</Tooltip.Content>
@@ -402,7 +389,7 @@
 		<Tooltip.Root>
 			<Tooltip.Trigger>
 				<span class="mr-2 inline-flex size-4 items-center justify-center">
-					<LoaderCircleIcon class="size-4 animate-spin text-blue-400" />
+					<Spinner class="size-4 text-blue-400" />
 				</span>
 			</Tooltip.Trigger>
 			<Tooltip.Content
@@ -412,19 +399,7 @@
 				align="center"
 			>
 				<div class="overflow-hidden rounded-xl">
-					<div class="bg-gradient-to-br from-blue-50 to-cyan-50/30 p-4 dark:from-blue-950/20 dark:to-cyan-950/10">
-						<div class="flex items-center gap-3">
-							<div
-								class="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-cyan-500 shadow-lg shadow-blue-500/25"
-							>
-								<LoaderCircleIcon class="size-5 animate-spin text-white" />
-							</div>
-							<div>
-								<div class="text-sm font-semibold text-blue-900 dark:text-blue-100">{m.image_update_checking_title()}</div>
-								<div class="text-xs text-blue-700/80 dark:text-blue-300/80">{m.image_update_querying_registry()}</div>
-							</div>
-						</div>
-					</div>
+					{@render loadingState()}
 				</div>
 			</Tooltip.Content>
 		</Tooltip.Root>
@@ -434,14 +409,14 @@
 		<Tooltip.Root>
 			<Tooltip.Trigger>
 				<span class="mr-2 inline-flex size-4 items-center justify-center">
-					{#if canCheckUpdate()}
+					{#if canCheckUpdate}
 						<button
 							onclick={checkImageUpdate}
 							disabled={isChecking}
 							class="group flex h-4 w-4 items-center justify-center rounded-full border-2 border-dashed border-gray-400 transition-colors hover:border-blue-400 hover:bg-blue-50 disabled:cursor-not-allowed dark:hover:bg-blue-950"
 						>
 							{#if isChecking}
-								<LoaderCircleIcon class="h-2 w-2 animate-spin text-blue-400" />
+								<Spinner class="h-2 w-2 text-blue-400" />
 							{:else}
 								<div class="h-1.5 w-1.5 rounded-full bg-gray-400 transition-colors group-hover:bg-blue-400"></div>
 							{/if}
@@ -460,25 +435,7 @@
 				align="center"
 			>
 				<div class="overflow-hidden rounded-xl">
-					<div class="bg-gradient-to-br from-gray-50 to-slate-50/30 p-4 dark:from-gray-900/20 dark:to-slate-900/10">
-						<div class="flex items-center gap-3">
-							<div
-								class="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-gray-400 to-slate-500 shadow-lg shadow-gray-400/25"
-							>
-								<TriangleAlertIcon class="size-5 text-white" />
-							</div>
-							<div>
-								<div class="text-sm font-semibold text-gray-900 dark:text-gray-100">{m.image_update_status_unknown()}</div>
-								<div class="text-xs text-gray-700/80 dark:text-gray-300/80">
-									{#if canCheckUpdate()}
-										{m.image_update_click_to_check()}
-									{:else}
-										{m.image_update_unable_check_tags()}
-									{/if}
-								</div>
-							</div>
-						</div>
-					</div>
+					{@render unknownState()}
 				</div>
 			</Tooltip.Content>
 		</Tooltip.Root>

--- a/frontend/src/lib/components/meter-metric.svelte
+++ b/frontend/src/lib/components/meter-metric.svelte
@@ -2,7 +2,6 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Progress } from '$lib/components/ui/progress/index.js';
 	import type { Icon as IconType } from '@lucide/svelte';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import { m } from '$lib/paraglide/messages';
 
 	interface Props {
@@ -37,7 +36,7 @@
 
 <Card.Root>
 	{#snippet children()}
-		<Card.Header icon={loading ? LoaderCircleIcon : icon} iconVariant="primary" compact>
+		<Card.Header {icon} iconVariant="primary" compact {loading}>
 			{#snippet children()}
 				<div class="min-w-0 flex-1">
 					<div class="text-foreground text-sm font-semibold">{title}</div>

--- a/frontend/src/lib/components/quick-actions.svelte
+++ b/frontend/src/lib/components/quick-actions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import CirclePlayIcon from '@lucide/svelte/icons/circle-play';
 	import CircleStopIcon from '@lucide/svelte/icons/circle-stop';
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
@@ -63,7 +63,7 @@
 					aria-busy={isLoading.starting}
 				>
 					{#if isLoading.starting}
-						<LoaderCircleIcon class="size-3.5 text-emerald-500 motion-safe:animate-spin" />
+						<Spinner class="size-3.5 text-emerald-500" />
 					{:else}
 						<CirclePlayIcon class="size-4 text-emerald-500" />
 					{/if}
@@ -84,7 +84,7 @@
 					aria-busy={isLoading.stopping}
 				>
 					{#if isLoading.stopping}
-						<LoaderCircleIcon class="size-3.5 text-sky-500 motion-safe:animate-spin" />
+						<Spinner class="size-3.5 text-sky-500" />
 					{:else}
 						<CircleStopIcon class="size-4 text-sky-500" />
 					{/if}
@@ -101,7 +101,7 @@
 					aria-busy={isLoading.pruning}
 				>
 					{#if isLoading.pruning}
-						<LoaderCircleIcon class="size-3.5 text-red-500 motion-safe:animate-spin" />
+						<Spinner class="size-3.5 text-red-500" />
 					{:else}
 						<Trash2Icon class="size-4 text-red-500" />
 					{/if}
@@ -115,7 +115,7 @@
 					aria-busy={refreshing}
 				>
 					{#if refreshing}
-						<LoaderCircleIcon class="size-3.5 text-violet-500 motion-safe:animate-spin" />
+						<Spinner class="size-3.5 text-violet-500" />
 					{:else}
 						<RefreshCwIcon class="size-4 text-violet-500" />
 					{/if}
@@ -196,7 +196,7 @@
 						<div class="relative">
 							<div class="flex size-10 items-center justify-center rounded-lg bg-emerald-500/10 ring-1 ring-emerald-500/30">
 								{#if isLoading.starting}
-									<LoaderCircleIcon class="size-4 text-emerald-400 motion-safe:animate-spin" />
+									<Spinner class="size-4 text-emerald-400" />
 								{:else}
 									<CirclePlayIcon class="size-5 text-emerald-400" />
 								{/if}
@@ -228,7 +228,7 @@
 						<div class="relative">
 							<div class="flex size-10 items-center justify-center rounded-lg bg-sky-500/10 ring-1 ring-sky-500/30">
 								{#if isLoading.stopping}
-									<LoaderCircleIcon class="size-4 text-sky-400 motion-safe:animate-spin" />
+									<Spinner class="size-4 text-sky-400" />
 								{:else}
 									<CircleStopIcon class="size-5 text-sky-400" />
 								{/if}
@@ -256,7 +256,7 @@
 						<div class="relative">
 							<div class="flex size-10 items-center justify-center rounded-lg bg-red-500/10 ring-1 ring-red-500/30">
 								{#if isLoading.pruning}
-									<LoaderCircleIcon class="size-4 text-red-400 motion-safe:animate-spin" />
+									<Spinner class="size-4 text-red-400" />
 								{:else}
 									<Trash2Icon class="size-5 text-red-400" />
 								{/if}

--- a/frontend/src/lib/components/sheets/add-template-registry-sheet.svelte
+++ b/frontend/src/lib/components/sheets/add-template-registry-sheet.svelte
@@ -3,7 +3,7 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import FormInput from '$lib/components/form/form-input.svelte';
 	import SwitchWithLabel from '$lib/components/form/labeled-switch.svelte';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import GlobeIcon from '@lucide/svelte/icons/globe';
 	import AlertCircleIcon from '@lucide/svelte/icons/alert-circle';
 	import { z } from 'zod/v4';
@@ -118,7 +118,7 @@
 				</Button>
 				<Button type="submit" class="arcane-button-create flex-1" disabled={isLoading}>
 					{#if isLoading}
-						<LoaderCircleIcon class="mr-2 size-4 animate-spin" />
+						<Spinner class="mr-2 size-4" />
 					{/if}
 					{m.templates_add_registry_button()}
 				</Button>

--- a/frontend/src/lib/components/sheets/container-registry-sheet.svelte
+++ b/frontend/src/lib/components/sheets/container-registry-sheet.svelte
@@ -3,7 +3,7 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import FormInput from '$lib/components/form/form-input.svelte';
 	import SwitchWithLabel from '$lib/components/form/labeled-switch.svelte';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import PackagePlusIcon from '@lucide/svelte/icons/package-plus';
 	import type { ContainerRegistry } from '$lib/types/container-registry.type';
 	import type { ContainerRegistryCreateDto, ContainerRegistryUpdateDto } from '$lib/types/container-registry.type';
@@ -119,7 +119,7 @@
 
 				<Button type="submit" class="arcane-button-create flex-1" disabled={isLoading}>
 					{#if isLoading}
-						<LoaderCircleIcon class="mr-2 size-4 animate-spin" />
+						<Spinner class="mr-2 size-4" />
 					{/if}
 					{isEditMode ? m.registries_save_changes() : m.registries_add_button()}
 				</Button>

--- a/frontend/src/lib/components/sheets/create-container-sheet.svelte
+++ b/frontend/src/lib/components/sheets/create-container-sheet.svelte
@@ -7,7 +7,7 @@
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import ContainerIcon from '@lucide/svelte/icons/container';
 	import XIcon from '@lucide/svelte/icons/x';
 	import PlusIcon from '@lucide/svelte/icons/plus';
@@ -769,7 +769,7 @@
 									>
 									<Button type="submit" disabled={isLoading}>
 										{#if isLoading}
-											<LoaderCircleIcon class="mr-2 size-4 animate-spin" />
+											<Spinner class="mr-2 size-4" />
 											{m.containers_creating()}
 										{:else}
 											<ContainerIcon class="mr-2 size-4" />

--- a/frontend/src/lib/components/sheets/create-network-sheet.svelte
+++ b/frontend/src/lib/components/sheets/create-network-sheet.svelte
@@ -6,7 +6,7 @@
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import NetworkIcon from '@lucide/svelte/icons/network';
 	import XIcon from '@lucide/svelte/icons/x';
 	import type { NetworkCreateOptions } from 'dockerode';
@@ -310,7 +310,7 @@
 				>
 				<Button type="submit" class="arcane-button-create flex-1" disabled={isLoading}>
 					{#if isLoading}
-						<LoaderCircleIcon class="mr-2 size-4 animate-spin" />
+						<Spinner class="mr-2 size-4" />
 						{m.networks_creating()}
 					{:else}
 						<NetworkIcon class="mr-2 size-4" />

--- a/frontend/src/lib/components/sheets/create-volume-sheet.svelte
+++ b/frontend/src/lib/components/sheets/create-volume-sheet.svelte
@@ -3,7 +3,7 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import FormInput from '$lib/components/form/form-input.svelte';
 	import * as Accordion from '$lib/components/ui/accordion/index.js';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import HardDriveIcon from '@lucide/svelte/icons/hard-drive';
 	import type { VolumeCreateOptions } from 'dockerode';
 	import { z } from 'zod/v4';
@@ -165,7 +165,7 @@
 				>
 				<Button type="submit" class="arcane-button-create flex-1" disabled={isLoading}>
 					{#if isLoading}
-						<LoaderCircleIcon class="mr-2 size-4 animate-spin" />
+						<Spinner class="mr-2 size-4" />
 						{m.volumes_creating()}
 					{:else}
 						<HardDriveIcon class="mr-2 size-4" />

--- a/frontend/src/lib/components/sheets/image-pull-sheet.svelte
+++ b/frontend/src/lib/components/sheets/image-pull-sheet.svelte
@@ -2,7 +2,7 @@
 	import * as Sheet from '$lib/components/ui/sheet/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import FormInput from '$lib/components/form/form-input.svelte';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import DownloadIcon from '@lucide/svelte/icons/download';
 	import { z } from 'zod/v4';
 	import { createForm, preventDefault } from '$lib/utils/form.utils';
@@ -288,7 +288,7 @@
 				>
 				<Button type="submit" class="arcane-button-create flex-1" disabled={isPulling}>
 					{#if isPulling}
-						<LoaderCircleIcon class="mr-2 size-4 animate-spin" />
+						<Spinner class="mr-2 size-4" />
 						<span class="opacity-0">{m.images_pull_image()}</span>
 					{:else}
 						<DownloadIcon class="mr-2 size-4" />

--- a/frontend/src/lib/components/sheets/new-environment-sheet.svelte
+++ b/frontend/src/lib/components/sheets/new-environment-sheet.svelte
@@ -3,7 +3,7 @@
 	import * as Sheet from '$lib/components/ui/sheet/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import FormInput from '$lib/components/form/form-input.svelte';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import ServerIcon from '@lucide/svelte/icons/server';
 	import * as Card from '$lib/components/ui/card';
 	import type { CreateEnvironmentDTO } from '$lib/types/environment.type';
@@ -92,7 +92,7 @@
 		<div class="space-y-6 py-6">
 			<Card.Root class="flex flex-col gap-6 py-3">
 				<Card.Header
-					class="@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6"
+					class="@container/card-header has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6 grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6"
 				>
 					<Card.Title class="text-lg">{m.environments_add_button()}</Card.Title>
 				</Card.Header>
@@ -118,7 +118,7 @@
 
 						<Button type="submit" class="w-full" disabled={isSubmitting}>
 							{#if isSubmitting}
-								<LoaderCircleIcon class="mr-2 size-4 animate-spin" />
+								<Spinner class="mr-2 size-4" />
 							{/if}
 							{m.environments_add_button()}
 						</Button>

--- a/frontend/src/lib/components/sheets/user-form-sheet.svelte
+++ b/frontend/src/lib/components/sheets/user-form-sheet.svelte
@@ -3,7 +3,7 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import FormInput from '$lib/components/form/form-input.svelte';
 	import SwitchWithLabel from '$lib/components/form/labeled-switch.svelte';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import UserPlusIcon from '@lucide/svelte/icons/user-plus';
 	import SaveIcon from '@lucide/svelte/icons/save';
 	import type { User } from '$lib/types/user.type';
@@ -169,7 +169,7 @@
 				>
 				<Button type="submit" class="arcane-button-create flex-1" disabled={isLoading}>
 					{#if isLoading}
-						<LoaderCircleIcon class="mr-2 size-4 animate-spin" />
+						<Spinner class="mr-2 size-4" />
 					{/if}
 					<SubmitIcon class="mr-2 size-4" />
 					{isEditMode ? m.users_save_changes() : m.users_create_button()}

--- a/frontend/src/lib/components/ui/card/card-header.svelte
+++ b/frontend/src/lib/components/ui/card/card-header.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { cn, type WithElementRef } from '$lib/utils.js';
 	import type { HTMLAttributes } from 'svelte/elements';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 
 	let {
 		ref = $bindable(null),
@@ -9,6 +10,7 @@
 		iconVariant = 'primary',
 		compact = false,
 		enableHover = false,
+		loading = false,
 		children,
 		...restProps
 	}: WithElementRef<
@@ -17,6 +19,7 @@
 			iconVariant?: 'primary' | 'emerald' | 'red' | 'amber' | 'blue' | 'purple' | 'cyan' | 'orange' | 'indigo' | 'pink';
 			compact?: boolean;
 			enableHover?: boolean;
+			loading?: boolean;
 		}
 	> = $props();
 
@@ -38,7 +41,7 @@
 	bind:this={ref}
 	data-slot="card-header"
 	class={cn(
-		'@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+		'@container/card-header has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6 grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6',
 		icon
 			? 'flex flex-row items-start space-y-0 bg-gradient-to-br from-gray-50 to-slate-50/30 dark:from-gray-900/20 dark:to-slate-900/10'
 			: '',
@@ -51,7 +54,7 @@
 	{...restProps}
 >
 	{#if icon}
-		{@const IconComponent = icon}
+		{@const IconComponent = loading ? Spinner : icon}
 		<div
 			class={cn(
 				'flex shrink-0 items-center justify-center rounded-full bg-gradient-to-br shadow-lg transition-transform group-[&:not(:has(button:hover,a:hover,[role=button]:hover))]:hover:scale-105',

--- a/frontend/src/lib/components/ui/spinner/index.ts
+++ b/frontend/src/lib/components/ui/spinner/index.ts
@@ -1,0 +1,1 @@
+export { default as Spinner } from "./spinner.svelte";

--- a/frontend/src/lib/components/ui/spinner/spinner.svelte
+++ b/frontend/src/lib/components/ui/spinner/spinner.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import Loader2Icon from "@lucide/svelte/icons/loader-2";
+	import type { ComponentProps } from "svelte";
+
+	type Props = ComponentProps<typeof Loader2Icon>;
+
+	let { class: className, ...restProps }: Props = $props();
+</script>
+
+<Loader2Icon
+	role="status"
+	aria-label="Loading"
+	class={cn("size-4 animate-spin", className)}
+	{...restProps}
+/>

--- a/frontend/src/routes/containers/container-table.svelte
+++ b/frontend/src/routes/containers/container-table.svelte
@@ -6,7 +6,7 @@
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import StopCircleIcon from '@lucide/svelte/icons/stop-circle';
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import EllipsisIcon from '@lucide/svelte/icons/ellipsis';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { goto } from '$app/navigation';
@@ -336,7 +336,7 @@
 				{#if item.state !== 'running'}
 					<DropdownMenu.Item onclick={() => performContainerAction('start', item.id)} disabled={isLoading.start || isAnyLoading}>
 						{#if isLoading.start}
-							<LoaderCircleIcon class="size-4 animate-spin" />
+							<Spinner class="size-4" />
 						{:else}
 							<PlayIcon class="size-4" />
 						{/if}
@@ -348,7 +348,7 @@
 						disabled={isLoading.restart || isAnyLoading}
 					>
 						{#if isLoading.restart}
-							<LoaderCircleIcon class="size-4 animate-spin" />
+							<Spinner class="size-4" />
 						{:else}
 							<RotateCcwIcon class="size-4" />
 						{/if}
@@ -357,7 +357,7 @@
 
 					<DropdownMenu.Item onclick={() => performContainerAction('stop', item.id)} disabled={isLoading.stop || isAnyLoading}>
 						{#if isLoading.stop}
-							<LoaderCircleIcon class="size-4 animate-spin" />
+							<Spinner class="size-4" />
 						{:else}
 							<StopCircleIcon class="size-4" />
 						{/if}
@@ -373,7 +373,7 @@
 					disabled={isLoading.remove || isAnyLoading}
 				>
 					{#if isLoading.remove}
-						<LoaderCircleIcon class="size-4 animate-spin" />
+						<Spinner class="size-4" />
 					{:else}
 						<Trash2Icon class="size-4" />
 					{/if}

--- a/frontend/src/routes/images/+page.svelte
+++ b/frontend/src/routes/images/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button/index.js';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import HardDriveIcon from '@lucide/svelte/icons/hard-drive';
 	import PackageIcon from '@lucide/svelte/icons/package';
 	import { toast } from 'svelte-sonner';
@@ -188,7 +188,7 @@
 					</Button>
 					<Button variant="destructive" onclick={handlePruneImages} disabled={isLoading.pruning}>
 						{#if isLoading.pruning}
-							<LoaderCircleIcon class="mr-2 size-4 animate-spin" /> {m.images_pruning()}
+							<Spinner class="mr-2 size-4" /> {m.images_pruning()}
 						{:else}
 							{m.images_prune_action()}
 						{/if}

--- a/frontend/src/routes/images/image-table.svelte
+++ b/frontend/src/routes/images/image-table.svelte
@@ -5,7 +5,7 @@
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
 	import EllipsisIcon from '@lucide/svelte/icons/ellipsis';
 	import ScanSearchIcon from '@lucide/svelte/icons/scan-search';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { goto } from '$app/navigation';
 	import { toast } from 'svelte-sonner';
@@ -118,7 +118,6 @@
 			}
 		});
 	}
-
 	async function handleInlineImagePull(imageId: string, repoTag: string) {
 		if (!repoTag || repoTag === '<none>:<none>') {
 			toast.error(m.images_pull_no_tag());
@@ -274,7 +273,7 @@
 		<div class="flex flex-wrap gap-x-4 gap-y-3 border-t pt-3">
 			{#if (mobileFieldVisibility.updates ?? true) && item.updateInfo !== undefined}
 				<div class="flex min-w-0 flex-1 basis-[180px] flex-col">
-					<div class="text-muted-foreground text-[10px] font-medium tracking-wide uppercase">
+					<div class="text-muted-foreground text-[10px] font-medium uppercase tracking-wide">
 						{m.images_updates()}
 					</div>
 					<div class="mt-0.5">
@@ -313,7 +312,7 @@
 					disabled={isPullingInline[item.id] || !item.repoTags?.[0]}
 				>
 					{#if isPullingInline[item.id]}
-						<LoaderCircleIcon class="size-4 animate-spin" />
+						<Spinner class="size-4" />
 						{m.images_pulling()}
 					{:else}
 						<DownloadIcon class="size-4" />
@@ -323,7 +322,7 @@
 				<DropdownMenu.Separator />
 				<DropdownMenu.Item variant="destructive" onclick={() => deleteImage(item.id)} disabled={isLoading.removing}>
 					{#if isLoading.removing}
-						<LoaderCircleIcon class="size-4 animate-spin" />
+						<Spinner class="size-4" />
 					{:else}
 						<Trash2Icon class="size-4" />
 					{/if}

--- a/frontend/src/routes/onboarding/complete/+page.svelte
+++ b/frontend/src/routes/onboarding/complete/+page.svelte
@@ -2,7 +2,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { toast } from 'svelte-sonner';
 	import { goto, invalidateAll } from '$app/navigation';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import CircleCheckIcon from '@lucide/svelte/icons/check-circle';
 	import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
 	import { settingsService } from '$lib/services/settings-service.js';
@@ -64,7 +64,7 @@
 
 		<Button onclick={completeOnboarding} disabled={isLoading} size="lg" class="w-full">
 			{#if isLoading}
-				<LoaderCircleIcon class="mr-2 size-4 animate-spin" />
+				<Spinner class="mr-2 size-4" />
 				Completing Setup...
 			{:else}
 				Go to Dashboard

--- a/frontend/src/routes/onboarding/docker/+page.svelte
+++ b/frontend/src/routes/onboarding/docker/+page.svelte
@@ -4,7 +4,7 @@
 	import * as Alert from '$lib/components/ui/alert';
 	import { toast } from 'svelte-sonner';
 	import { goto } from '$app/navigation';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner';
 	import ZapIcon from '@lucide/svelte/icons/zap';
 	import SwitchWithLabel from '$lib/components/form/labeled-switch.svelte';
 	import FormInput from '$lib/components/form/form-input.svelte';
@@ -117,7 +117,7 @@
 	<div class="grid gap-6 md:grid-cols-2">
 		<Card.Root class="flex flex-col gap-6 py-3">
 			<Card.Header
-				class="@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6"
+				class="@container/card-header has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6 grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6"
 			>
 				<Card.Title>{m.docker_title()}</Card.Title>
 				<Card.Description>{m.docker_description()}</Card.Description>
@@ -184,7 +184,7 @@
 
 		<Card.Root class="flex flex-col gap-6 py-3">
 			<Card.Header
-				class="@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6"
+				class="@container/card-header has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6 grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6"
 			>
 				<Card.Title>{m.docker_prune_action_label()}</Card.Title>
 				<Card.Description>{pruneModeDescription}</Card.Description>
@@ -211,7 +211,7 @@
 			<Button variant="ghost" onclick={handleSkip}>Skip</Button>
 			<Button onclick={handleNext} disabled={isLoading}>
 				{#if isLoading}
-					<LoaderCircleIcon class="mr-2 size-4 animate-spin" />
+					<Spinner class="mr-2 size-4" />
 				{/if}
 				Next
 			</Button>

--- a/frontend/src/routes/onboarding/security/+page.svelte
+++ b/frontend/src/routes/onboarding/security/+page.svelte
@@ -6,7 +6,7 @@
 	import SwitchWithLabel from '$lib/components/form/labeled-switch.svelte';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import OidcConfigDialog from '$lib/components/dialogs/oidc-config-dialog.svelte';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import { toast } from 'svelte-sonner';
 	import { goto } from '$app/navigation';
 	import { createForm, preventDefault } from '$lib/utils/form.utils';
@@ -288,7 +288,7 @@
 						<Button type="button" variant="ghost" onclick={handleSkip}>{m.common_skip()}</Button>
 						<Button type="submit" disabled={isLoading.saving}>
 							{#if isLoading.saving}
-								<LoaderCircleIcon class="mr-2 size-4 animate-spin" />
+								<Spinner class="mr-2 size-4" />
 							{/if}
 							{m.common_continue?.() ?? 'Continue'}
 						</Button>

--- a/frontend/src/routes/onboarding/settings/+page.svelte
+++ b/frontend/src/routes/onboarding/settings/+page.svelte
@@ -5,7 +5,7 @@
 	import SwitchWithLabel from '$lib/components/form/labeled-switch.svelte';
 	import { toast } from 'svelte-sonner';
 	import { goto } from '$app/navigation';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import { createForm, preventDefault } from '$lib/utils/form.utils';
 	import { z } from 'zod/v4';
 	import { m } from '$lib/paraglide/messages';
@@ -107,7 +107,7 @@
 						<Button type="button" variant="ghost" onclick={handleSkip}>Skip</Button>
 						<Button type="submit" disabled={isLoading}>
 							{#if isLoading}
-								<LoaderCircleIcon class="mr-2 size-4 animate-spin" />
+								<Spinner class="mr-2 size-4" />
 							{/if}
 							{m.common_continue()}
 						</Button>

--- a/frontend/src/routes/projects/new/+page.svelte
+++ b/frontend/src/routes/projects/new/+page.svelte
@@ -3,7 +3,7 @@
 	import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
 	import TerminalIcon from '@lucide/svelte/icons/terminal';
 	import CopyIcon from '@lucide/svelte/icons/copy';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import LayoutTemplateIcon from '@lucide/svelte/icons/layout-template';
 	import WandIcon from '@lucide/svelte/icons/wand';
 	import { Input } from '$lib/components/ui/input/index.js';
@@ -188,7 +188,7 @@
 							<div class="flex w-full justify-end pt-4">
 								<Button type="button" disabled={!dockerRunCommand.trim() || converting} onclick={handleConvertDockerRun}>
 									{#if converting}
-										<LoaderCircleIcon class="mr-2 size-4 animate-spin" />
+										<Spinner class="mr-2 size-4" />
 										{m.compose_converting()}
 									{:else}
 										<WandIcon class="mr-2 size-4" />
@@ -211,7 +211,7 @@
 								class={`${templateBtnClass} gap-2 rounded-r-none hover:!translate-y-0 focus-visible:!translate-y-0 active:!translate-y-0`}
 							>
 								{#if saving}
-									<LoaderCircleIcon class="size-4 animate-spin" />
+									<Spinner class="size-4" />
 									{m.compose_creating()}
 								{:else}
 									<PlusCircleIcon class="size-4" />

--- a/frontend/src/routes/projects/projects-table.svelte
+++ b/frontend/src/routes/projects/projects-table.svelte
@@ -8,7 +8,7 @@
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import StopCircleIcon from '@lucide/svelte/icons/stop-circle';
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { goto } from '$app/navigation';
 	import { toast } from 'svelte-sonner';
@@ -238,7 +238,7 @@
 				{#if item.status !== 'running'}
 					<DropdownMenu.Item onclick={() => performProjectAction('start', item.id)} disabled={isLoading.start || isAnyLoading}>
 						{#if isLoading.start}
-							<LoaderCircleIcon class="size-4 animate-spin" />
+							<Spinner class="size-4" />
 						{:else}
 							<PlayIcon class="size-4" />
 						{/if}
@@ -250,7 +250,7 @@
 						disabled={isLoading.restart || isAnyLoading}
 					>
 						{#if isLoading.restart}
-							<LoaderCircleIcon class="size-4 animate-spin" />
+							<Spinner class="size-4" />
 						{:else}
 							<RotateCcwIcon class="size-4" />
 						{/if}
@@ -259,7 +259,7 @@
 
 					<DropdownMenu.Item onclick={() => performProjectAction('stop', item.id)} disabled={isLoading.stop || isAnyLoading}>
 						{#if isLoading.stop}
-							<LoaderCircleIcon class="size-4 animate-spin" />
+							<Spinner class="size-4" />
 						{:else}
 							<StopCircleIcon class="size-4" />
 						{/if}
@@ -269,7 +269,7 @@
 
 				<DropdownMenu.Item onclick={() => performProjectAction('pull', item.id)} disabled={isLoading.pull || isAnyLoading}>
 					{#if isLoading.pull}
-						<LoaderCircleIcon class="size-4 animate-spin" />
+						<Spinner class="size-4" />
 					{:else}
 						<RotateCcwIcon class="size-4" />
 					{/if}
@@ -284,7 +284,7 @@
 					disabled={isLoading.remove || isAnyLoading}
 				>
 					{#if isLoading.remove}
-						<LoaderCircleIcon class="size-4 animate-spin" />
+						<Spinner class="size-4" />
 					{:else}
 						<Trash2Icon class="size-4" />
 					{/if}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: ^3.10.0
         version: 3.10.0
       '@lucide/svelte':
-        specifier: ^0.545.0
-        version: 0.545.0(svelte@5.39.11)
+        specifier: ^0.544.0
+        version: 0.544.0(svelte@5.39.11)
       '@sveltejs/kit':
         specifier: ^2.46.4
         version: 2.46.4(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.39.11)(vite@7.1.9(@types/node@24.7.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)))(svelte@5.39.11)(vite@7.1.9(@types/node@24.7.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6))
@@ -585,8 +585,8 @@ packages:
   '@lix-js/server-protocol-schema@0.1.1':
     resolution: {integrity: sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ==}
 
-  '@lucide/svelte@0.545.0':
-    resolution: {integrity: sha512-RlAtWefx9MdpXaOMbx3Qv3/NqpeZKOIPxN2D0RBN2+op0opKly8VgYEEWZTT6Ow/zf7UwyTg6/0ExJlsVLK+8g==}
+  '@lucide/svelte@0.544.0':
+    resolution: {integrity: sha512-9f9O6uxng2pLB01sxNySHduJN3HTl5p0HDu4H26VR51vhZfiMzyOMe9Mhof3XAk4l813eTtl+/DYRvGyoRR+yw==}
     peerDependencies:
       svelte: ^5
 
@@ -2821,7 +2821,7 @@ snapshots:
 
   '@lix-js/server-protocol-schema@0.1.1': {}
 
-  '@lucide/svelte@0.545.0(svelte@5.39.11)':
+  '@lucide/svelte@0.544.0(svelte@5.39.11)':
     dependencies:
       svelte: 5.39.11
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a unified Spinner component for loading states.
  - Card headers now support a loading state and show a spinner when busy.
- Style
  - Replaced assorted loading icons with Spinner across dialogs, sheets, tables, and buttons for consistent visuals.
  - Minor class ordering tweaks for headers and cards.
- Refactor
  - Image update item revamped to present clearer loading, error, and success states.
  - Simplified header icon handling by using a loading prop instead of swapping icons.
- Chores
  - Downgraded a UI icon dev dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->