### PR TITLE
fix: wrong repo link in examples

### DIFF
--- a/examples/compose.agent.yaml
+++ b/examples/compose.agent.yaml
@@ -1,6 +1,6 @@
 services:
   arcane-agent:
-    image: ghcr.io/getaracneapp/arcane-headless:latest
+    image: ghcr.io/getarcaneapp/arcane-headless:latest
     container_name: arcane-agent
     ports:
       - "3553:3553"

--- a/examples/compose.basic.yaml
+++ b/examples/compose.basic.yaml
@@ -1,6 +1,6 @@
 services:
   arcane:
-    image: ghcr.io/getaracneapp/arcane:latest
+    image: ghcr.io/getarcaneapp/arcane:latest
     container_name: arcane
     ports:
       - "3552:3552"

--- a/examples/compose.proxy.yaml
+++ b/examples/compose.proxy.yaml
@@ -38,7 +38,7 @@ services:
       - no-new-privileges:true
 
   arcane:
-    image: ghcr.io/getaracneapp/arcane:latest
+    image: ghcr.io/getarcaneapp/arcane:latest
     container_name: arcane
     ports:
       - "3552:3552"


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews uses AI, make sure to check over its work

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>


Fixed typo in GitHub Container Registry organization name across all example Docker Compose files, changing `getaracneapp` to the correct `getarcaneapp`.

- Corrected image path in `compose.agent.yaml` for `arcane-headless:latest`
- Corrected image path in `compose.basic.yaml` for `arcane:latest`
- Corrected image path in `compose.proxy.yaml` for `arcane:latest`

This ensures users can successfully pull the correct images from `ghcr.io/getarcaneapp/*` as documented in the README.


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with no risk
- Simple typo fix correcting organization name in image references. Changes are minimal, correct, and consistent across all affected files. No logic, syntax, or security issues.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| examples/compose.agent.yaml | 5/5 | Fixed typo in GHCR image repository path from `getaracneapp` to `getarcaneapp` |
| examples/compose.basic.yaml | 5/5 | Fixed typo in GHCR image repository path from `getaracneapp` to `getarcaneapp` |
| examples/compose.proxy.yaml | 5/5 | Fixed typo in GHCR image repository path from `getaracneapp` to `getarcaneapp` |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->