### PR TITLE
chore: update dialog overflow

### DIFF
--- a/frontend/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/frontend/src/lib/components/ui/dialog/dialog-content.svelte
@@ -23,7 +23,8 @@
 		bind:ref
 		data-slot="dialog-content"
 		class={cn(
-			'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border p-6 shadow-lg backdrop-blur-md duration-200 sm:rounded-2xl'
+			'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border p-6 shadow-lg backdrop-blur-md duration-200 sm:rounded-2xl',
+			className
 		)}
 		{...restProps}
 	>

--- a/frontend/src/lib/components/ui/responsive-dialog/responsive-dialog.svelte
+++ b/frontend/src/lib/components/ui/responsive-dialog/responsive-dialog.svelte
@@ -32,9 +32,14 @@
 				{@render trigger()}
 			</Dialog.Trigger>
 		{/if}
-		<Dialog.Content class={cn('flex max-h-[90vh] flex-col', contentClass ?? 'sm:max-w-[425px]')}>
+		<Dialog.Content
+			class={cn(
+				'max-h-[calc(100vh-2rem)] grid-rows-[auto_minmax(0,1fr)_auto]! overflow-hidden p-0!',
+				contentClass ?? 'sm:max-w-[425px]'
+			)}
+		>
 			{#if title || description}
-				<Dialog.Header class="shrink-0">
+				<Dialog.Header class="shrink-0 px-6 pt-6">
 					{#if title}
 						<Dialog.Title>{title}</Dialog.Title>
 					{/if}
@@ -43,11 +48,11 @@
 					{/if}
 				</Dialog.Header>
 			{/if}
-			<div class={cn('min-h-0 flex-1 overflow-y-auto', className)}>
+			<div class={cn('min-h-0 overflow-y-auto px-6', className)}>
 				{@render children()}
 			</div>
 			{#if footer}
-				<Dialog.Footer class="shrink-0">
+				<Dialog.Footer class="shrink-0 px-6 pb-6">
 					{@render footer()}
 				</Dialog.Footer>
 			{/if}
@@ -60,7 +65,7 @@
 				{@render trigger()}
 			</Drawer.Trigger>
 		{/if}
-		<Drawer.Content class="flex max-h-[80vh] flex-col">
+		<Drawer.Content class="flex max-h-[85vh] flex-col overflow-hidden">
 			{#if title || description}
 				<Drawer.Header class="shrink-0 text-left">
 					{#if title}


### PR DESCRIPTION
I swear it was working in the previous patch but I noticed It wasn't working on main. I can confirm it is this time now though.
<img width="2000" height="1498" alt="image" src="https://github.com/user-attachments/assets/2482a252-a113-43d2-8ae3-69da3476d795" />

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews uses AI, make sure to check over its work

<h2>Greptile Overview</h2>

Updated On: 2025-10-27 18:52:35 UTC

<details><summary><h3>Greptile Summary</h3></summary>


This PR fixes dialog overflow issues by making two key improvements:

- Fixed `dialog-content.svelte` to properly accept the `className` prop, which was previously missing from the `cn()` call
- Refactored `responsive-dialog.svelte` to use CSS Grid with explicit row definitions (`grid-rows-[auto_minmax(0,1fr)_auto]!`) for better overflow control, moved padding from the dialog container to individual sections (header, content, footer), and increased drawer max height from 80vh to 85vh

The changes implement a more robust overflow handling strategy using CSS Grid layout instead of flexbox, ensuring the dialog content scrolls properly while header and footer remain fixed.


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The changes are focused on CSS styling and layout improvements with no logic changes. The fix properly addresses the missing `className` prop propagation and implements a standard CSS Grid pattern for overflow handling. The author has tested and confirmed the fix works correctly.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| frontend/src/lib/components/ui/dialog/dialog-content.svelte | 5/5 | Added missing `className` prop to the `cn()` function call to allow custom classes to be applied to dialog content |
| frontend/src/lib/components/ui/responsive-dialog/responsive-dialog.svelte | 5/5 | Improved overflow handling with CSS grid layout, proper padding distribution, and increased drawer height from 80vh to 85vh |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->