### PR TITLE
fix: missing tooltip provider

### DIFF
--- a/frontend/src/routes/environments/[id]/+page.svelte
+++ b/frontend/src/routes/environments/[id]/+page.svelte
@@ -165,18 +165,6 @@
 		toast.info(m.environments_changes_reset());
 	}
 
-	const needsEnvironmentSwitch = $derived(() => {
-		return currentEnvironment?.id !== environment?.id;
-	});
-
-	async function handleEditSettings() {
-		if (needsEnvironmentSwitch()) {
-			showSwitchDialog = true;
-		} else {
-			goto('/settings');
-		}
-	}
-
 	async function confirmSwitchAndEdit() {
 		try {
 			await environmentStore.setEnvironment(environment);
@@ -189,7 +177,7 @@
 	}
 </script>
 
-<div class="container mx-auto max-w-full space-y-6 overflow-hidden p-2 pb-16 sm:p-6">
+<div class="container mx-auto max-w-full space-y-6 overflow-hidden p-2 sm:p-6">
 	<div class="space-y-3 sm:space-y-4">
 		<Button variant="ghost" onclick={() => goto('/environments')} class="w-fit gap-2">
 			<ArrowLeftIcon class="size-4" />
@@ -292,14 +280,16 @@
 						<div class="text-muted-foreground text-xs">{m.environments_enable_disable_description()}</div>
 					</div>
 					{#if environment.id === '0'}
-						<Tooltip.Root>
-							<Tooltip.Trigger>
-								<Switch id="env-enabled" disabled={true} bind:checked={formEnabled} />
-							</Tooltip.Trigger>
-							<Tooltip.Content>
-								<p>{m.environments_local_setting_disabled()}</p>
-							</Tooltip.Content>
-						</Tooltip.Root>
+						<Tooltip.Provider>
+							<Tooltip.Root>
+								<Tooltip.Trigger>
+									<Switch id="env-enabled" disabled={true} bind:checked={formEnabled} />
+								</Tooltip.Trigger>
+								<Tooltip.Content>
+									<p>{m.environments_local_setting_disabled()}</p>
+								</Tooltip.Content>
+							</Tooltip.Root>
+						</Tooltip.Provider>
 					{:else}
 						<Switch id="env-enabled" bind:checked={formEnabled} />
 					{/if}
@@ -391,22 +381,24 @@
 				<div>
 					<Label for="api-url" class="text-sm font-medium">{m.environments_api_url()}</Label>
 					{#if environment.id === '0'}
-						<Tooltip.Root>
-							<Tooltip.Trigger class="w-full">
-								<Input
-									id="api-url"
-									type="url"
-									bind:value={formApiUrl}
-									class="mt-1.5 font-mono"
-									placeholder={m.environments_api_url_placeholder()}
-									disabled={true}
-									required
-								/>
-							</Tooltip.Trigger>
-							<Tooltip.Content>
-								<p>{m.environments_local_setting_disabled()}</p>
-							</Tooltip.Content>
-						</Tooltip.Root>
+						<Tooltip.Provider>
+							<Tooltip.Root>
+								<Tooltip.Trigger class="w-full">
+									<Input
+										id="api-url"
+										type="url"
+										bind:value={formApiUrl}
+										class="mt-1.5 font-mono"
+										placeholder={m.environments_api_url_placeholder()}
+										disabled={true}
+										required
+									/>
+								</Tooltip.Trigger>
+								<Tooltip.Content>
+									<p>{m.environments_local_setting_disabled()}</p>
+								</Tooltip.Content>
+							</Tooltip.Root>
+						</Tooltip.Provider>
 					{:else}
 						<Input
 							id="api-url"


### PR DESCRIPTION
The missing Tooltip provider was causing the mobile layout for local environments to lock up

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews uses AI, make sure to check over its work

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>


Fixed mobile layout lockup issue in local environment settings by adding missing `Tooltip.Provider` wrappers around tooltip components.

- Wrapped two tooltip instances (for environment enabled switch and API URL input) with `Tooltip.Provider` components
- This follows the correct shadcn-svelte tooltip pattern used throughout the codebase
- Also removed unused code (`needsEnvironmentSwitch` function and `handleEditSettings` function) and cleaned up styling (`pb-16` padding removed from container)


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with no risk
- The change correctly fixes a bug by adding the required `Tooltip.Provider` wrapper around tooltip components, following the proper shadcn-svelte pattern used throughout the codebase. The fix is minimal, targeted, and aligns with the framework's requirements.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| frontend/src/routes/environments/[id]/+page.svelte | 5/5 | Added missing `Tooltip.Provider` wrappers around two tooltip instances for local environment fields, fixing mobile layout lockup issue |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->