### PR TITLE
chore: table cell newline wrapping fix

### DIFF
--- a/frontend/src/lib/components/ui/table/table-cell.svelte
+++ b/frontend/src/lib/components/ui/table/table-cell.svelte
@@ -8,7 +8,7 @@
 <td
 	bind:this={ref}
 	data-slot="table-cell"
-	class={cn('px-4 py-3 align-middle first:pl-6 last:pr-6 [&:has([role=checkbox])]:pr-0', className)}
+	class={cn('px-4 py-3 align-middle whitespace-nowrap first:pl-6 last:pr-6 [&:has([role=checkbox])]:pr-0', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/frontend/src/lib/components/ui/table/table-head.svelte
+++ b/frontend/src/lib/components/ui/table/table-head.svelte
@@ -9,7 +9,7 @@
 	bind:this={ref}
 	data-slot="table-head"
 	class={cn(
-		'text-muted-foreground h-12 px-4 text-left align-middle text-xs font-medium uppercase first:pl-6 last:pr-6 [&:has([role=checkbox])]:pr-0',
+		'text-muted-foreground h-12 px-4 text-left align-middle text-xs font-medium whitespace-nowrap uppercase first:pl-6 last:pr-6 [&:has([role=checkbox])]:pr-0',
 		className
 	)}
 	{...restProps}


### PR DESCRIPTION
before:
<img width="2528" height="2008" alt="image" src="https://github.com/user-attachments/assets/692f4404-9ed2-4473-829a-25ed41630192" />
after:
<img width="2528" height="2008" alt="image" src="https://github.com/user-attachments/assets/fb90efb9-e676-4f23-886a-2f512d22d1eb" />

even worse on my personal:
<img width="2984" height="2008" alt="image" src="https://github.com/user-attachments/assets/4c10dd17-963b-4593-bef0-8a7b941b14de" />
