### PR TITLE
fix: popovers fully transparent without glassmorphism

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -280,7 +280,9 @@ body:not(.glass-enabled) {
 
 	[data-slot='dialog-content'],
 	[data-slot='sheet-content'],
-	[data-slot='popover-content'] {
+	[data-slot='popover-content'],
+	[data-slot='dropdown-menu-content'],
+	[data-slot='select-content'] {
 		background: var(--bg-surface) !important;
 	}
 

--- a/frontend/src/lib/components/sidebar/sidebar-env-switcher.svelte
+++ b/frontend/src/lib/components/sidebar/sidebar-env-switcher.svelte
@@ -98,7 +98,7 @@
 				{/snippet}
 			</DropdownMenu.Trigger>
 			<DropdownMenu.Content
-				class="w-[var(--bits-dropdown-menu-anchor-width)] min-w-56 rounded-2xl border shadow-lg backdrop-blur-[var(--glass-blur-popup)] backdrop-saturate-150"
+				class="w-(--bits-dropdown-menu-anchor-width) min-w-56 rounded-2xl border shadow-lg backdrop-blur-(--glass-blur-popup) backdrop-saturate-150"
 				align="start"
 				side="right"
 				sideOffset={4}

--- a/frontend/src/lib/components/sidebar/sidebar-user.svelte
+++ b/frontend/src/lib/components/sidebar/sidebar-user.svelte
@@ -63,7 +63,7 @@
 									<Avatar.Image src={getDefaultProfilePicture()} alt={user.displayName} />
 								{/if}
 								<Avatar.Fallback
-									class="from-primary/20 to-primary/10 text-primary border-primary/20 rounded-lg border bg-gradient-to-br"
+									class="from-primary/20 to-primary/10 text-primary border-primary/20 rounded-lg border bg-linear-to-br"
 								>
 									{user.displayName?.charAt(0).toUpperCase()}
 								</Avatar.Fallback>
@@ -79,7 +79,7 @@
 				{/snippet}
 			</DropdownMenu.Trigger>
 			<DropdownMenu.Content
-				class="border-border/20 min-w-56 rounded-2xl border p-0 shadow-lg backdrop-blur-[var(--glass-blur-popup)] backdrop-saturate-150"
+				class="border-border/20 min-w-56 rounded-2xl border p-0 shadow-lg backdrop-blur-(--glass-blur-popup) backdrop-saturate-150"
 				side="right"
 				align="end"
 				sideOffset={12}
@@ -113,7 +113,7 @@
 									<Avatar.Image src={getDefaultProfilePicture()} alt={user.displayName} />
 								{/if}
 								<Avatar.Fallback
-									class="from-primary/20 to-primary/10 text-primary border-primary/20 rounded-lg border bg-gradient-to-br"
+									class="from-primary/20 to-primary/10 text-primary border-primary/20 rounded-lg border bg-linear-to-br"
 								>
 									{user.displayName?.charAt(0).toUpperCase()}
 								</Avatar.Fallback>
@@ -140,7 +140,7 @@
 						<Button.Root
 							variant="ghost"
 							class={cn(
-								'text-muted-foreground flex w-full items-center rounded-xl text-sm font-medium transition-all duration-200 hover:bg-gradient-to-br',
+								'text-muted-foreground flex w-full items-center rounded-xl text-sm font-medium transition-all duration-200 hover:bg-linear-to-br',
 								'h-11 justify-start gap-3 px-3 py-2.5'
 							)}
 							title={m.common_toggle_theme()}

--- a/frontend/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
+++ b/frontend/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
@@ -20,7 +20,7 @@
 		preventScroll={false}
 		{sideOffset}
 		class={cn(
-			'text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl border p-1 shadow-md backdrop-blur-[var(--glass-blur-popup)] backdrop-saturate-150 outline-none',
+			'text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl border p-1 shadow-md backdrop-blur-(--glass-blur-popup) backdrop-saturate-150 outline-none',
 			'max-h-(--radix-dropdown-menu-content-available-height) max-w-[calc(100vw-2rem)]',
 			'max-[768px]:max-w-[calc(100vw-1rem)]',
 			className

--- a/frontend/src/lib/components/ui/popover/popover-content.svelte
+++ b/frontend/src/lib/components/ui/popover/popover-content.svelte
@@ -22,7 +22,7 @@
 		{sideOffset}
 		{align}
 		class={cn(
-			'text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--bits-popover-content-transform-origin) rounded-xl border p-4 shadow-md outline-hidden backdrop-blur-[var(--glass-blur-popup)] backdrop-saturate-150',
+			'text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--bits-popover-content-transform-origin) rounded-xl border p-4 shadow-md outline-hidden backdrop-blur-(--glass-blur-popup) backdrop-saturate-150',
 			className
 		)}
 		{...restProps}

--- a/frontend/src/lib/components/ui/select/select-content.svelte
+++ b/frontend/src/lib/components/ui/select/select-content.svelte
@@ -24,12 +24,12 @@
 		{align}
 		data-slot="select-content"
 		class={cn(
-			'text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-xl border shadow-md backdrop-blur-[var(--glass-blur-popup)] backdrop-saturate-150 data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+			'text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 min-w-32 overflow-x-hidden overflow-y-auto rounded-xl border shadow-md backdrop-blur-(--glass-blur-popup) backdrop-saturate-150 data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
 			'max-h-(--bits-select-content-available-height) origin-(--bits-select-content-transform-origin)',
-			'w-[var(--radix-popper-anchor-width)] max-w-[calc(100vw-2rem)] min-w-[var(--radix-popper-anchor-width)]',
+			'w-(--radix-popper-anchor-width) max-w-[calc(100vw-2rem)] min-w-(--radix-popper-anchor-width)',
 			'max-[768px]:max-w-[calc(100vw-1rem)]',
-			'[&[data-side="right"]]:!right-0 [&[data-side="right"]]:!left-auto',
-			'[&[data-side="bottom"]]:!max-h-[min(var(--bits-select-content-available-height),_calc(100vh-2rem))]',
+			'data-[side="right"]:right-0! data-[side="right"]:left-auto!',
+			'data-[side="bottom"]:max-h-[min(var(--bits-select-content-available-height),calc(100vh-2rem))]!',
 			className
 		)}
 		{...restProps}


### PR DESCRIPTION
greptileai is wrong, the tailwind linter itself suggested these class fixes

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews uses AI, make sure to check over its work

<h2>Greptile Overview</h2>

Updated On: 2025-10-28 18:56:39 UTC

<details><summary><h3>Greptile Summary</h3></summary>


This PR updates CSS syntax to fix popover transparency issues when glassmorphism is disabled, migrating from Tailwind v3 to v4 syntax.

**Key changes:**
- Updated `backdrop-blur-[var(--...)]` to `backdrop-blur-(--...)` syntax across multiple components
- Added `data-slot` selectors for `dropdown-menu-content` and `select-content` in app.css to ensure proper background when glassmorphism is disabled
- Updated CSS variable references from square brackets to parentheses (e.g., `w-[var(--...)]` → `w-(--...)`)
- Changed `min-w-[8rem]` to `min-w-32` in select-content
- Updated data attribute selectors to use new Tailwind v4 syntax

**Critical issue found:**
- `sidebar-user.svelte` incorrectly changed `bg-gradient-to-br` to `bg-linear-to-br` (3 occurrences), which is not a valid Tailwind class and will break gradient styling on avatar fallbacks and hover states


</details>
<details><summary><h3>Confidence Score: 1/5</h3></summary>


- This PR contains critical syntax errors that will break visual styling
- While most changes correctly migrate to Tailwind v4 syntax, the use of invalid `bg-linear-to-br` class in sidebar-user.svelte will cause gradients to not render, breaking the avatar fallback and button hover styling
- frontend/src/lib/components/sidebar/sidebar-user.svelte requires immediate fixes to correct the invalid gradient class names
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| frontend/src/app.css | 5/5 | Added `data-slot` selectors for dropdown-menu-content and select-content to support non-glassmorphism mode - correct implementation |
| frontend/src/lib/components/sidebar/sidebar-user.svelte | 0/5 | Changed `bg-gradient-to-br` to invalid `bg-linear-to-br` class (3 occurrences) - will break gradient styling. Also updated backdrop-blur syntax correctly |
| frontend/src/lib/components/ui/select/select-content.svelte | 5/5 | Updated CSS syntax to Tailwind v4 format: backdrop-blur, width variables, min-width (8rem→32), and data attribute selectors - all correct |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->