### PR TITLE
fix: properly persist local vs environment settings

### DIFF
--- a/backend/internal/models/settings.go
+++ b/backend/internal/models/settings.go
@@ -49,7 +49,7 @@ type Settings struct {
 	BaseServerURL     SettingVariable `key:"baseServerUrl" meta:"label=Base Server URL;type=text;keywords=base,url,server,domain,host,endpoint,address,link;category=general;description=Set the base URL for the application"`
 	EnableGravatar    SettingVariable `key:"enableGravatar" meta:"label=Enable Gravatar;type=boolean;keywords=gravatar,avatar,profile,picture,image,user,photo;category=general;description=Enable Gravatar profile pictures for users"`
 	DefaultShell      SettingVariable `key:"defaultShell" meta:"label=Default Shell;type=text;keywords=shell,default,shellpath,path,login;category=general;description=Default shell to use for commands"`
-	AccentColor       SettingVariable `key:"accentColor,public" meta:"label=Accent Color;type=text;keywords=color,accent,theme,css,appearance,ui;category=general;description=Primary accent color for UI"`
+	AccentColor       SettingVariable `key:"accentColor,public,local" meta:"label=Accent Color;type=text;keywords=color,accent,theme,css,appearance,ui;category=general;description=Primary accent color for UI"`
 
 	// Deprecated: OnboardingCompleted is no longer used as of the onboarding removal.
 	// This field is kept for backward compatibility and is automatically set to true on startup.
@@ -77,11 +77,11 @@ type Settings struct {
 	AuthOidcConfig     SettingVariable `key:"authOidcConfig,sensitive" meta:"label=OIDC Config;type=text;keywords=oidc,config,client,id,issuer,secret,oauth;category=security;description=OIDC provider configuration"`
 
 	// Navigation category
-	MobileNavigationMode         SettingVariable `key:"mobileNavigationMode,public" meta:"label=Mobile Navigation Mode;type=select;keywords=mode,style,type,floating,docked,position,layout,design,appearance,bottom;category=navigation;description=Choose between floating or docked navigation on mobile" catmeta:"id=navigation;title=Navigation;icon=navigation;url=/settings/navigation;description=Customize navigation and interface behavior"`
-	MobileNavigationShowLabels   SettingVariable `key:"mobileNavigationShowLabels,public" meta:"label=Show Navigation Labels;type=boolean;keywords=labels,text,icons,display,show,hide,names,captions,titles,visible,toggle;category=navigation;description=Display text labels alongside navigation icons"`
-	MobileNavigationScrollToHide SettingVariable `key:"mobileNavigationScrollToHide,public" meta:"label=Scroll to Hide;type=boolean;keywords=scroll,hide,auto-hide,behavior,down,up,automatic,disappear,vanish,minimize,collapse;category=navigation;description=Automatically hide navigation when scrolling down"`
-	SidebarHoverExpansion        SettingVariable `key:"sidebarHoverExpansion,public" meta:"label=Sidebar Hover Expansion;type=boolean;keywords=sidebar,hover,expansion,expand,desktop,mouse,over,collapsed,collapsible,icon,labels,text,preview,peek,tooltip,overlay,temporary,quick,access,navigation,menu,items,submenu,nested;category=navigation;description=Expand sidebar on hover in desktop mode"`
-	GlassEffectEnabled           SettingVariable `key:"glassEffectEnabled,public" meta:"label=Glass Effect;type=boolean;keywords=glass,glassmorphism,blur,backdrop,frosted,effect,gradient,ambient,design,ui,appearance,modern,visual,style,theme,transparency,translucent;category=navigation;description=Enable modern glassmorphism design with blur, gradients, and ambient effects"`
+	MobileNavigationMode         SettingVariable `key:"mobileNavigationMode,public,local" meta:"label=Mobile Navigation Mode;type=select;keywords=mode,style,type,floating,docked,position,layout,design,appearance,bottom;category=navigation;description=Choose between floating or docked navigation on mobile" catmeta:"id=navigation;title=Navigation;icon=navigation;url=/settings/navigation;description=Customize navigation and interface behavior"`
+	MobileNavigationShowLabels   SettingVariable `key:"mobileNavigationShowLabels,public,local" meta:"label=Show Navigation Labels;type=boolean;keywords=labels,text,icons,display,show,hide,names,captions,titles,visible,toggle;category=navigation;description=Display text labels alongside navigation icons"`
+	MobileNavigationScrollToHide SettingVariable `key:"mobileNavigationScrollToHide,public,local" meta:"label=Scroll to Hide;type=boolean;keywords=scroll,hide,auto-hide,behavior,down,up,automatic,disappear,vanish,minimize,collapse;category=navigation;description=Automatically hide navigation when scrolling down"`
+	SidebarHoverExpansion        SettingVariable `key:"sidebarHoverExpansion,public,local" meta:"label=Sidebar Hover Expansion;type=boolean;keywords=sidebar,hover,expansion,expand,desktop,mouse,over,collapsed,collapsible,icon,labels,text,preview,peek,tooltip,overlay,temporary,quick,access,navigation,menu,items,submenu,nested;category=navigation;description=Expand sidebar on hover in desktop mode"`
+	GlassEffectEnabled           SettingVariable `key:"glassEffectEnabled,public,local" meta:"label=Glass Effect;type=boolean;keywords=glass,glassmorphism,blur,backdrop,frosted,effect,gradient,ambient,design,ui,appearance,modern,visual,style,theme,transparency,translucent;category=navigation;description=Enable modern glassmorphism design with blur, gradients, and ambient effects"`
 
 	InstanceID SettingVariable `key:"instanceId,internal" meta:"label=Instance ID;type=text;keywords=instance,id,uuid,identifier;category=internal;description=Unique instance identifier"`
 }
@@ -140,6 +140,21 @@ func (s *Settings) FieldByKey(key string) (defaultValue string, isPublic bool, i
 	}
 
 	return "", false, false, SettingKeyNotFoundError{field: key}
+}
+
+func (s *Settings) IsLocalSetting(key string) bool {
+	rt := reflect.TypeOf(s).Elem()
+
+	for i := 0; i < rt.NumField(); i++ {
+		tagValue := strings.Split(rt.Field(i).Tag.Get("key"), ",")
+		keyFromTag := tagValue[0]
+
+		if keyFromTag == key {
+			return slices.Contains(tagValue, "local")
+		}
+	}
+
+	return false
 }
 
 func (s *Settings) UpdateField(key string, value string, noSensitive bool) error {

--- a/frontend/src/lib/utils/settings.util.ts
+++ b/frontend/src/lib/utils/settings.util.ts
@@ -1,0 +1,41 @@
+export type LocalSettings = {
+	accentColor: string;
+	mobileNavigationMode: string;
+	mobileNavigationShowLabels: boolean;
+	mobileNavigationScrollToHide: boolean;
+	sidebarHoverExpansion: boolean;
+	glassEffectEnabled: boolean;
+};
+
+const LOCAL_SETTING_KEYS = new Set([
+	'accentColor',
+	'mobileNavigationMode',
+	'mobileNavigationShowLabels',
+	'mobileNavigationScrollToHide',
+	'sidebarHoverExpansion',
+	'glassEffectEnabled'
+]);
+
+export function isLocalSetting(key: string): boolean {
+	return LOCAL_SETTING_KEYS.has(key);
+}
+
+export function extractLocalSettings(settings: Record<string, any>): Partial<LocalSettings> {
+	const local: Partial<LocalSettings> = {};
+	for (const key of LOCAL_SETTING_KEYS) {
+		if (key in settings) {
+			local[key as keyof LocalSettings] = settings[key];
+		}
+	}
+	return local;
+}
+
+export function extractEnvironmentSettings(settings: Record<string, any>): Record<string, any> {
+	const env: Record<string, any> = {};
+	for (const key in settings) {
+		if (!LOCAL_SETTING_KEYS.has(key)) {
+			env[key] = settings[key];
+		}
+	}
+	return env;
+}


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews uses AI, make sure to check over its work

<h2>Greptile Overview</h2>

Updated On: 2025-10-24 20:34:53 UTC

<details><summary><h3>Greptile Summary</h3></summary>


Implements proper separation of local UI settings from environment-specific operational settings by adding a `local` tag to UI preference fields in the backend and updating the frontend to fetch/persist these settings to environment 0 (main instance) while environment-specific settings go to the current environment.

**Key changes:**
- Backend: Added `local` tag to 6 UI settings (accent color, navigation preferences) and created `IsLocalSetting()` helper method
- Frontend: Created settings utility to identify local settings and modified service to route local settings to environment 0, operational settings to current environment
- This ensures UI preferences persist globally while environment settings remain isolated


</details>
<details><summary><h3>Confidence Score: 4/5</h3></summary>


- Safe to merge with minor maintenance consideration
- Implementation correctly separates local from environment settings. The hardcoded list in frontend matches backend tags. Minor concern about keeping backend tags and frontend list synchronized in future changes, but current implementation is correct.
- Pay attention to frontend/src/lib/utils/settings.util.ts - the hardcoded `LOCAL_SETTING_KEYS` must stay in sync with backend `local` tags
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| backend/internal/models/settings.go | 5/5 | Added `local` flag to UI settings (accent color, navigation preferences) and implemented `IsLocalSetting()` method to check if a setting is local |
| frontend/src/lib/services/settings-service.ts | 4/5 | Modified to fetch/save local settings from environment 0 and operational settings from current environment, merging them appropriately |
| frontend/src/lib/utils/settings.util.ts | 5/5 | New utility file with hardcoded list of local settings and helper functions to separate local from environment settings |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->