### PR TITLE
fix: use proper svelte reactivity logic to fix svelte-check warnings

### DIFF
--- a/frontend/src/lib/components/badges/status-badge.svelte
+++ b/frontend/src/lib/components/badges/status-badge.svelte
@@ -79,7 +79,6 @@
 		orange: 'text-orange-900 bg-orange-200 ring-orange-500 dark:text-orange-300 dark:bg-orange-400/15 dark:ring-orange-300/25'
 	};
 
-	const resolvedMinWidth = minWidth as MinWidth;
 	const badgeClasses = $derived(
 		cn(
 			// base
@@ -90,7 +89,7 @@
 			// variant styles
 			variantStyles[variant as Variant],
 			// optional fixed width
-			minWidthClasses[resolvedMinWidth],
+			minWidthClasses[minWidth as MinWidth],
 			className
 		)
 	);

--- a/frontend/src/lib/components/dropdown-card.svelte
+++ b/frontend/src/lib/components/dropdown-card.svelte
@@ -25,7 +25,8 @@
 		children: Snippet;
 	} = $props();
 
-	let expanded = $state(defaultExpanded);
+	let expanded = $state(false);
+	let initialized = $state(false);
 
 	function loadExpandedState() {
 		const state = JSON.parse(localStorage.getItem('collapsible-cards-expanded') || '{}');
@@ -57,10 +58,14 @@
 	}
 
 	onMount(() => {
-		if (defaultExpanded) {
-			saveExpandedState();
+		if (!initialized) {
+			expanded = defaultExpanded;
+			if (defaultExpanded) {
+				saveExpandedState();
+			}
+			loadExpandedState();
+			initialized = true;
 		}
-		loadExpandedState();
 	});
 </script>
 

--- a/frontend/src/lib/components/form/form-input.svelte
+++ b/frontend/src/lib/components/form/form-input.svelte
@@ -35,7 +35,7 @@
 		autocomplete?: HTMLInputElement['autocomplete'];
 	} = $props();
 
-	const id = label?.toLowerCase().replace(/ /g, '-');
+	const id = $derived(label?.toLowerCase().replace(/ /g, '-'));
 </script>
 
 <div {...restProps}>

--- a/frontend/src/lib/components/gradient-frame-card.svelte
+++ b/frontend/src/lib/components/gradient-frame-card.svelte
@@ -26,23 +26,29 @@
 		children?: Snippet;
 	} = $props();
 
-	const frameGradientClass =
+	const frameGradientClass = $derived(
 		color === 'emerald'
 			? 'before:[background:linear-gradient(135deg,rgba(16,185,129,0.35),rgba(16,185,129,0))]'
 			: color === 'purple'
 				? 'before:[background:linear-gradient(135deg,rgba(168,85,247,0.35),rgba(168,85,247,0))]'
-				: 'before:[background:linear-gradient(135deg,rgba(59,130,246,0.35),rgba(59,130,246,0))]';
+				: 'before:[background:linear-gradient(135deg,rgba(59,130,246,0.35),rgba(59,130,246,0))]'
+	);
 
-	const iconBoxClass =
+	const iconBoxClass = $derived(
 		color === 'emerald'
 			? 'bg-emerald-500/10 ring-1 ring-emerald-500/30'
 			: color === 'purple'
 				? 'bg-purple-500/10 ring-1 ring-purple-500/30'
-				: 'bg-blue-500/10 ring-1 ring-blue-500/30';
+				: 'bg-blue-500/10 ring-1 ring-blue-500/30'
+	);
 
-	const iconColorClass = color === 'emerald' ? 'text-emerald-400' : color === 'purple' ? 'text-purple-400' : 'text-blue-400';
+	const iconColorClass = $derived(
+		color === 'emerald' ? 'text-emerald-400' : color === 'purple' ? 'text-purple-400' : 'text-blue-400'
+	);
 
