### PR TITLE
chore(deps): upgrade to node 25 for frontend builds

### DIFF
--- a/.github/workflows/build-next-images.yml
+++ b/.github/workflows/build-next-images.yml
@@ -54,7 +54,7 @@ jobs:
         if: matrix.needs-frontend
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 25
           cache: pnpm
 
       - name: Setup Go

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 25
           cache: pnpm
 
       - name: Cache Playwright Browsers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 25
           cache: pnpm
 
       - name: Install frontend deps

--- a/.github/workflows/svelte-check.yml
+++ b/.github/workflows/svelte-check.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 25
           cache: pnpm
 
       - name: Install dependencies

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,8 +5,6 @@ services:
       context: .
       dockerfile: docker/Dockerfile.dev
       target: frontend-dev
-      args:
-        NODE_VERSION: "24"
     container_name: arcane-frontend-dev
     ports:
       - "3000:3000"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,8 +4,8 @@
 ARG BUILD_TAGS=""
 
 # Stage 1: Build Frontend
-FROM node:24-alpine AS frontend-builder
-RUN corepack enable
+FROM node:25-alpine AS frontend-builder
+RUN npm install -g --force corepack && corepack enable
 WORKDIR /build
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY frontend/package.json ./frontend/package.json

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,9 +1,5 @@
-# Development Dockerfile with hot reload support
-ARG NODE_VERSION="24"
-
-# Stage 1: Frontend Development
-FROM node:${NODE_VERSION}-alpine AS frontend-dev
-RUN corepack enable
+FROM node:25-alpine AS frontend-dev
+RUN npm install -g --force corepack && corepack enable
 WORKDIR /app
 
 # Copy package configuration files and install dependencies


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews uses AI, make sure to check over its work

<details><summary><h3>Greptile Summary</h3></summary>


- Upgraded Node.js from version 24 to 25 across all GitHub Actions workflows and Docker build configurations
- Modified corepack installation to use `npm install -g --force corepack && corepack enable` instead of just `corepack enable`


</details>
<details><summary><h3>Confidence Score: 4/5</h3></summary>


- This PR is safe to merge with one minor configuration mismatch that should be corrected
- The Node.js 25 upgrade is straightforward and Node 25 is available and stable. The corepack installation method change is appropriate. However, the `package.json` engines field still specifies `>=24` instead of `>=25`, creating a minor inconsistency that should be fixed to ensure proper version enforcement
- The `frontend/package.json` engines field should be updated to match the Node 25 upgrade
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docker/Dockerfile | Updated Node.js to version 25 and changed corepack installation to use npm with --force flag |
| docker/Dockerfile.dev | Updated Node.js to version 25, removed ARG parameterization, and changed corepack installation method |
| frontend/package.json | Engines field still specifies `>=24` but should be updated to `>=25` to match the Node.js version upgrade |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->