### PR TITLE
refactor: use accent color for card header

### DIFF
--- a/frontend/src/lib/components/ui/card/card-header.svelte
+++ b/frontend/src/lib/components/ui/card/card-header.svelte
@@ -51,8 +51,7 @@
 	data-slot="card-header"
 	class={cn(
 		'@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
-		icon ? 'flex flex-row items-start space-y-0 transition-colors' : '',
-		icon && 'from-primary/3 bg-linear-to-br to-transparent',
+		icon && 'from-primary/3 flex flex-row items-start space-y-0 bg-linear-to-br to-transparent',
 		icon && compact ? 'gap-2 p-2' : icon ? 'gap-3 p-3.5' : '',
 		icon && enableHover && `transition-colors ${headerHoverClass}`,
 		className


### PR DESCRIPTION
Optional PR. Confidence score is wrong, its not aware of the modern tailwind utils.

The card headers subtly incorporate the user’s accent color instead of static grey.
<img width="2984" height="2008" alt="image" src="https://github.com/user-attachments/assets/df336e09-a0c1-4c05-a11c-87eef1e3c5b3" />

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews uses AI, make sure to check over its work

<h2>Greptile Overview</h2>

Updated On: 2025-10-27 19:23:35 UTC

<details><summary><h3>Greptile Summary</h3></summary>


This PR refactors the card header component to use the user's accent color (primary) instead of gray/slate tones. The change replaces mode-dependent gray gradients with primary color gradients at low opacity.

**Key changes:**
- Removed `headerBackgroundClass` derived variable that used gray/slate colors
- Updated header background to use `from-primary/3` and `to-transparent`
- Changed hover effect from gray/slate tones to primary color with `from-primary/8` (dark) or `from-primary/6` (light)
- Updated icon container gradient class

**Issue found:**
- Uses `bg-linear-to-br` which is not a valid Tailwind CSS utility class - should be `bg-gradient-to-br`


</details>
<details><summary><h3>Confidence Score: 2/5</h3></summary>


- This PR has a critical CSS class error that will prevent gradients from rendering
- The refactoring approach is sound and the color changes align with the PR goal, but the invalid Tailwind class `bg-linear-to-br` (should be `bg-gradient-to-br`) will cause visual rendering issues. This same error appears in multiple places in the PR
- frontend/src/lib/components/ui/card/card-header.svelte requires fixing the invalid CSS class before merge
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| frontend/src/lib/components/ui/card/card-header.svelte | 2/5 | Refactored to use accent color for card headers, but introduced invalid Tailwind class `bg-linear-to-br` (should be `bg-gradient-to-br`) |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->