### PR TITLE
feat: improved pull ui including layer progress

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1261,10 +1261,17 @@
 	"progress_title": "Progress",
 	"progress_subtitle": "Working…",
 	"progress_preparing": "Preparing…",
+	"progress_downloading": "Downloading",
+	"progress_extracting": "Extracting",
+	"progress_pulling": "Pulling",
+	"progress_verifying": "Verifying",
+	"progress_waiting": "Waiting",
 	"progress_pull_completed": "Pull Completed",
 	"progress_in_progress_note": "This may take a while depending on size and connection.",
 	"progress_completed_success": "Completed successfully!",
 	"progress_pulling_images": "Pulling Images",
+	"progress_layers_status": "{completed} of {total} layers",
+	"progress_show_layers": "Show Layers",
 	"meter_footer_usage": "{percent}% of resources being used",
 
 	"_comment_image_updates": "=== IMAGE UPDATES ===",
@@ -1571,5 +1578,5 @@
 	"upgrade_status_checking": "Checking for new version...",
 	"upgrade_status_detected": "New version detected!",
 	"upgrade_wait_info": "This may take 30-60 seconds. The page will reload automatically when ready.",
-    "auto_start": "Auto-start"
+	"auto_start": "Auto-start"
 }

--- a/frontend/src/lib/components/progress-popover.svelte
+++ b/frontend/src/lib/components/progress-popover.svelte
@@ -3,10 +3,25 @@
 	import * as Popover from '$lib/components/ui/popover/index.js';
 	import { Popover as PopoverPrimitive } from 'bits-ui';
 	import { Progress } from '$lib/components/ui/progress/index.js';
+	import * as Item from '$lib/components/ui/item/index.js';
+	import * as Collapsible from '$lib/components/ui/collapsible/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import DownloadIcon from '@lucide/svelte/icons/download';
+	import CheckCircleIcon from '@lucide/svelte/icons/check-circle';
+	import XCircleIcon from '@lucide/svelte/icons/x-circle';
+	import PackageIcon from '@lucide/svelte/icons/package';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import type { Icon as IconType } from '@lucide/svelte';
 	import type { Snippet } from 'svelte';
 	import { m } from '$lib/paraglide/messages';
+	import {
+		type LayerProgress,
+		type PullPhase,
+		getPullPhase,
+		getLayerStats,
+		showImageLayersState,
+		isIndeterminatePhase
+	} from '$lib/utils/pull-progress';
 
 	interface Props {
 		open?: boolean;
@@ -22,6 +37,8 @@
 		icon?: typeof IconType;
 		iconClass?: string;
 		preventCloseWhileLoading?: boolean;
+		onCancel?: () => void;
+		layers?: Record<string, LayerProgress>;
 		children: Snippet;
 	}
 
@@ -37,14 +54,66 @@
 		sideOffset = 4,
 		class: className = '',
 		icon,
-		iconClass = 'text-primary size-4',
+		iconClass = 'size-5',
 		preventCloseWhileLoading = true,
+		onCancel,
+		layers = {},
 		children
 	}: Props = $props();
 
 	const percent = $derived(Math.round(progress));
-	const isComplete = $derived(progress === 100);
-	const displaySubtitle = $derived(error ? subtitle : isComplete ? m.progress_pull_completed() : subtitle);
+	const isComplete = $derived(progress >= 100);
+
+	// Track if we've ever reached complete state to prevent flashing back
+	let hasReachedComplete = $state(false);
+
+	// Update complete tracking
+	$effect(() => {
+		if (isComplete && !error) {
+			hasReachedComplete = true;
+		}
+		// Reset when popover closes
+		if (!open) {
+			hasReachedComplete = false;
+		}
+	});
+
+	// Derive layer stats using utility
+	const layerStats = $derived(getLayerStats(layers, hasReachedComplete));
+
+	// Check if we're in an indeterminate phase (extracting with no byte progress)
+	const isIndeterminate = $derived(isIndeterminatePhase(layers, progress));
+
+	// Derive the current phase from status text using utility
+	const currentPhase = $derived.by((): PullPhase => {
+		return getPullPhase(statusText, hasReachedComplete || isComplete, !!error);
+	});
+
+	// Get localized title based on phase
+	const displayTitle = $derived.by(() => {
+		switch (currentPhase) {
+			case 'error':
+				return 'Error';
+			case 'complete':
+				return m.progress_pull_completed();
+			case 'downloading':
+				return m.progress_downloading();
+			case 'extracting':
+				return m.progress_extracting();
+			case 'verifying':
+				return m.progress_verifying();
+			case 'waiting':
+				return m.progress_waiting();
+			default:
+				return title;
+		}
+	});
+
+	// Get the appropriate icon based on phase
+	const PhaseIcon = $derived.by(() => {
+		if (currentPhase === 'extracting') return PackageIcon;
+		return icon ?? DownloadIcon;
+	});
 
 	function handleOpenChange(next: boolean) {
 		if (preventCloseWhileLoading && !next && loading) {
@@ -53,6 +122,10 @@
 		}
 		open = next;
 	}
+
+	function getLayerPhase(status: string): PullPhase {
+		return getPullPhase(status, false, false);
+	}
 </script>
 
 <Popover.Root bind:open onOpenChange={handleOpenChange}>
@@ -60,64 +133,96 @@
 		{@render children()}
 	</Popover.Trigger>
 
