### PR TITLE
fix: handle vanity urls for image registries

### DIFF
--- a/backend/internal/utils/registry/helpers.go
+++ b/backend/internal/utils/registry/helpers.go
@@ -1,6 +1,13 @@
 package registry
 
-import ref "go.podman.io/image/v5/docker/reference"
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	ref "go.podman.io/image/v5/docker/reference"
+)
 
 func GetRegistryAddress(imageRef string) (string, error) {
 	named, err := ref.ParseNormalizedNamed(imageRef)
@@ -12,4 +19,84 @@ func GetRegistryAddress(imageRef string) (string, error) {
 		return DefaultRegistryHost, nil
 	}
 	return addr, nil
+}
+
+// ResolveRegistryRedirect checks if a registry domain redirects to Docker Hub
+// by attempting a HEAD request to /v2/. If it fails with DNS or connection errors,
+// it assumes the domain is a redirect/alias to Docker Hub.
+func ResolveRegistryRedirect(ctx context.Context, registryDomain string) (resolvedDomain string, isDockerHub bool) {
+	// Skip if already a known Docker Hub domain
+	if registryDomain == DefaultRegistryDomain ||
+		registryDomain == DefaultRegistry ||
+		registryDomain == DefaultRegistryHost {
+		return DefaultRegistry, true
+	}
+
+	// Try to connect to the registry's v2 API
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+	}
+
+	testURL := "https://" + registryDomain + "/v2/"
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, testURL, nil)
+	if err != nil {
+		// If we can't even create a request, assume it's a Docker Hub redirect
+		return DefaultRegistry, true
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		// DNS failure, connection refused, or timeout - likely a redirect domain
+		// Common for custom domains like docker.umami.is that don't host registry APIs
+		if strings.Contains(err.Error(), "no such host") ||
+			strings.Contains(err.Error(), "connection refused") ||
+			strings.Contains(err.Error(), "timeout") {
+			return DefaultRegistry, true
+		}
+		// Other errors - return original domain
+		return registryDomain, false
+	}
+	defer resp.Body.Close()
+
+	// If we get a valid response (even 401/403), the registry API exists
+	// Status codes 200, 401, 403 indicate a working registry
+	if resp.StatusCode == http.StatusOK ||
+		resp.StatusCode == http.StatusUnauthorized ||
+		resp.StatusCode == http.StatusForbidden {
+		return registryDomain, false
+	}
+
+	// For other status codes, assume it might be a redirect
+	return DefaultRegistry, true
+}
+
+// RegistryConfig represents a registry configuration for scheme determination
+type RegistryConfig struct {
+	URL      string
+	Insecure bool
+}
+
+// GetRegistryScheme determines whether a registry should use http or https
+// based on the provided registry configurations
+func GetRegistryScheme(domain string, registries []RegistryConfig) string {
+	// Normalize domain for comparison
+	normalizedDomain := strings.TrimPrefix(domain, "https://")
+	normalizedDomain = strings.TrimPrefix(normalizedDomain, "http://")
+	normalizedDomain = strings.ToLower(normalizedDomain)
+
+	for _, reg := range registries {
+		regURL := strings.TrimPrefix(reg.URL, "https://")
+		regURL = strings.TrimPrefix(regURL, "http://")
+		regURL = strings.TrimSuffix(regURL, "/")
+		regURL = strings.ToLower(regURL)
+
+		if regURL == normalizedDomain || strings.Contains(normalizedDomain, regURL) {
+			if reg.Insecure {
+				return "http"
+			}
+			return "https"
+		}
+	}
+
+	return "https" // Default to secure
 }


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>


This PR adds support for Docker registry vanity URLs (custom domains that redirect to Docker Hub like `docker.umami.is`) by detecting registry redirects and determining the appropriate URL scheme (http/https) based on registry configuration.

## Key Changes
- Modified `parseRegistryAndRepo` to become a service method that accepts context and resolves registry redirects
- Added `ResolveRegistryRedirect` utility that probes registry domains to detect Docker Hub aliases
- Added `GetRegistryScheme` to determine http vs https based on stored registry configurations with the `Insecure` flag
- Added `getRegistryScheme` service method that queries enabled registries to configure URL schemes