-	const glowBgClass = color === 'emerald' ? 'bg-emerald-500/20' : color === 'purple' ? 'bg-purple-500/20' : 'bg-blue-500/20';
+	const glowBgClass = $derived(
+		color === 'emerald' ? 'bg-emerald-500/20' : color === 'purple' ? 'bg-purple-500/20' : 'bg-blue-500/20'
+	);
 </script>
 
 <Card.Root

--- a/frontend/src/lib/components/logs/log-viewer.svelte
+++ b/frontend/src/lib/components/logs/log-viewer.svelte
@@ -135,7 +135,7 @@
 		return type === 'project' ? (projectId ? `project:${projectId}` : null) : containerId ? `ctr:${containerId}` : null;
 	}
 
-	const humanType = type === 'project' ? m.project() : m.container();
+	const humanType = $derived(type === 'project' ? m.project() : m.container());
 
 	function buildWebSocketEndpoint(path: string): string {
 		const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';

--- a/frontend/src/lib/components/meter-metric.svelte
+++ b/frontend/src/lib/components/meter-metric.svelte
@@ -31,7 +31,7 @@
 	}: Props = $props();
 
 	const percentage = $derived(currentValue !== undefined && !loading && maxValue > 0 ? (currentValue / maxValue) * 100 : 0);
-	const Icon = icon;
+	const Icon = $derived(icon);
 </script>
 
 <Card.Root>

--- a/frontend/src/lib/components/ui/copy-button/copy-button.svelte
+++ b/frontend/src/lib/components/ui/copy-button/copy-button.svelte
@@ -25,18 +25,15 @@
 		children
 	}: CopyButtonProps = $props();
 
-	// this way if the user passes text then the button will be the default size
-	if (size === 'icon' && children) {
-		size = 'default';
-	}
-
 	const clipboard = new UseClipboard();
+
+	const resolvedSize = $derived(size === 'icon' && children ? 'default' : size);
 </script>
 
 <Button
 	bind:ref
 	{variant}
-	{size}
+	size={resolvedSize}
 	{tabindex}
 	class={cn('flex items-center gap-2', className)}
 	type="button"

--- a/frontend/src/lib/components/ui/dropdown-button/dropdown-button.svelte
+++ b/frontend/src/lib/components/ui/dropdown-button/dropdown-button.svelte
@@ -25,7 +25,9 @@
 		...restProps
 	}: DropdownButtonProps = $props();
 
-	provideDropdownButtonRoot({ variant, size, align, disabled });
+	$effect(() => {
+		provideDropdownButtonRoot({ variant, size, align, disabled });
+	});
 </script>
 
 <div bind:this={ref} data-slot="dropdown-button" class={cn('flex', className)} {...restProps}>

--- a/frontend/src/lib/components/ui/file-drop-zone/file-drop-zone.svelte
+++ b/frontend/src/lib/components/ui/file-drop-zone/file-drop-zone.svelte
@@ -20,9 +20,11 @@
 		...rest
 	}: FileDropZoneProps = $props();
 
-	if (maxFiles !== undefined && fileCount === undefined) {
-		console.warn('Make sure to provide FileDropZone with `fileCount` when using the `maxFiles` prompt');
-	}
+	$effect(() => {
+		if (maxFiles !== undefined && fileCount === undefined) {
+			console.warn('Make sure to provide FileDropZone with `fileCount` when using the `maxFiles` prompt');
+		}
+	});
 
 	let uploading = $state(false);
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -38,8 +38,14 @@
 		}
 	});
 
-	const { versionInformation, user, settings } = data;
-	let isGlassEnabled = $state(settings?.glassEffectEnabled ?? false);
+	const versionInformation = $derived(data.versionInformation);
+	const user = $derived(data.user);
+	const settings = $derived(data.settings);
+	let isGlassEnabled = $state(false);
+
+	$effect(() => {
+		isGlassEnabled = settings?.glassEffectEnabled ?? false;
+	});
 
 	// Apply glass-enabled class to body based on settings
 	$effect(() => {
@@ -87,10 +93,12 @@
 	});
 	const navigationMode = $derived(navigationSettings.mode);
 
