### PR TITLE
feat: inline start and stop functions for containers

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -155,6 +155,7 @@
 	"common_action_downloading": "Downloading…",
 	"common_action_restarting": "Restarting…",
 	"common_action_removing": "Removing…",
+	"common_action_updating": "Updating…",
 	"common_action_redeploying": "Redeploying…",
 	"common_action_inspecting": "Inspecting…",
 	"common_action_confirming": "Confirming…",

--- a/frontend/src/routes/(app)/containers/container-table.svelte
+++ b/frontend/src/routes/(app)/containers/container-table.svelte
@@ -72,6 +72,24 @@
 		return { repo: imageRef, tag: 'latest' };
 	}
 
+	function getActionStatusMessage(status: ActionStatus): string {
+		const messages: Record<ActionStatus, () => string> = {
+			starting: () => m.common_action_starting(),
+			stopping: () => m.common_action_stopping(),
+			restarting: () => m.common_action_restarting(),
+			updating: () => m.common_action_updating(),
+			removing: () => m.common_action_removing(),
+			'': () => ''
+		};
+		return messages[status]();
+	}
+
+	function getStateBadgeVariant(state: string): 'green' | 'red' | 'amber' {
+		if (state === 'running') return 'green';
+		if (state === 'exited') return 'red';
+		return 'amber';
+	}
+
 	async function performContainerAction(action: 'start' | 'stop' | 'restart', id: string) {
 		// Set action status for this specific container
 		if (action === 'start') {
@@ -290,15 +308,12 @@
 		{#if status}
 			<div class="flex items-center gap-1.5">
 				<Spinner class="size-3.5" />
-				<span class="text-xs text-muted-foreground font-medium">
-					{status === 'starting' ? m.common_start() + 'ing...' : status === 'stopping' ? m.common_stop() + 'ping...' : status === 'restarting' ? m.common_restart() + 'ing...' : status === 'updating' ? m.containers_update_container() + 'ing...' : status === 'removing' ? m.common_remove() + 'ing...' : status}
+				<span class="text-muted-foreground text-xs font-medium">
+					{getActionStatusMessage(status)}
 				</span>
 			</div>
 		{:else}
-			<StatusBadge
-				variant={item.state === 'running' ? 'green' : item.state === 'exited' ? 'red' : 'amber'}
-				text={capitalizeFirstLetter(item.state)}
-			/>
+			<StatusBadge variant={getStateBadgeVariant(item.state)} text={capitalizeFirstLetter(item.state)} />
 		{/if}
 		<div class="flex items-center gap-1">
 			{#if !status && item.state !== 'running'}
@@ -479,7 +494,10 @@
 				{/if}
 
 				{#if item.state !== 'running'}
-					<DropdownMenu.Item onclick={() => performContainerAction('start', item.id)} disabled={status === 'starting' || isAnyLoading}>
+					<DropdownMenu.Item
+						onclick={() => performContainerAction('start', item.id)}
+						disabled={status === 'starting' || isAnyLoading}
+					>
 						{#if status === 'starting'}
 							<Spinner class="size-4" />
 						{:else}
@@ -500,7 +518,10 @@
 						{m.common_restart()}
 					</DropdownMenu.Item>
 
-					<DropdownMenu.Item onclick={() => performContainerAction('stop', item.id)} disabled={status === 'stopping' || isAnyLoading}>
+					<DropdownMenu.Item
+						onclick={() => performContainerAction('stop', item.id)}
+						disabled={status === 'stopping' || isAnyLoading}
+					>
 						{#if status === 'stopping'}
 							<Spinner class="size-4" />
 						{:else}


### PR DESCRIPTION
Closes: https://github.com/getarcaneapp/arcane/issues/762

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>


This PR adds inline start/stop buttons directly in the container table's State column, addressing issue #762. Key changes:

- Refactored loading state management from a global `isLoading` object to per-container `actionStatus` tracking using `Record<string, ActionStatus>`
- Added inline Play/Stop buttons that appear contextually based on container state (running vs stopped)
- Added inline Update button for containers with available updates
- Status column shows action progress with spinner and localized messages (e.g., "Starting…", "Stopping…")
- Added new i18n key `common_action_updating` for the updating status message
- All buttons are disabled when any action is in progress (`isAnyLoading` derived state)

The implementation follows existing patterns in the codebase and properly uses i18n message keys for all status messages.


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge - it's a clean UI enhancement with no breaking changes or risky logic.
- The changes are well-scoped UI improvements that follow existing codebase patterns. The refactoring from global to per-container loading state is correct, i18n is properly handled using existing message keys, and the Svelte 5 patterns are correctly applied.
- No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| frontend/src/routes/(app)/containers/container-table.svelte | 5/5 | Refactored loading state from global object to per-container tracking, added inline start/stop/update buttons in State column with proper i18n support. |
| frontend/messages/en.json | 5/5 | Added new i18n key `common_action_updating` for the updating action status message. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant ContainerTable
    participant ActionStatus
    participant ContainerService
    participant API

    User->>ContainerTable: Click Start/Stop button
    ContainerTable->>ActionStatus: Set status (e.g., "starting")
    ContainerTable->>ContainerService: startContainer(id) / stopContainer(id)
    ContainerService->>API: POST /containers/{id}/start or /stop
    
    alt Success
        API-->>ContainerService: 200 OK
        ContainerService-->>ContainerTable: Result (success)
        ContainerTable->>ActionStatus: Clear status ('')
        ContainerTable->>User: Show success toast
        ContainerTable->>ContainerService: getContainers()
        ContainerService-->>ContainerTable: Updated container list
    else Failure
        API-->>ContainerService: Error
        ContainerService-->>ContainerTable: Result (error)
        ContainerTable->>ActionStatus: Clear status ('')
        ContainerTable->>User: Show error toast
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->