### PR TITLE
fix: load project services concurrently

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -464,6 +464,8 @@ func (s *ProjectService) GetProjectStatusCounts(ctx context.Context) (folderCoun
 					runningProjects++
 				case models.ProjectStatusStopped, models.ProjectStatusStopping:
 					stoppedProjects++
+				case models.ProjectStatusUnknown:
+					// Don't count unknown
 				}
 			}
 			return folderCount, runningProjects, stoppedProjects, totalProjects, nil


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews uses AI, make sure to check over its work

<h2>Greptile Overview</h2>

Updated On: 2025-10-21 16:44:13 UTC

### Greptile Summary

**This review covers only the changes made since the last review, not the entire PR.** The latest commit addresses previous review feedback by replacing the fixed 15-second global timeout with a dynamic calculation: `(projectCount / concurrency) * perProjectTimeout * 1.5`, with a 30-second floor. This allows the system to scale gracefully—smaller deployments get tighter timeouts while larger environments receive proportionally more time. The update also removes approximately 12 debug statements per project (previously logging semaphore acquire/release and status fetch events), retaining only the single function-entry debug log and error-level warnings. The core concurrency architecture (10-worker semaphore, 3s per-project timeouts, graceful fallback to cached data) remains intact, ensuring the performance improvements from concurrent Docker API calls persist while eliminating the log volume and timeout scaling issues identified in earlier reviews.

</details><details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| backend/internal/services/project_service.go | 4/5 | Replaced fixed 15s timeout with dynamic calculation `(projects/10)*3s*1.5` (min 30s) and removed ~12 debug logs per project; core concurrency logic unchanged |

</details>

### Confidence score: 4/5

- This PR is now safe to merge with minimal remaining risk after addressing the previous timeout scaling and logging concerns.
- Score reflects: (1) dynamic timeout calculation correctly scales with project count using ceiling division and 1.5x buffer, eliminating the worst-case scenario where many projects would timeout under the old 15s fixed limit; (2) removal of excessive debug logging resolves production log volume issues while preserving essential error visibility; (3) the semaphore-based concurrency pattern with per-project 3s timeouts remains sound and prevents Docker daemon overload; (4) minor deduction because the dynamic timeout calculation logic (lines 890-902) adds complexity and should be validated with real-world project counts to ensure the 1.5x multiplier provides adequate buffer under varying Docker API latencies.
- Pay close attention to lines 890-902 where the dynamic timeout is calculated—verify the ceiling division `(len(projects) + concurrency - 1) / concurrency` correctly handles edge cases (0 projects, 1 project, exact multiples of 10) and that the 1.5x buffer multiplier is appropriate for your Docker daemon's typical response times under concurrent load.

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - .github/copilot-instructions.md file ([source](https://app.greptile.com/review/custom-context?memory=a66806fd-d5c8-4295-a793-06df78baccfa))

<!-- /greptile_comment -->