## Issues Found
- **Critical**: String-based error checking in `helpers.go:51-54` is fragile and not idiomatic Go
- **Critical**: Ambiguous domain matching using `strings.Contains` in `helpers.go:93` could cause false positives
- **Important**: Missing context cancellation check after `ResolveRegistryRedirect` could lead to using stale results
- **Performance**: New HTTP client created on every redirect check instead of reusing connections
- **Performance**: 3-second timeout added to critical path on every digest fetch without caching

The redirect detection logic is sound in principle but needs refinement in error handling and matching logic.


</details>
<details><summary><h3>Confidence Score: 2/5</h3></summary>


- This PR has multiple logic issues that could cause production failures including incorrect error handling and ambiguous domain matching
- Score reflects critical issues: (1) string-based error checking that violates Go best practices from custom instructions and could fail unpredictably, (2) domain matching logic using `strings.Contains` that could incorrectly match unrelated registries, (3) missing context cancellation checks that could use timeout results. While the feature addresses a real need for vanity URL support, these issues need resolution before merge.
- backend/internal/utils/registry/helpers.go requires the most attention due to fragile error checking and domain matching logic
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| backend/internal/services/container_registry_service.go | 3/5 | Added registry redirect resolution and scheme detection for vanity URLs. Has logic issues with context handling and performance concerns with per-call timeouts. |
| backend/internal/utils/registry/helpers.go | 2/5 | Implemented redirect detection and scheme lookup utilities. Contains critical issues: string-based error checking, ambiguous domain matching logic, and lack of HTTP client reuse. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant ContainerRegistryService
    participant GetImageDigest
    participant parseRegistryAndRepo
    participant getRegistryScheme
    participant ResolveRegistryRedirect
    participant RegistryAPI

    Client->>ContainerRegistryService: GetImageDigest(ctx, imageRef)
    ContainerRegistryService->>GetImageDigest: fetchDigestFromRegistry(ctx, repository, tag)
    GetImageDigest->>parseRegistryAndRepo: parseRegistryAndRepo(ctx, repository)
    
    parseRegistryAndRepo->>getRegistryScheme: getRegistryScheme(ctx, domain)
    getRegistryScheme->>getRegistryScheme: GetEnabledRegistries(ctx)
    getRegistryScheme->>getRegistryScheme: Check registry configs for insecure flag
    getRegistryScheme-->>parseRegistryAndRepo: return "http" or "https"
    
    parseRegistryAndRepo->>ResolveRegistryRedirect: ResolveRegistryRedirect(ctx, domain)
    ResolveRegistryRedirect->>RegistryAPI: HEAD /v2/ (with 3s timeout)
    alt Registry exists
        RegistryAPI-->>ResolveRegistryRedirect: 200/401/403
        ResolveRegistryRedirect-->>parseRegistryAndRepo: (domain, false)
    else DNS/Connection error
        RegistryAPI-->>ResolveRegistryRedirect: no such host/timeout
        ResolveRegistryRedirect-->>parseRegistryAndRepo: (registry-1.docker.io, true)
    else Other error
        RegistryAPI-->>ResolveRegistryRedirect: other status
        ResolveRegistryRedirect-->>parseRegistryAndRepo: (registry-1.docker.io, true)
    end
    
    alt Is Docker Hub redirect
        parseRegistryAndRepo-->>GetImageDigest: ("https://registry-1.docker.io", originalRepoPath)
    else Normal registry
        parseRegistryAndRepo-->>GetImageDigest: (scheme+"://"+registryURL, repoPath)
    end
    
    GetImageDigest->>RegistryAPI: HEAD /v2/{repo}/manifests/{tag}
    RegistryAPI-->>GetImageDigest: Docker-Content-Digest header
    GetImageDigest-->>ContainerRegistryService: digest
    ContainerRegistryService-->>Client: digest
```
</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - GoLang Best Practices

Follow idiomatic Go patterns and conventions
Handle errors explicitly, don’t ... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->