-	<Popover.Content class={cn('bg-popover/20 w-80 backdrop-blur-md', className)} {align} {sideOffset}>
-		<div class="space-y-3">
-			{@render headerSection()}
-			{@render contentSection()}
-		</div>
+	<Popover.Content class={cn('w-80 p-2', className)} {align} {sideOffset}>
+		<Item.Root variant={error ? 'outline' : 'default'} class={cn(error && 'border-destructive/50')}>
+			<Item.Media
+				variant="icon"
+				class={cn(
+					error && 'bg-destructive/10 text-destructive',
+					isComplete && !loading && !error && 'bg-green-500/10 text-green-500'
+				)}
+			>
+				{#if error}
+					<XCircleIcon class={iconClass} />
+				{:else if isComplete && !loading}
+					<CheckCircleIcon class={iconClass} />
+				{:else}
+					<PhaseIcon class={cn(iconClass, loading && 'animate-pulse')} />
+				{/if}
+			</Item.Media>
+			<Item.Content>
+				<Item.Title class={cn(error && 'text-destructive')}>{displayTitle}</Item.Title>
+				<Item.Description>
+					{#if error}
+						{error}
+					{:else if layerStats.total > 0}
+						{m.progress_layers_status({ completed: layerStats.completed, total: layerStats.total })}
+					{:else}
+						{hasReachedComplete ? 100 : percent}% · {statusText || subtitle}
+					{/if}
+				</Item.Description>
+			</Item.Content>
+			{#if loading && onCancel}
+				<Item.Actions>
+					<Button variant="outline" size="sm" onclick={onCancel}>
+						{m.common_cancel()}
+					</Button>
+				</Item.Actions>
+			{/if}
+			{#if !error}
+				<Item.Footer>
+					<Progress
+						value={hasReachedComplete || isIndeterminate ? 100 : progress}
+						max={100}
+						class="h-1.5 w-full"
+						indeterminate={isIndeterminate && !hasReachedComplete}
+					/>
+				</Item.Footer>
+			{/if}
+		</Item.Root>
+
+		{#if Object.keys(layers).length > 0 && !error}
+			<Collapsible.Root bind:open={showImageLayersState.current} class="mt-2">
+				<Collapsible.Trigger
+					class="text-muted-foreground hover:text-foreground hover:bg-accent flex w-full items-center justify-between rounded-md px-2 py-1.5 text-xs transition-colors"
+				>
+					{m.progress_show_layers()}
+					<ChevronDownIcon class={cn('size-3 transition-transform', showImageLayersState.current && 'rotate-180')} />
+				</Collapsible.Trigger>
+				<Collapsible.Content>
+					<div class="mt-2 max-h-48 space-y-1.5 overflow-y-auto">
+						{#each Object.entries(layers) as [id, layer] (id)}
+							{@const phase = hasReachedComplete ? 'complete' : getLayerPhase(layer.status)}
+							{@const layerPercent =
+								phase === 'complete' ? 100 : layer.total > 0 ? Math.round((layer.current / layer.total) * 100) : 0}
+							<div class="bg-muted/30 rounded-md px-2 py-1.5">
+								<div class="flex items-center justify-between gap-2">
+									<span class="text-muted-foreground truncate font-mono text-[10px]">{id.slice(0, 12)}</span>
+									<span
+										class={cn(
+											'text-[10px] font-medium',
+											phase === 'complete' && 'text-green-500',
+											phase === 'downloading' && 'text-blue-500',
+											phase === 'extracting' && 'text-amber-500'
+										)}
+									>
+										{#if phase === 'complete'}
+											✓
+										{:else if layer.total > 0}
+											{layerPercent}%
+										{:else}
+											{layer.status}
+										{/if}
+									</span>
+								</div>
+								<Progress value={layerPercent} max={100} class="mt-1 h-1" />
+							</div>
+						{/each}
+					</div>
+				</Collapsible.Content>
+			</Collapsible.Root>
+		{/if}
+
 		<PopoverPrimitive.Arrow class="fill-background stroke-border" />
 	</Popover.Content>
 </Popover.Root>
-
-{#snippet headerSection()}
-	<div class="flex items-center gap-3">
-		<div class="bg-primary/10 flex size-8 shrink-0 items-center justify-center rounded-full">
-			{#if icon}
-				{@const Icon = icon}
-				<Icon class={iconClass} />
-			{:else}
-				<DownloadIcon class={iconClass} />
-			{/if}
-		</div>
-		<div>
-			<h4 class="text-sm font-semibold">{title}</h4>
-			<p class="text-muted-foreground text-xs">{displaySubtitle}</p>
-		</div>
-	</div>
-{/snippet}
-
-{#snippet contentSection()}
-	{#if error}
-		{@render errorDisplay()}
-	{:else}
-		{@render progressDisplay()}
-		{#if isComplete && !loading}
-			{@render successDisplay()}
-		{/if}
-	{/if}
-{/snippet}
-
-{#snippet errorDisplay()}
-	<div class="rounded-md bg-red-50 p-3 dark:bg-red-950/20">
-		<p class="text-destructive text-sm">{error}</p>
-	</div>
-{/snippet}
-
-{#snippet progressDisplay()}
-	<div class="space-y-2">
-		<div class="flex justify-between text-xs">
-			<span class="text-muted-foreground truncate pr-2">{statusText || m.progress_preparing()}</span>
-			<span class="text-muted-foreground shrink-0">{percent}%</span>
-		</div>
-		<Progress value={progress} max={100} class="h-2 w-full" />
-		{#if loading}
-			<p class="text-muted-foreground text-xs">{m.progress_in_progress_note()}</p>
-		{/if}
-	</div>
-{/snippet}
-
-{#snippet successDisplay()}
-	<div class="rounded-md bg-green-50 p-3 dark:bg-green-950/20">
-		<p class="text-sm text-green-600 dark:text-green-400">{m.progress_completed_success()}</p>
-	</div>
-{/snippet}

--- a/frontend/src/lib/components/sheets/image-pull-sheet.svelte
+++ b/frontend/src/lib/components/sheets/image-pull-sheet.svelte
@@ -2,13 +2,29 @@
 	import * as Sheet from '$lib/components/ui/sheet/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import FormInput from '$lib/components/form/form-input.svelte';
-	import { Spinner } from '$lib/components/ui/spinner/index.js';
+	import { Progress } from '$lib/components/ui/progress/index.js';
+	import * as Collapsible from '$lib/components/ui/collapsible/index.js';
 	import DownloadIcon from '@lucide/svelte/icons/download';
+	import CheckCircleIcon from '@lucide/svelte/icons/check-circle';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import { z } from 'zod/v4';
 	import { createForm, preventDefault } from '$lib/utils/form.utils';
 	import { toast } from 'svelte-sonner';
-	import { environmentStore, LOCAL_DOCKER_ENVIRONMENT_ID } from '$lib/stores/environment.store.svelte';
+	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import { m } from '$lib/paraglide/messages';
+	import { cn } from '$lib/utils.js';
+	import {
+		type LayerProgress,
+		type PullPhase,
+		calculateOverallProgress,
+		areAllLayersComplete,
+		updateLayerFromStreamData,
+		extractErrorMessage,
+		getLayerStats,
+		getPullPhase,
+		showImageLayersState,
+		isIndeterminatePhase
+	} from '$lib/utils/pull-progress';
 
 	type ImagePullFormProps = {
 		open: boolean;
@@ -33,7 +49,28 @@
 	let pullProgress = $state(0);
 	let pullStatusText = $state('');
 	let pullError = $state('');
-	let layerProgress = $state<Record<string, { current: number; total: number; status: string }>>({});
+	let layerProgress = $state<Record<string, LayerProgress>>({});
+	let hasReachedComplete = $state(false);
+	let currentImageName = $state('');
+
+	const layerStats = $derived(getLayerStats(layerProgress, hasReachedComplete));
+	const showPullUI = $derived(isPulling || hasReachedComplete || !!pullError);
+	const isIndeterminate = $derived(isIndeterminatePhase(layerProgress, pullProgress));
+	let prevOpen = $state(false);
+
+	$effect(() => {
+		if (prevOpen && !open && !isPulling) {
+			// Sheet just closed, reset state and form
+			resetState();
+			$inputs.imageRef.value = '';
+			$inputs.tag.value = 'latest';
+		}
+		prevOpen = open;
+	});
+
+	function getLayerPhase(status: string): PullPhase {
+		return getPullPhase(status, false, false);
+	}
 
 	function resetState() {
 		isPulling = false;
@@ -41,32 +78,12 @@
 		pullStatusText = '';
 		pullError = '';
 		layerProgress = {};
+		hasReachedComplete = false;
+		currentImageName = '';
 	}
 
-	function calculateOverallProgress() {
-		let totalCurrentBytes = 0;
-		let totalExpectedBytes = 0;
-		let activeLayers = 0;
-
-		for (const id in layerProgress) {
-			const layer = layerProgress[id];
-			if (layer.total > 0) {
-				totalCurrentBytes += layer.current;
-				totalExpectedBytes += layer.total;
-				activeLayers++;
-			}
-		}
-
-		if (totalExpectedBytes > 0) {
-			pullProgress = (totalCurrentBytes / totalExpectedBytes) * 100;
-		} else if (activeLayers > 0 && totalCurrentBytes > 0) {
-			pullProgress = 5;
-		} else if (Object.keys(layerProgress).length > 0 && activeLayers === 0) {
-			const allDone = Object.values(layerProgress).every(
-				(l) => l.status && (l.status.toLowerCase().includes('pull complete') || l.status.toLowerCase().includes('already exists'))
-			);
-			if (allDone) pullProgress = 100;
-		}
+	function updateProgress() {
+		pullProgress = calculateOverallProgress(layerProgress);
 	}
 
 	async function handleSubmit() {
@@ -91,8 +108,9 @@
 		}
 
 		const fullImageName = `${imageName}:${imageTag}`;
+		currentImageName = fullImageName;
 		const envId = await environmentStore.getCurrentEnvironmentId();
-		pullStatusText = `${m.common_action_pulling()} ${fullImageName}`;
+		pullStatusText = m.images_pull_initiating();
 
 		try {
 			const response = await fetch(`/api/environments/${envId}/images/pull`, {
@@ -137,57 +155,43 @@
 					try {
 						const data = JSON.parse(line);
 
-						if (data.error) {
-							console.error('Error in stream:', data.error);
-							pullError = typeof data.error === 'string' ? data.error : data.error.message || m.images_pull_stream_error();
+						const errorMsg = extractErrorMessage(data, m.images_pull_stream_error());
+						if (errorMsg) {
+							console.error('Error in stream:', errorMsg);
+							pullError = errorMsg;
 							pullStatusText = m.images_pull_failed_with_error({ error: pullError });
 							continue;
 						}
 
-						pullStatusText = data.status || pullStatusText;
-						if (data.id) {
-							const currentLayer = layerProgress[data.id] || { current: 0, total: 0, status: '' };
-							currentLayer.status = data.status || currentLayer.status;
-
-							if (data.progressDetail) {
-								currentLayer.current = data.progressDetail.current || currentLayer.current;
-								currentLayer.total = data.progressDetail.total || currentLayer.total;
-							}
-							layerProgress[data.id] = currentLayer;
-						}
-						calculateOverallProgress();
+						if (data.status) pullStatusText = data.status;
+						layerProgress = updateLayerFromStreamData(layerProgress, data);
+						updateProgress();
 					} catch (e: any) {
 						console.warn('Failed to parse stream line or process data:', line, e);
 					}
 				}
 			}
 
-			calculateOverallProgress();
-			if (!pullError && pullProgress < 100) {
-				const allLayersCompleteOrExisting = Object.values(layerProgress).every(
-					(l) =>
-						l.status &&
-						(l.status.toLowerCase().includes('complete') ||
-							l.status.toLowerCase().includes('already exists') ||
-							l.status.toLowerCase().includes('downloaded newer image'))
-				);
-				if (allLayersCompleteOrExisting && Object.keys(layerProgress).length > 0) {
-					pullProgress = 100;
-				}
+			updateProgress();
+			if (!pullError && pullProgress < 100 && areAllLayersComplete(layerProgress)) {
+				pullProgress = 100;
 			}
 
 			if (pullError) {
 				throw new Error(pullError);
 			}
 
+			hasReachedComplete = true;
+			pullProgress = 100;
 			pullStatusText = m.images_pull_success({ repoTag: fullImageName });
 			toast.success(m.images_pull_success({ repoTag: fullImageName }));
 			onPullFinished(true, fullImageName);
 
-			// Reset form and close sheet
-			$inputs.imageRef.value = '';
-			$inputs.tag.value = 'latest';
-			open = false;
+			// Close sheet after a brief delay to show success state
+			// State will be reset by handleOpenChange when sheet closes
+			setTimeout(() => {
+				open = false;
+			}, 1500);
 		} catch (error: any) {
 			console.error('Pull image error:', error);
 			const message = error.message || m.images_pull_unexpected_error();
@@ -208,16 +212,17 @@
 		}
 
 		open = newOpenState;
-		if (!newOpenState && !isPulling) {
+		if (!newOpenState) {
+			// Reset when closing (if we get here, isPulling is false)
+			resetState();
+			$inputs.imageRef.value = '';
+			$inputs.tag.value = 'latest';
+		} else {
+			// Also reset when opening to ensure clean state
 			resetState();
 			$inputs.imageRef.value = '';
 			$inputs.tag.value = 'latest';
 		}
-	}
-
-	function getCurrentEnvironmentId(): string {
-		const env = environmentStore.selected;
-		return env?.id || LOCAL_DOCKER_ENVIRONMENT_ID;
 	}
 </script>
 
@@ -225,76 +230,152 @@
 	<Sheet.Content class="p-6">
 		<Sheet.Header class="space-y-3 border-b pb-6">
 			<div class="flex items-center gap-3">
-				<div class="bg-primary/10 flex size-10 shrink-0 items-center justify-center rounded-lg">
-					<DownloadIcon class="text-primary size-5" />
+				<div
+					class={cn(
+						'flex size-10 shrink-0 items-center justify-center rounded-lg',
+						pullError && 'bg-destructive/10 text-destructive',
+						hasReachedComplete && !pullError && 'bg-green-500/10 text-green-500',
+						!showPullUI && 'bg-primary/10 text-primary',
+						isPulling && !pullError && !hasReachedComplete && 'bg-primary/10 text-primary'
+					)}
+				>
+					{#if hasReachedComplete && !pullError}
+						<CheckCircleIcon class="size-5" />
+					{:else}
+						<DownloadIcon class={cn('size-5', isPulling && 'animate-pulse')} />
+					{/if}
 				</div>
-				<div>
+				<div class="min-w-0 flex-1">
 					<Sheet.Title class="text-xl font-semibold">{m.images_pull_image()}</Sheet.Title>
 					<Sheet.Description class="text-muted-foreground mt-1 text-sm">
-						{m.images_pull_description()}
-						{#if pullError}
-							<p class="text-destructive mt-2 text-sm">{pullError}</p>
+						{#if showPullUI && currentImageName}
+							<span class="block truncate" title={currentImageName}>{currentImageName}</span>
+						{:else}
+							{m.images_pull_description()}
 						{/if}
 					</Sheet.Description>
 				</div>
 			</div>
 		</Sheet.Header>
 
-		<form onsubmit={preventDefault(handleSubmit)} class="grid gap-4 py-4">
-			<FormInput
-				label={m.images_image_name_label()}
-				type="text"
-				placeholder={m.images_image_name_placeholder()}
-				description={m.images_image_name_description()}
-				disabled={isPulling}
-				bind:input={$inputs.imageRef}
-			/>
-			<FormInput
-				label={m.images_tag()}
-				type="text"
-				placeholder={m.images_tag_latest()}
-				description={m.images_tag_description()}
-				disabled={isPulling}
-				bind:input={$inputs.tag}
-			/>
+		{#if showPullUI}
+			<!-- Pull progress UI -->
+			<div class="space-y-4 py-6">
+				{#if pullError}
+					<div class="bg-destructive/10 text-destructive rounded-lg p-4">
+						<p class="text-sm font-medium">{m.image_update_error_label()}</p>
+						<p class="mt-1 text-xs">{pullError}</p>
+					</div>
+				{:else}
+					<!-- Progress status -->
+					<div class="space-y-2">
+						<div class="flex items-center justify-between">
+							<p class="text-sm font-medium">
+								{#if hasReachedComplete}
+									{m.progress_pull_completed()}
+								{:else if layerStats.total > 0}
+									{m.progress_layers_status({ completed: layerStats.completed, total: layerStats.total })}
+								{:else}
+									{pullStatusText || m.common_action_pulling()}
+								{/if}
+							</p>
+							{#if !isIndeterminate || hasReachedComplete}
+								<p class="text-muted-foreground text-sm">{Math.round(hasReachedComplete ? 100 : pullProgress)}%</p>
+							{/if}
+						</div>
+						<Progress
+							value={hasReachedComplete || isIndeterminate ? 100 : pullProgress}
+							max={100}
+							class="h-2 w-full"
+							indeterminate={isIndeterminate && !hasReachedComplete}
+						/>
+					</div>
 
-			{#if isPulling || pullStatusText}
-				<div class="mt-4">
-					{#if isPulling}
-						<div class="mb-1 flex justify-between text-xs">
-							<span>{pullStatusText || m.common_action_pulling()}</span>
-							<span>{Math.round(pullProgress)}%</span>
-						</div>
-						<div class="bg-secondary h-2 w-full overflow-hidden rounded-full">
-							<div class="bg-primary h-full transition-all duration-150 ease-linear" style="width: {pullProgress}%"></div>
-						</div>
-					{:else if pullStatusText && !pullError}
-						<p class="mt-1 text-xs text-green-600">{pullStatusText}</p>
+					{#if Object.keys(layerProgress).length > 0}
+						<Collapsible.Root bind:open={showImageLayersState.current}>
+							<Collapsible.Trigger
+								class="text-muted-foreground hover:text-foreground hover:bg-accent flex w-full items-center justify-between rounded-md px-2 py-1.5 text-xs transition-colors"
+							>
+								{m.progress_show_layers()}
+								<ChevronDownIcon class={cn('size-3 transition-transform', showImageLayersState.current && 'rotate-180')} />
+							</Collapsible.Trigger>
+							<Collapsible.Content>
+								<div class="mt-2 space-y-1.5">
+									{#each Object.entries(layerProgress) as [id, layer] (id)}
+										{@const phase = hasReachedComplete ? 'complete' : getLayerPhase(layer.status)}
+										{@const layerPercent =
+											phase === 'complete' ? 100 : layer.total > 0 ? Math.round((layer.current / layer.total) * 100) : 0}
+										<div class="bg-muted/30 rounded-md px-2 py-1.5">
+											<div class="flex items-center justify-between gap-2">
+												<span class="text-muted-foreground truncate font-mono text-[10px]">{id.slice(0, 12)}</span>
+												<span
+													class={cn(
+														'shrink-0 text-[10px] font-medium',
+														phase === 'complete' && 'text-green-500',
+														phase === 'downloading' && 'text-blue-500',
+														phase === 'extracting' && 'text-amber-500'
+													)}
+												>
+													{#if phase === 'complete'}
+														✓
+													{:else if layer.total > 0}
+														{layerPercent}%
+													{:else}
+														{layer.status}
+													{/if}
+												</span>
+											</div>
+											<Progress value={layerPercent} max={100} class="mt-1 h-1" />
+										</div>
+									{/each}
+								</div>
+							</Collapsible.Content>
+						</Collapsible.Root>
 					{/if}
+
 					{#if isPulling}
-						<p class="text-muted-foreground mt-1 text-xs">{m.images_pull_wait_message()}</p>
+						<p class="text-muted-foreground text-xs">{m.images_pull_wait_message()}</p>
 					{/if}
-				</div>
+				{/if}
+			</div>
+
+			{#if pullError}
+				<Sheet.Footer class="flex flex-row gap-2">
+					<Button type="button" class="flex-1" variant="outline" onclick={() => resetState()}>
+						{m.common_retry()}
+					</Button>
+					<Button type="button" class="flex-1" onclick={() => (open = false)}>
+						{m.common_close()}
+					</Button>
+				</Sheet.Footer>
 			{/if}
+		{:else}
+			<form onsubmit={preventDefault(handleSubmit)} class="grid gap-4 py-4">
+				<FormInput
+					label={m.images_image_name_label()}
+					type="text"
+					placeholder={m.images_image_name_placeholder()}
+					description={m.images_image_name_description()}
+					bind:input={$inputs.imageRef}
+				/>
+				<FormInput
+					label={m.images_tag()}
+					type="text"
+					placeholder={m.images_tag_latest()}
+					description={m.images_tag_description()}
+					bind:input={$inputs.tag}
+				/>
 
-			<Sheet.Footer class="flex flex-row gap-2">
-				<Button
-					type="button"
-					class="arcane-button-cancel flex-1"
-					variant="outline"
-					onclick={() => (open = false)}
-					disabled={isPulling}>{m.common_cancel()}</Button
-				>
-				<Button type="submit" class="arcane-button-create flex-1" disabled={isPulling}>
-					{#if isPulling}
-						<Spinner class="mr-2 size-4" />
-						<span class="opacity-0">{m.images_pull_image()}</span>
-					{:else}
+				<Sheet.Footer class="flex flex-row gap-2">
+					<Button type="button" class="arcane-button-cancel flex-1" variant="outline" onclick={() => (open = false)}>
+						{m.common_cancel()}
+					</Button>
+					<Button type="submit" class="arcane-button-create flex-1">
 						<DownloadIcon class="mr-2 size-4" />
 						{m.images_pull_image()}
-					{/if}
-				</Button>
-			</Sheet.Footer>
-		</form>
+					</Button>
+				</Sheet.Footer>
+			</form>
+		{/if}
 	</Sheet.Content>
 </Sheet.Root>

--- a/frontend/src/lib/components/ui/item/index.ts
+++ b/frontend/src/lib/components/ui/item/index.ts
@@ -1,0 +1,34 @@
+import Root from "./item.svelte";
+import Group from "./item-group.svelte";
+import Separator from "./item-separator.svelte";
+import Header from "./item-header.svelte";
+import Footer from "./item-footer.svelte";
+import Content from "./item-content.svelte";
+import Title from "./item-title.svelte";
+import Description from "./item-description.svelte";
+import Actions from "./item-actions.svelte";
+import Media from "./item-media.svelte";
+
+export {
+	Root,
+	Group,
+	Separator,
+	Header,
+	Footer,
+	Content,
+	Title,
+	Description,
+	Actions,
+	Media,
+	//
+	Root as Item,
+	Group as ItemGroup,
+	Separator as ItemSeparator,
+	Header as ItemHeader,
+	Footer as ItemFooter,
+	Content as ItemContent,
+	Title as ItemTitle,
+	Description as ItemDescription,
+	Actions as ItemActions,
+	Media as ItemMedia,
+};

--- a/frontend/src/lib/components/ui/item/item-actions.svelte
+++ b/frontend/src/lib/components/ui/item/item-actions.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="item-actions"
+	class={cn("flex items-center gap-2", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend/src/lib/components/ui/item/item-content.svelte
+++ b/frontend/src/lib/components/ui/item/item-content.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="item-content"
+	class={cn("flex flex-1 flex-col gap-1 [&+[data-slot=item-content]]:flex-none", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend/src/lib/components/ui/item/item-description.svelte
+++ b/frontend/src/lib/components/ui/item/item-description.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLParagraphElement>> = $props();
+</script>
+
+<p
+	bind:this={ref}
+	data-slot="item-description"
+	class={cn(
+		"text-muted-foreground line-clamp-2 text-balance text-sm font-normal leading-normal",
+		"[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</p>

--- a/frontend/src/lib/components/ui/item/item-footer.svelte
+++ b/frontend/src/lib/components/ui/item/item-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="item-footer"
+	class={cn("flex basis-full items-center justify-between gap-2", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend/src/lib/components/ui/item/item-group.svelte
+++ b/frontend/src/lib/components/ui/item/item-group.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	role="list"
+	data-slot="item-group"
+	class={cn("group/item-group flex flex-col", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend/src/lib/components/ui/item/item-header.svelte
+++ b/frontend/src/lib/components/ui/item/item-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="item-header"
+	class={cn("flex basis-full items-center justify-between gap-2", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend/src/lib/components/ui/item/item-media.svelte
+++ b/frontend/src/lib/components/ui/item/item-media.svelte
@@ -1,0 +1,42 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from "tailwind-variants";
+
+	export const itemMediaVariants = tv({
+		base: "flex shrink-0 items-center justify-center gap-2 group-has-[[data-slot=item-description]]/item:translate-y-0.5 group-has-[[data-slot=item-description]]/item:self-start [&_svg]:pointer-events-none",
+		variants: {
+			variant: {
+				default: "bg-transparent",
+				icon: "bg-muted size-8 rounded-sm border [&_svg:not([class*='size-'])]:size-4",
+				image: "size-10 overflow-hidden rounded-sm [&_img]:size-full [&_img]:object-cover",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	});
+
+	export type ItemMediaVariant = VariantProps<typeof itemMediaVariants>["variant"];
+</script>
+
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		variant = "default",
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & { variant?: ItemMediaVariant } = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="item-media"
+	data-variant={variant}
+	class={cn(itemMediaVariants({ variant }), className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend/src/lib/components/ui/item/item-separator.svelte
+++ b/frontend/src/lib/components/ui/item/item-separator.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { Separator } from "$lib/components/ui/separator/index.js";
+	import { cn } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: ComponentProps<typeof Separator> = $props();
+</script>
+
+<Separator
+	bind:ref
+	data-slot="item-separator"
+	orientation="horizontal"
+	class={cn("my-0", className)}
+	{...restProps}
+/>

--- a/frontend/src/lib/components/ui/item/item-title.svelte
+++ b/frontend/src/lib/components/ui/item/item-title.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="item-title"
+	class={cn("flex w-fit items-center gap-2 text-sm font-medium leading-snug", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend/src/lib/components/ui/item/item.svelte
+++ b/frontend/src/lib/components/ui/item/item.svelte
@@ -1,0 +1,60 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from "tailwind-variants";
+
+	export const itemVariants = tv({
+		base: "group/item [a]:hover:bg-accent/50 [a]:transition-colors focus-visible:border-ring focus-visible:ring-ring/50 flex flex-wrap items-center rounded-md border border-transparent text-sm outline-none transition-colors duration-100 focus-visible:ring-[3px]",
+		variants: {
+			variant: {
+				default: "bg-transparent",
+				outline: "border-border",
+				muted: "bg-muted/50",
+			},
+			size: {
+				default: "gap-4 p-4",
+				sm: "gap-2.5 px-4 py-3",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+			size: "default",
+		},
+	});
+
+	export type ItemSize = VariantProps<typeof itemVariants>["size"];
+	export type ItemVariant = VariantProps<typeof itemVariants>["variant"];
+</script>
+
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { Snippet } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		child,
+		variant,
+		size,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+		variant?: ItemVariant;
+		size?: ItemSize;
+	} = $props();
+
+	const mergedProps = $derived({
+		class: cn(itemVariants({ variant, size }), className),
+		"data-slot": "item",
+		"data-variant": variant,
+		"data-size": size,
+		...restProps,
+	});
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<div bind:this={ref} {...mergedProps}>
+		{@render mergedProps.children?.()}
+	</div>
+{/if}

--- a/frontend/src/lib/components/ui/progress/progress.svelte
+++ b/frontend/src/lib/components/ui/progress/progress.svelte
@@ -7,8 +7,9 @@
 		class: className,
 		max = 100,
 		value,
+		indeterminate = false,
 		...restProps
-	}: WithoutChildrenOrChild<ProgressPrimitive.RootProps> = $props();
+	}: WithoutChildrenOrChild<ProgressPrimitive.RootProps> & { indeterminate?: boolean } = $props();
 </script>
 
 <ProgressPrimitive.Root
@@ -22,4 +23,31 @@
 		class="bg-primary h-full w-full flex-1 transition-all"
 		style={`transform: translateX(-${100 - (100 * (value ?? 0)) / (max ?? 1)}%)`}
 	></div>
+	{#if indeterminate}
+		<div class="progress-shimmer absolute inset-0"></div>
+	{/if}
 </ProgressPrimitive.Root>
+
+<style>
+	.progress-shimmer {
+		background: linear-gradient(
+			90deg,
+			transparent 0%,
+			rgba(0, 0, 0, 0.15) 40%,
+			rgba(0, 0, 0, 0.25) 50%,
+			rgba(0, 0, 0, 0.15) 60%,
+			transparent 100%
+		);
+		background-size: 200% 100%;
+		animation: shimmer 1.5s infinite linear;
+	}
+
+	@keyframes shimmer {
+		0% {
+			background-position: 200% 0;
+		}
+		100% {
+			background-position: -200% 0;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/ui/separator/index.ts
+++ b/frontend/src/lib/components/ui/separator/index.ts
@@ -1,7 +1,7 @@
-import Root from './separator.svelte';
+import Root from "./separator.svelte";
 
 export {
 	Root,
 	//
-	Root as Separator
+	Root as Separator,
 };

--- a/frontend/src/lib/components/ui/separator/separator.svelte
+++ b/frontend/src/lib/components/ui/separator/separator.svelte
@@ -1,15 +1,20 @@
 <script lang="ts">
-	import { Separator as SeparatorPrimitive } from 'bits-ui';
-	import { cn } from '$lib/utils.js';
+	import { Separator as SeparatorPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
 
-	let { ref = $bindable(null), class: className, ...restProps }: SeparatorPrimitive.RootProps = $props();
+	let {
+		ref = $bindable(null),
+		class: className,
+		"data-slot": dataSlot = "separator",
+		...restProps
+	}: SeparatorPrimitive.RootProps = $props();
 </script>
 
 <SeparatorPrimitive.Root
 	bind:ref
-	data-slot="separator"
+	data-slot={dataSlot}
 	class={cn(
-		'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
+		"bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=vertical]:h-full data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px",
 		className
 	)}
 	{...restProps}

--- a/frontend/src/lib/layouts/tabbed-page-layout.svelte
+++ b/frontend/src/lib/layouts/tabbed-page-layout.svelte
@@ -56,7 +56,7 @@
 				<div class="flex items-start justify-between gap-3">
 					<div class="flex min-w-0 items-start gap-3">
 						<Button variant="ghost" size="sm" href={backUrl}>
-							<ArrowLeftIcon class="mr-2 size-4" />
+							<ArrowLeftIcon class="size-4" />
 							{backLabel}
 						</Button>
 						<div class="min-w-0">

--- a/frontend/src/lib/utils/pull-progress.ts
+++ b/frontend/src/lib/utils/pull-progress.ts
@@ -1,0 +1,264 @@
+/**
+ * Utility for tracking Docker image pull progress
+ */
+
+import { PersistedState } from 'runed';
+
+export type PullPhase = 'preparing' | 'downloading' | 'extracting' | 'verifying' | 'waiting' | 'complete' | 'error';
+
+export interface LayerProgress {
+	current: number;
+	total: number;
+	status: string;
+}
+
+export interface PullProgressState {
+	progress: number;
+	statusText: string;
+	error: string;
+	layers: Record<string, LayerProgress>;
+}
+
+/**
+ * Persisted state for whether to show layer details in pull progress UI
+ */
+export const showImageLayersState = new PersistedState('arcane-show-image-layers', false);
+
+/**
+ * Creates an initial pull progress state
+ */
+export function createPullProgressState(): PullProgressState {
+	return {
+		progress: 0,
+		statusText: '',
+		error: '',
+		layers: {}
+	};
+}
+
+/**
+ * Checks if the status indicates a layer is complete
+ */
+export function isLayerComplete(status: string): boolean {
+	const s = status.toLowerCase();
+	return (
+		s.includes('pull complete') ||
+		s.includes('already exists') ||
+		s.includes('download complete') ||
+		s.includes('extracted') ||
+		(s.includes('complete') && !s.includes('downloading'))
+	);
+}
+
+/**
+ * Determines the phase of a pull operation from status text
+ */
+export function getPullPhase(status: string, isComplete = false, hasError = false): PullPhase {
+	if (hasError) return 'error';
+	if (isComplete) return 'complete';
+
+	const s = status.toLowerCase();
+	if (isLayerComplete(s)) return 'complete';
+	if (s.includes('downloading')) return 'downloading';
+	if (s.includes('extracting')) return 'extracting';
+	if (s.includes('verifying') || s.includes('digest')) return 'verifying';
+	if (s.includes('waiting')) return 'waiting';
+	if (s.includes('pulling') || s.includes('pull')) return 'downloading';
+	return 'preparing';
+}
+
+/**
+ * Checks if a stream line indicates downloading activity (should open popover)
+ */
+export function isDownloadingLine(data: unknown): boolean {
+	if (!data || typeof data !== 'object') return false;
+
+	const obj = data as Record<string, unknown>;
+	const status = String(obj?.status ?? '').toLowerCase();
+	const pd = obj?.progressDetail as Record<string, unknown> | undefined;
+
+	// Open if we see byte progress or any of the common pull statuses
+	if (pd && (typeof pd.total === 'number' || typeof pd.current === 'number')) return true;
+
+	return (
+		status.includes('downloading') ||
+		status.includes('extracting') ||
+		status.includes('pulling fs layer') ||
+		status.includes('download complete') ||
+		status.includes('pull complete')
+	);
+}
+
+/**
+ * Calculates overall progress from layer progress data
+ */
+export function calculateOverallProgress(layers: Record<string, LayerProgress>): number {
+	let totalCurrentBytes = 0;
+	let totalExpectedBytes = 0;
+	let activeLayers = 0;
+
+	for (const id in layers) {
+		const layer = layers[id];
+		if (layer.total > 0) {
+			totalCurrentBytes += layer.current;
+			totalExpectedBytes += layer.total;
+			activeLayers++;
+		}
+	}
+
+	if (totalExpectedBytes > 0) {
+		return (totalCurrentBytes / totalExpectedBytes) * 100;
+	}
+
+	if (activeLayers > 0 && totalCurrentBytes > 0) {
+		return 5;
+	}
+
+	if (Object.keys(layers).length > 0 && activeLayers === 0) {
+		const allDone = Object.values(layers).every((l) => l.status && isLayerComplete(l.status));
+		if (allDone) return 100;
+	}
+
+	return 0;
+}
+
+/**
+ * Checks if all layers are complete
+ */
+export function areAllLayersComplete(layers: Record<string, LayerProgress>): boolean {
+	const entries = Object.values(layers);
+	if (entries.length === 0) return false;
+
+	return entries.every(
+		(l) =>
+			l.status &&
+			(l.status.toLowerCase().includes('complete') ||
+				l.status.toLowerCase().includes('already exists') ||
+				l.status.toLowerCase().includes('downloaded newer image'))
+	);
+}
+
+/**
+ * Calculates layer statistics
+ */
+export function getLayerStats(layers: Record<string, LayerProgress>, forceComplete = false) {
+	const entries = Object.entries(layers);
+	const total = entries.length;
+	const completed = entries.filter(([_, l]) => isLayerComplete(l.status || '')).length;
+	const effectiveCompleted = forceComplete ? total : completed;
+	const downloading = entries.filter(([_, l]) => l.status?.toLowerCase().includes('downloading')).length;
+	const extracting = entries.filter(([_, l]) => l.status?.toLowerCase().includes('extracting')).length;
+
+	return { total, completed: effectiveCompleted, downloading, extracting };
+}
+
+/**
+ * Checks if the pull is in an indeterminate phase (extracting/verifying with no measurable progress)
+ * This is used to show a marquee-style progress bar
+ */
+export function isIndeterminatePhase(layers: Record<string, LayerProgress>, currentProgress: number): boolean {
+	const stats = getLayerStats(layers);
+	// If we have layers and most downloads are complete but extraction is happening
+	// and progress is low (byte progress doesn't apply to extraction)
+	if (stats.total === 0) return false;
+
+	const downloadComplete = stats.downloading === 0;
+	const hasExtractingLayers = stats.extracting > 0;
+	const notAllComplete = stats.completed < stats.total;
+
+	// We're in indeterminate phase if downloads are done, extraction is happening,
+	// but not all layers are complete yet
+	return downloadComplete && hasExtractingLayers && notAllComplete && currentProgress < 95;
+}
+
+/**
+ * Extracts error message from stream data
+ */
+export function extractErrorMessage(data: unknown, fallbackMessage: string): string {
+	if (!data || typeof data !== 'object') return fallbackMessage;
+
+	const obj = data as Record<string, unknown>;
+	if (!obj.error) return '';
+
+	if (typeof obj.error === 'string') return obj.error;
+	if (typeof obj.error === 'object' && obj.error !== null) {
+		const errObj = obj.error as Record<string, unknown>;
+		if (typeof errObj.message === 'string') return errObj.message;
+	}
+
+	return fallbackMessage;
+}
+
+/**
+ * Updates layer progress from stream data
+ */
+export function updateLayerFromStreamData(layers: Record<string, LayerProgress>, data: unknown): Record<string, LayerProgress> {
+	if (!data || typeof data !== 'object') return layers;
+
+	const obj = data as Record<string, unknown>;
+	const id = obj.id as string | undefined;
+	if (!id) return layers;
+
+	const currentLayer = layers[id] || { current: 0, total: 0, status: '' };
+	const status = obj.status as string | undefined;
+
+	if (status) {
+		currentLayer.status = status;
+	}
+
+	const progressDetail = obj.progressDetail as Record<string, unknown> | undefined;
+	if (progressDetail) {
+		const current = progressDetail.current as number | undefined;
+		const total = progressDetail.total as number | undefined;
+		if (typeof current === 'number') currentLayer.current = current;
+		if (typeof total === 'number') currentLayer.total = total;
+	}
+
+	return { ...layers, [id]: currentLayer };
+}
+
+/**
+ * Creates a stream handler for pull progress
+ */
+export function createPullStreamHandler(callbacks: {
+	onStatusChange: (status: string) => void;
+	onProgressChange: (progress: number) => void;
+	onLayersChange: (layers: Record<string, LayerProgress>) => void;
+	onError: (error: string) => void;
+	onFirstDownload?: () => void;
+	errorMessage: string;
+}) {
+	let layers: Record<string, LayerProgress> = {};
+	let hasOpenedPopover = false;
+
+	return (data: unknown) => {
+		if (!data) return;
+
+		// Check for first download activity
+		if (!hasOpenedPopover && isDownloadingLine(data)) {
+			hasOpenedPopover = true;
+			callbacks.onFirstDownload?.();
+		}
+
+		// Handle errors
+		const errorMsg = extractErrorMessage(data, callbacks.errorMessage);
+		if (errorMsg) {
+			callbacks.onError(errorMsg);
+			return;
+		}
+
+		// Update status text
+		const obj = data as Record<string, unknown>;
+		if (obj.status && typeof obj.status === 'string') {
+			callbacks.onStatusChange(obj.status);
+		}
+
+		// Update layer progress
+		layers = updateLayerFromStreamData(layers, data);
+		callbacks.onLayersChange(layers);
+
+		// Calculate and update overall progress
+		const progress = calculateOverallProgress(layers);
+		callbacks.onProgressChange(progress);
+	};
+}

--- a/frontend/src/routes/images/+page.svelte
+++ b/frontend/src/routes/images/+page.svelte
@@ -169,6 +169,14 @@
 			disabled: isLoading.checking
 		},
 		{
+			id: 'refresh',
+			action: 'restart',
+			label: m.common_refresh(),
+			onclick: refreshImages,
+			loading: isLoading.refreshing,
+			disabled: isLoading.refreshing
+		},
+		{
 			id: 'prune',
 			action: 'remove',
 			label: m.images_prune_unused(),
@@ -176,14 +184,6 @@
 			onclick: () => (isConfirmPruneDialogOpen = true),
 			loading: isLoading.pruning,
 			disabled: isLoading.pruning
-		},
-		{
-			id: 'refresh',
-			action: 'restart',
-			label: m.common_refresh(),
-			onclick: refreshImages,
-			loading: isLoading.refreshing,
-			disabled: isLoading.refreshing
 		}
 	]);
 


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews uses AI, make sure to check over its work

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>


Significantly improved Docker image pull UI with granular layer-by-layer progress tracking, phase detection, and visual feedback. The implementation introduces a new reusable Item component system and comprehensive pull progress utilities that track individual layer downloads/extractions. Key enhancements include:

- **Layer-level progress tracking**: Shows individual layer status with download/extraction phases and byte-level progress
- **Phase-aware UI**: Displays appropriate icons and titles based on current operation (downloading, extracting, verifying)
- **Indeterminate progress**: Shimmer animation during extraction phase when byte progress isn't available
- **Improved state management**: Prevents UI flashing and properly handles completion state transitions
- **Collapsible layer details**: User preference persisted for showing/hiding detailed layer information
- **Better error handling**: Centralized error extraction from stream data

The implementation follows Svelte 5 patterns correctly and provides a much better user experience during long-running pull operations.


</details>
<details><summary><h3>Confidence Score: 4/5</h3></summary>


- Safe to merge with one minor logic issue in form reset behavior
- The PR implements a substantial UX improvement with well-structured utility functions and proper Svelte 5 patterns. One logic bug exists where form inputs are cleared when opening the sheet (lines 220-225), which could discard pre-filled values. All other code follows best practices with proper type safety, error handling, and state management.
- frontend/src/lib/components/sheets/image-pull-sheet.svelte requires attention for the form reset logic issue
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| frontend/src/lib/utils/pull-progress.ts | 5/5 | New utility module providing comprehensive Docker pull progress tracking with layer-level detail, phase detection, and state management |
| frontend/src/lib/components/progress-popover.svelte | 4/5 | Enhanced popover with layer progress visualization, phase-based titles/icons, and indeterminate progress support |
| frontend/src/lib/components/sheets/image-pull-sheet.svelte | 4/5 | Complete UI overhaul with two-mode interface (form/progress), layer visualization, and improved state management |
| frontend/src/lib/components/ui/progress/progress.svelte | 5/5 | Added indeterminate progress mode with shimmer animation for extraction phase |
| frontend/src/lib/components/action-buttons.svelte | 5/5 | Integrated new pull progress utilities and layer tracking with existing action button handlers |

</details>


</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - .github/copilot-instructions.md file

## Referenced Files:
### Content from github://github.com/ofkm... ([source](https://app.greptile.com/review/custom-context?memory=a66806fd-d5c8-4295-a793-06df78baccfa))

<!-- /greptile_comment -->