-	const redirectPath = getAuthRedirectPath(page.url.pathname, user);
-	if (redirectPath) {
-		goto(redirectPath);
-	}
+	$effect(() => {
+		const redirectPath = getAuthRedirectPath(page.url.pathname, user);
+		if (redirectPath) {
+			goto(redirectPath);
+		}
+	});
 
 	if (browser) {
 		afterNavigate((event) => {

--- a/frontend/src/routes/auth/login/+page.svelte
+++ b/frontend/src/routes/auth/login/+page.svelte
@@ -26,10 +26,10 @@
 	// Make logo URL reactive to accent color changes
 	let logoUrl = $derived(getApplicationLogo());
 
-	const oidcEnabledBySettings = data.settings?.oidcEnabled === true;
+	const oidcEnabledBySettings = $derived(data.settings?.oidcEnabled === true);
 	const showOidcLoginButton = $derived(oidcEnabledBySettings);
 
-	const localAuthEnabledBySettings = data.settings?.authLocalEnabled !== false;
+	const localAuthEnabledBySettings = $derived(data.settings?.authLocalEnabled !== false);
 	const showLocalLoginForm = $derived(localAuthEnabledBySettings);
 
 	function handleOidcLogin() {

--- a/frontend/src/routes/containers/+page.svelte
+++ b/frontend/src/routes/containers/+page.svelte
@@ -9,13 +9,16 @@
 	import { m } from '$lib/paraglide/messages';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import { imageService } from '$lib/services/image-service';
+	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton, type StatCardConfig } from '$lib/layouts/index.js';
 
 	let { data } = $props();
 
-	let { containers, containerStatusCounts, containerRequestOptions } = $state(data);
+	let containers = $state(untrack(() => data.containers));
+	let containerStatusCounts = $state(untrack(() => data.containerStatusCounts));
+	let containerRequestOptions = $state(untrack(() => data.containerRequestOptions));
 
-	let requestOptions = $state(containerRequestOptions);
+	let requestOptions = $state(untrack(() => data.containerRequestOptions));
 	let selectedIds = $state([]);
 	let isCreateDialogOpen = $state(false);
 

--- a/frontend/src/routes/customize/registries/+page.svelte
+++ b/frontend/src/routes/customize/registries/+page.svelte
@@ -10,15 +10,16 @@
 	import { tryCatch } from '$lib/utils/try-catch';
 	import { m } from '$lib/paraglide/messages';
 	import { containerRegistryService } from '$lib/services/container-registry-service';
+	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton, type StatCardConfig } from '$lib/layouts/index.js';
 
 	let { data } = $props();
 
-	let registries = $state(data.registries);
+	let registries = $state(untrack(() => data.registries));
 	let selectedIds = $state<string[]>([]);
 	let isRegistryDialogOpen = $state(false);
 	let registryToEdit = $state<ContainerRegistry | null>(null);
-	let requestOptions = $state(data.registryRequestOptions);
+	let requestOptions = $state(untrack(() => data.registryRequestOptions));
 
 	let isLoading = $state({
 		create: false,

--- a/frontend/src/routes/customize/templates/+page.svelte
+++ b/frontend/src/routes/customize/templates/+page.svelte
@@ -13,13 +13,14 @@
 	import TemplatesBrowser from './components/TemplatesBrowser.svelte';
 	import RegistryManager from './components/RegistryManager.svelte';
 	import type { TemplateRegistry } from '$lib/types/template.type';
+	import { untrack } from 'svelte';
 	import type { SearchPaginationSortRequest } from '$lib/types/pagination.type';
 
 	let { data } = $props();
 
-	let templates = $state(data.templates);
-	let registries = $state<TemplateRegistry[]>(data.registries);
-	let requestOptions = $state<SearchPaginationSortRequest>(data.templateRequestOptions);
+	let templates = $state(untrack(() => data.templates));
+	let registries = $state<TemplateRegistry[]>(untrack(() => data.registries));
+	let requestOptions = $state<SearchPaginationSortRequest>(untrack(() => data.templateRequestOptions));
 	let activeView = $state<'browse' | 'registries'>('browse');
 
 	const tabItems: TabItem[] = [

--- a/frontend/src/routes/customize/templates/[id]/+page.svelte
+++ b/frontend/src/routes/customize/templates/[id]/+page.svelte
@@ -17,13 +17,14 @@
 	import { m } from '$lib/paraglide/messages.js';
 	import { templateService } from '$lib/services/template-service';
 	import { openConfirmDialog } from '$lib/components/confirm-dialog';
+	import { untrack } from 'svelte';
 	import { toast } from 'svelte-sonner';
 
 	let { data } = $props();
 
 	let template = $derived(data.templateData.template);
-	let compose = $state(data.templateData.content);
-	let env = $state(data.templateData.envContent);
+	let compose = $state(untrack(() => data.templateData.content));
+	let env = $state(untrack(() => data.templateData.envContent));
 	let services = $derived(data.templateData.services);
 	let envVars = $derived(data.templateData.envVariables);
 

--- a/frontend/src/routes/customize/templates/default/+page.svelte
+++ b/frontend/src/routes/customize/templates/default/+page.svelte
@@ -15,6 +15,7 @@
 	import FileTextIcon from '@lucide/svelte/icons/file-text';
 	import SaveIcon from '@lucide/svelte/icons/save';
 	import TemplateSelectionDialog from '$lib/components/dialogs/template-selection-dialog.svelte';
+	import { untrack } from 'svelte';
 	import type { Template } from '$lib/types/template.type';
 
 	let { data } = $props();
@@ -22,8 +23,8 @@
 	let saving = $state(false);
 	let showTemplateDialog = $state(false);
 	let isLoadingTemplate = $state(false);
-	let originalComposeContent = $state(data.composeTemplate);
-	let originalEnvContent = $state(data.envTemplate);
+	let originalComposeContent = $state(untrack(() => data.composeTemplate));
+	let originalEnvContent = $state(untrack(() => data.envTemplate));
 
 	const formSchema = z.object({
 		composeContent: z.string().min(1, m.compose_compose_content_required()),

--- a/frontend/src/routes/customize/variables/+page.svelte
+++ b/frontend/src/routes/customize/variables/+page.svelte
@@ -14,11 +14,12 @@
 	import { ResourcePageLayout, type ActionButton } from '$lib/layouts/index.js';
 	import { templateService } from '$lib/services/template-service.js';
 	import type { Variable } from '$lib/types/variable.type';
+	import { untrack } from 'svelte';
 	import { m } from '$lib/paraglide/messages';
 
 	let { data } = $props();
-	let envVars = $state<Variable[]>([...data.variables]);
-	let originalVars = $state<Variable[]>([...data.variables]);
+	let envVars = $state<Variable[]>(untrack(() => [...data.variables]));
+	let originalVars = $state<Variable[]>(untrack(() => [...data.variables]));
 	let searchQuery = $state('');
 	let isLoading = $state(false);
 

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -21,13 +21,21 @@
 	import { m } from '$lib/paraglide/messages';
 	import { invalidateAll } from '$app/navigation';
 	import { systemService } from '$lib/services/system-service';
+	import { untrack } from 'svelte';
 	import bytes from 'bytes';
 
 	let { data } = $props();
-	let containers = $state(data.containers);
-	let images = $state(data.images);
-	let dockerInfo = $state(data.dockerInfo);
-	let containerStatusCounts = $state(data.containerStatusCounts);
+	let containers = $state(untrack(() => data.containers));
+	let images = $state(untrack(() => data.images));
+	let dockerInfo = $state(untrack(() => data.dockerInfo));
+	let containerStatusCounts = $state(untrack(() => data.containerStatusCounts));
+
+	let dashboardStates = $state({
+		dockerInfo: untrack(() => data.dockerInfo) as typeof data.dockerInfo | null,
+		settings: untrack(() => data.settings) as typeof data.settings | null,
+		systemStats: null as SystemStats | null,
+		isPruneDialogOpen: false
+	});
 
 	$effect(() => {
 		containers = data.containers;
@@ -36,13 +44,6 @@
 		containerStatusCounts = data.containerStatusCounts;
 		dashboardStates.dockerInfo = data.dockerInfo;
 		dashboardStates.settings = data.settings;
-	});
-
-	let dashboardStates = $state({
-		dockerInfo: data.dockerInfo,
-		settings: data.settings,
-		systemStats: null as SystemStats | null,
-		isPruneDialogOpen: false
 	});
 
 	type PruneType = 'containers' | 'images' | 'networks' | 'volumes' | 'buildCache';

--- a/frontend/src/routes/environments/+page.svelte
+++ b/frontend/src/routes/environments/+page.svelte
@@ -8,14 +8,15 @@
 	import { openConfirmDialog } from '$lib/components/confirm-dialog';
 	import { m } from '$lib/paraglide/messages';
 	import { environmentManagementService } from '$lib/services/env-mgmt-service';
+	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton, type StatCardConfig } from '$lib/layouts/index.js';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
 
 	let { data } = $props();
 
-	let environments = $state(data.environments);
+	let environments = $state(untrack(() => data.environments));
 	let selectedIds = $state<string[]>([]);
-	let requestOptions = $state(data.environmentRequestOptions);
+	let requestOptions = $state(untrack(() => data.environmentRequestOptions));
 	let showEnvironmentSheet = $state(false);
 
 	let isLoading = $state({

--- a/frontend/src/routes/events/+page.svelte
+++ b/frontend/src/routes/events/+page.svelte
@@ -9,13 +9,14 @@
 	import { openConfirmDialog } from '$lib/components/confirm-dialog';
 	import { m } from '$lib/paraglide/messages';
 	import { eventService } from '$lib/services/event-service';
+	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton, type StatCardConfig } from '$lib/layouts/index.js';
 
 	let { data }: { data: PageData } = $props();
 
-	let events = $state(data.events);
+	let events = $state(untrack(() => data.events));
 	let selectedIds = $state<string[]>([]);
-	let requestOptions = $state(data.eventRequestOptions);
+	let requestOptions = $state(untrack(() => data.eventRequestOptions));
 
 	let isLoading = $state({
 		refreshing: false,

--- a/frontend/src/routes/images/+page.svelte
+++ b/frontend/src/routes/images/+page.svelte
@@ -15,11 +15,14 @@
 	import { m } from '$lib/paraglide/messages';
 	import { imageService } from '$lib/services/image-service';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
+	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton, type StatCardConfig } from '$lib/layouts/index.js';
 
 	let { data } = $props();
 
-	let { images, imageUsageCounts, imageRequestOptions: requestOptions } = $state(data);
+	let images = $state(untrack(() => data.images));
+	let imageUsageCounts = $state(untrack(() => data.imageUsageCounts));
+	let requestOptions = $state(untrack(() => data.imageRequestOptions));
 	let selectedIds = $state<string[]>([]);
 
 	let isLoading = $state({

--- a/frontend/src/routes/networks/+page.svelte
+++ b/frontend/src/routes/networks/+page.svelte
@@ -12,11 +12,14 @@
 	import { networkService } from '$lib/services/network-service';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import type { Environment } from '$lib/types/environment.type';
+	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton, type StatCardConfig } from '$lib/layouts/index.js';
 
 	let { data } = $props();
 
-	let { networks, networkUsageCounts, networkRequestOptions: requestOptions } = $state(data);
+	let networks = $state(untrack(() => data.networks));
+	let networkUsageCounts = $state(untrack(() => data.networkUsageCounts));
+	let requestOptions = $state(untrack(() => data.networkRequestOptions));
 	let selectedIds = $state<string[]>([]);
 	let isCreateDialogOpen = $state(false);
 

--- a/frontend/src/routes/projects/+page.svelte
+++ b/frontend/src/routes/projects/+page.svelte
@@ -12,11 +12,14 @@
 	import { imageService } from '$lib/services/image-service';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import type { Environment } from '$lib/types/environment.type';
+	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton, type StatCardConfig } from '$lib/layouts/index.js';
 
 	let { data } = $props();
 
-	let { projects, projectStatusCounts, projectRequestOptions } = $state(data);
+	let projects = $state(untrack(() => data.projects));
+	let projectStatusCounts = $state(untrack(() => data.projectStatusCounts));
+	let projectRequestOptions = $state(untrack(() => data.projectRequestOptions));
 	let selectedIds = $state<string[]>([]);
 
 	let isLoading = $state({

--- a/frontend/src/routes/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/projects/[projectId]/+page.svelte
@@ -28,11 +28,12 @@
 	import ServicesGrid from '../components/ServicesGrid.svelte';
 	import CodePanel from '../components/CodePanel.svelte';
 	import ProjectsLogsPanel from '../components/ProjectLogsPanel.svelte';
+	import { untrack } from 'svelte';
 	import { projectService } from '$lib/services/project-service';
 
 	let { data } = $props();
 	let projectId = $derived(data.projectId);
-	let project = $state(data.project);
+	let project = $state(untrack(() => data.project));
 	let editorState = $derived(data.editorState);
 
 	let isLoading = $state({
@@ -47,9 +48,9 @@
 		saving: false
 	});
 
-	let originalName = $state(data.editorState.originalName);
-	let originalComposeContent = $state(data.editorState.originalComposeContent);
-	let originalEnvContent = $state(data.editorState.originalEnvContent || '');
+	let originalName = $state(untrack(() => data.editorState.originalName));
+	let originalComposeContent = $state(untrack(() => data.editorState.originalComposeContent));
+	let originalEnvContent = $state(untrack(() => data.editorState.originalEnvContent || ''));
 	let includeFilesState = $state<Record<string, string>>({});
 	let originalIncludeFiles = $state<Record<string, string>>({});
 

--- a/frontend/src/routes/projects/new/+page.svelte
+++ b/frontend/src/routes/projects/new/+page.svelte
@@ -49,7 +49,9 @@
 		envContent: z.string().optional().default('')
 	});
 
-	const initialName = data.selectedTemplate ? data.selectedTemplate.name.toLowerCase().replace(/[^a-z0-9-_]/g, '-') : '';
+	const initialName = $derived(
+		data.selectedTemplate ? data.selectedTemplate.name.toLowerCase().replace(/[^a-z0-9-_]/g, '-') : ''
+	);
 
 	let formData = $derived({
 		name: initialName,

--- a/frontend/src/routes/settings/users/+page.svelte
+++ b/frontend/src/routes/settings/users/+page.svelte
@@ -10,13 +10,14 @@
 	import type { CreateUser } from '$lib/types/user.type';
 	import { m } from '$lib/paraglide/messages';
 	import { userService } from '$lib/services/user-service';
+	import { untrack } from 'svelte';
 	import { SettingsPageLayout, type SettingsActionButton } from '$lib/layouts/index.js';
 
 	let { data } = $props();
 
-	let users = $state(data.users);
+	let users = $state(untrack(() => data.users));
 	let selectedIds = $state<string[]>([]);
-	let requestOptions = $state<SearchPaginationSortRequest>(data.userRequestOptions);
+	let requestOptions = $state<SearchPaginationSortRequest>(untrack(() => data.userRequestOptions));
 
 	let isDialogOpen = $state({
 		create: false,

--- a/frontend/src/routes/volumes/+page.svelte
+++ b/frontend/src/routes/volumes/+page.svelte
@@ -11,11 +11,14 @@
 	import { m } from '$lib/paraglide/messages';
 	import { volumeService } from '$lib/services/volume-service';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
+	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton, type StatCardConfig } from '$lib/layouts/index.js';
 
 	let { data } = $props();
 
-	let { volumes, volumeUsageCounts, volumeRequestOptions: requestOptions } = $state(data);
+	let volumes = $state(untrack(() => data.volumes));
+	let volumeUsageCounts = $state(untrack(() => data.volumeUsageCounts));
+	let requestOptions = $state(untrack(() => data.volumeRequestOptions));
 
 	let selectedIds = $state<string[]>([]);
 	let isCreateDialogOpen = $state(false);

--- a/frontend/src/routes/volumes/[volumeName]/+page.svelte
+++ b/frontend/src/routes/volumes/[volumeName]/+page.svelte
@@ -19,11 +19,12 @@
 	import { format } from 'date-fns';
 	import ContainerIcon from '@lucide/svelte/icons/container';
 	import { m } from '$lib/paraglide/messages';
+	import { untrack } from 'svelte';
 	import { volumeService } from '$lib/services/volume-service.js';
 
 	let { data } = $props();
-	let volume = $state(data.volume);
-	let containersDetailed = $state<{ id: string; name: string }[]>(data.containersDetailed ?? []);
+	let volume = $state(untrack(() => data.volume));
+	let containersDetailed = $state<{ id: string; name: string }[]>(untrack(() => data.containersDetailed ?? []));
 
 	let isLoading = $state({ remove: false });
 	const createdDate = $derived(volume.createdAt ? format(new Date(volume.createdAt), 'PP p') : m.common_unknown());


### PR DESCRIPTION
Alot of svelte-check warnings due to reactivity, which i believe was due to this (not a bad change though) https://github.com/sveltejs/svelte/pull/17266

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews uses AI, make sure to check over its work

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>


Systematic refactor to fix svelte-check warnings by properly implementing Svelte 5 reactivity patterns. The changes convert non-reactive constants that depend on props/state to `$derived`, wrap side effects and context providers in `$effect`, and use `untrack()` to prevent unwanted reactive subscriptions during initial state setup.

Key changes:
- Converted computed values from constants to `$derived` (class names, IDs, component references)
- Moved side effects (context providers, warnings, redirects) into `$effect` blocks
- Used `untrack()` wrapper for initial data destructuring across 20+ page components
- Fixed `arcane-table` reactivity issues: PersistedState initialization, column building, and hidden column handling
- Added initialization guards in `dropdown-card` to prevent premature state mutation


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The changes are purely about fixing Svelte 5 reactivity compliance without altering business logic. The patterns used (`$derived`, `$effect`, `untrack()`) are standard Svelte 5 best practices. The most complex change in `arcane-table` properly separates reactive dependencies and prevents state mutation during derived computation
- Pay close attention to `frontend/src/lib/components/arcane-table/arcane-table.svelte` due to its complexity
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| frontend/src/lib/components/arcane-table/arcane-table.svelte | 4/5 | Complex refactor converting constants to `$derived`, moved PersistedState initialization to `$effect`, fixed column building reactivity, and properly handled hidden columns initialization |
| frontend/src/lib/components/dropdown-card.svelte | 5/5 | Added initialization guard to prevent state mutation during setup, ensuring `defaultExpanded` is applied correctly on mount |
| frontend/src/routes/+layout.svelte | 5/5 | Converted data destructuring to `$derived` and moved auth redirect logic into `$effect` for proper reactivity |
| frontend/src/routes/dashboard/+page.svelte | 5/5 | Used `untrack()` to prevent reactive tracking during initial state setup, then synced with data changes via `$effect` |
| frontend/src/lib/components/ui/dropdown-button/dropdown-button.svelte | 5/5 | Wrapped context provider call in `$effect` to ensure reactive updates propagate properly |

</details>


</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - .github/copilot-instructions.md file

## Referenced Files:
### Content from github://github.com/ofkm... ([source](https://app.greptile.com/review/custom-context?memory=a66806fd-d5c8-4295-a793-06df78baccfa))

<!-- /greptile_comment -->