### PR TITLE
fix: update icon import

### DIFF
--- a/frontend/src/lib/components/accent-color/accent-color-picker.svelte
+++ b/frontend/src/lib/components/accent-color/accent-color-picker.svelte
@@ -2,7 +2,8 @@
 	import { Label } from '$lib/components/ui/label/index.js';
 	import * as RadioGroup from '$lib/components/ui/radio-group/index.js';
 	import { applyAccentColor } from '$lib/utils/accent-color-util';
-	import { Check, Plus } from '@lucide/svelte';
+	import PlusIcon from '@lucide/svelte/icons/plus';
+	import CheckIcon from '@lucide/svelte/icons/check';
 	import CustomColorDialog from './custom-color.svelte';
 
 	let {
@@ -80,11 +81,11 @@
 					<div
 						class="bg-muted absolute inset-0 flex items-center justify-center rounded-full border-2 border-dashed border-gray-300"
 					>
-						<Plus class="text-muted-foreground size-4" />
+						<PlusIcon class="text-muted-foreground size-4" />
 					</div>
 				{:else if isSelected}
 					<div class="absolute inset-0 flex items-center justify-center">
-						<Check class="size-4 text-white drop-shadow-sm" />
+						<CheckIcon class="size-4 text-white drop-shadow-sm" />
 					</div>
 				{/if}
 			</div>


### PR DESCRIPTION
Ever since the accent color picker has been introduced I have not been able to access the general settings page. This finally fixed it.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-19 01:41:17 UTC

### Greptile Summary

This PR fixes a critical import error in the accent color picker component that was preventing access to the general settings page. The change updates the Lucide icon imports from barrel exports (`import { Check, Plus } from '@lucide/svelte'`) to direct path imports (`import CheckIcon from '@lucide/svelte/icons/check'`). This pattern is more explicit and resolves module resolution issues that can occur with icon libraries during build or runtime. The fix is minimal and surgical, only touching the problematic import statements and updating the corresponding component references in the template. This approach is commonly used to avoid tree-shaking or bundling problems in icon libraries that support both barrel and individual file exports.

</details><details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| frontend/src/lib/components/accent-color/accent-color-picker.svelte | 5/5 | Changed Lucide icon imports from named exports to direct path imports and updated component references |

</details>

### Confidence score: 5/5

- This PR is safe to merge with minimal risk and resolves a blocking issue
- Score reflects a straightforward fix to a module resolution problem with no logic changes, clear intent, and proper component reference updates
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->