### PR TITLE
feat: dynamic oidc redirect url based on url origin

### DIFF
--- a/backend/internal/huma/huma.go
+++ b/backend/internal/huma/huma.go
@@ -331,7 +331,7 @@ func registerHandlers(api huma.API, svc *Services) {
 	handlers.RegisterUsers(api, userSvc)
 	handlers.RegisterVersion(api, versionSvc)
 	handlers.RegisterEvents(api, eventSvc)
-	handlers.RegisterOidc(api, authSvc, oidcSvc)
+	handlers.RegisterOidc(api, authSvc, oidcSvc, cfg)
 	handlers.RegisterEnvironments(api, environmentSvc, settingsSvc, cfg)
 	handlers.RegisterContainerRegistries(api, containerRegistrySvc)
 	handlers.RegisterTemplates(api, templateSvc)


### PR DESCRIPTION
Closes: https://github.com/getarcaneapp/arcane/issues/987

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>


This PR implements dynamic OIDC redirect URLs based on the client's request origin rather than a static environment variable. The change enables Arcane to work correctly behind multiple proxies, IPs, or URLs by dynamically constructing the redirect URL from request headers (`Origin`, `X-Forwarded-Host`, `X-Forwarded-Proto`, `Host`).

**Key Changes:**
- Added `GetClientBaseURL()` utility function that extracts the client's base URL from request headers
- Updated OIDC service methods to accept and use dynamic `origin` parameter
- Modified all OIDC handlers to capture request headers and pass them through the service layer
- The redirect URL is now constructed dynamically per-request instead of using the static `APP_URL` environment variable

**Security Concern:**
The implementation blindly trusts `Origin`, `X-Forwarded-Host`, and `X-Forwarded-Proto` headers without validation. This creates a security vulnerability if Arcane is exposed directly to the internet or behind an improperly configured reverse proxy. An attacker could spoof these headers to redirect OIDC callbacks to their own domain, potentially intercepting authorization codes. While OIDC providers should validate redirect URLs on their side, this still presents a risk if providers have overly permissive configurations.


</details>
<details><summary><h3>Confidence Score: 3/5</h3></summary>


- This PR has critical security concerns around header spoofing that must be addressed before merging
- The implementation correctly threads the dynamic origin through all OIDC methods and solves the multi-URL problem described in issue #987. However, the score reflects serious security vulnerabilities: the code blindly trusts client-controlled headers (`Origin`, `X-Forwarded-Host`, `X-Forwarded-Proto`) without validation or verification that they come from trusted proxies. This could allow attackers to manipulate OIDC redirect URLs. The score would be 4-5 if proper header validation were added (checking against `APP_URL` or implementing trusted proxy validation).
- Pay close attention to `backend/internal/utils/http/request.go` - the `GetClientBaseURL()` function needs security hardening to validate headers before trusting them
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| backend/internal/utils/http/request.go | 3/5 | Added `GetClientBaseURL` function to dynamically determine client base URL from request headers. Security concern: blindly trusts `Origin` and `X-Forwarded-*` headers without validation, which could allow header injection attacks if not behind a trusted reverse proxy. |
| backend/internal/services/oidc_service.go | 4/5 | Updated OIDC service methods to accept `origin` parameter for dynamic redirect URL generation. Implementation correctly threads the origin through all relevant methods (`GenerateAuthURL`, `HandleCallback`, `exchangeToken`, `getOauth2Config`, `GetOidcRedirectURL`). |
| backend/internal/huma/handlers/oidc.go | 4/5 | Added `OidcHeaders` struct to capture request headers and pass them to `GetClientBaseURL`. Correctly updated all OIDC handler methods to extract and use dynamic origin. Implementation properly threads origin through service calls. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as OidcHandler
    participant HttpUtils as httputils.GetClientBaseURL
    participant OidcSvc as OidcService
    participant Provider as OIDC Provider

    Note over Client,Provider: 1. Get OIDC Config
    Client->>Handler: GET /oidc/config<br/>(Origin, X-Forwarded-Host, X-Forwarded-Proto, Host)
    Handler->>HttpUtils: GetClientBaseURL(headers, appURL)
    HttpUtils-->>Handler: origin (dynamic base URL)
    Handler->>OidcSvc: GetOidcRedirectURL(origin)
    OidcSvc-->>Handler: origin + "/auth/oidc/callback"
    Handler-->>Client: ClientID, RedirectUri, IssuerUrl, etc.

    Note over Client,Provider: 2. Generate Auth URL
    Client->>Handler: POST /oidc/url<br/>(Origin, X-Forwarded-Host, X-Forwarded-Proto, Host)
    Handler->>HttpUtils: GetClientBaseURL(headers, appURL)
    HttpUtils-->>Handler: origin (dynamic base URL)
    Handler->>OidcSvc: GenerateAuthURL(ctx, redirectTo, origin)
    OidcSvc->>OidcSvc: getOauth2Config(cfg, provider, origin)
    OidcSvc->>OidcSvc: GetOidcRedirectURL(origin)
    OidcSvc-->>Handler: authUrl, stateCookie
    Handler-->>Client: authUrl + Set-Cookie (oidc_state)

    Note over Client,Provider: 3. User Authenticates
    Client->>Provider: Redirect to authUrl
    Provider-->>Client: Redirect to RedirectUri with code & state

    Note over Client,Provider: 4. Handle Callback
    Client->>Handler: POST /oidc/callback<br/>(code, state, oidc_state cookie)<br/>(Origin, X-Forwarded-Host, X-Forwarded-Proto, Host)
    Handler->>HttpUtils: GetClientBaseURL(headers, appURL)
    HttpUtils-->>Handler: origin (dynamic base URL)
    Handler->>OidcSvc: HandleCallback(ctx, code, state, storedState, origin)
    OidcSvc->>OidcSvc: validateState(state, storedState)
    OidcSvc->>OidcSvc: exchangeToken(ctx, cfg, provider, code, verifier, origin)
    OidcSvc->>OidcSvc: getOauth2Config(cfg, provider, origin)
    OidcSvc->>OidcSvc: GetOidcRedirectURL(origin)
    OidcSvc->>Provider: Exchange code for token<br/>(with dynamic redirect_uri)
    Provider-->>OidcSvc: OAuth2 token
    OidcSvc-->>Handler: userInfo, tokenResp
    Handler-->>Client: Success + Set-Cookie (session token)
```
</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - GoLang Best Practices

Follow idiomatic Go patterns and conventions
Handle errors explicitly, don’t ... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->