### PR TITLE
fix: auto updater issues with certain network modes

### DIFF
--- a/frontend/src/routes/(app)/settings/+layout.svelte
+++ b/frontend/src/routes/(app)/settings/+layout.svelte
@@ -3,7 +3,7 @@
 	import { goto, beforeNavigate } from '$app/navigation';
 	import { setContext } from 'svelte';
 	import { ArcaneButton } from '$lib/components/arcane-button/index.js';
-	import { SettingsIcon, ArrowRightIcon, ArrowLeftIcon, SaveIcon, ResetIcon } from '$lib/icons';
+	import { SettingsIcon, ArrowRightIcon, ArrowLeftIcon } from '$lib/icons';
 	import { useSidebar } from '$lib/components/ui/sidebar/context.svelte.js';
 	import { m } from '$lib/paraglide/messages';
 	import settingsStore from '$lib/stores/config-store';


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1048

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


This PR fixes Docker API errors when auto-updating containers with `network_mode: "container:..."` or `network_mode: "host"` configurations.

**Key changes:**
- Added proper handling for container network modes in both `upgrade.go` and `updater_service.go`
- When `NetworkMode.IsHost()` or `NetworkMode.IsContainer()`: clears `Hostname` and `Domainname` fields to prevent "conflicting options: hostname and the network mode" error
- When `NetworkMode.IsContainer()`: clears `ExposedPorts`, `PortBindings`, and `PublishAllPorts` to prevent "conflicting options: port exposing and the container type network mode" error  
- When `NetworkMode.IsContainer()`: passes `nil` for `networkingConfig` since container mode shares the network stack of another container
- Uses Docker SDK's built-in `IsHost()` and `IsContainer()` methods instead of string comparisons for more reliable detection
- Bonus: cleaned up unused icon imports in settings layout

The fix correctly addresses the reported issue where containers using `network_mode: service:gluetun` failed to restart during auto-updates. The implementation is consistent across both the auto-updater service and the CLI upgrade command.


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The fix directly addresses the reported Docker API errors with a clean, targeted solution. It uses Docker SDK's native `IsHost()` and `IsContainer()` methods for reliable network mode detection, applies the same logic consistently across both affected code paths (auto-updater and CLI upgrade), and follows Docker's documented requirements for container network modes. The changes are minimal, well-scoped, and include a harmless cleanup of unused imports.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/cli/upgrade/upgrade.go | Fixed container network mode conflicts by clearing hostname/ports for container mode and skipping network config |
| backend/internal/services/updater_service.go | Applied same network mode fixes to updater service, handling hostname and port conflicts correctly |
| frontend/src/routes/(app)/settings/+layout.svelte | Removed unused icon imports (`SaveIcon`, `ResetIcon`) that were no longer referenced in the component |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant AU as Auto Updater
    participant US as UpdaterService
    participant UG as upgrade CLI
    participant DC as Docker Client
    participant C as Container

    Note over AU,C: Container Update Flow

    AU->>US: updateContainer(container)
    US->>DC: ContainerStop(oldContainer)
    DC->>C: Stop
    US->>DC: ContainerRemove(oldContainer)
    DC-->>C: Remove
    
    Note over US: Check NetworkMode
    alt NetworkMode is host/container
        US->>US: Clear Hostname & Domainname
    end
    
    alt NetworkMode is container
        US->>US: Clear ExposedPorts & PortBindings
        US->>US: Set networkingConfig = nil
    else Normal network mode
        US->>US: Preserve network settings
    end
    
    US->>DC: ContainerCreate(newConfig)
    DC-->>US: newContainerID
    US->>DC: ContainerStart(newContainerID)
    DC->>C: Start with new image
    
    Note over UG,C: Self-Upgrade Flow (CLI)
    
    UG->>DC: ContainerStop(oldArcane)
    DC->>C: Stop
    
    Note over UG: Apply same network mode fixes
    alt NetworkMode is host/container
        UG->>UG: Clear Hostname & Domainname
    end
    
    alt NetworkMode is container
        UG->>UG: Clear ExposedPorts & PortBindings
        UG->>UG: Set networkConfig = nil
    else Normal network mode
        UG->>UG: Build network config with IPs
    end
    
    UG->>DC: ContainerCreate(newArcane, tempName)
    DC-->>UG: newContainerID
    UG->>DC: ContainerStart(newContainerID)
    DC->>C: Start
    UG->>DC: ContainerRemove(oldArcane)
    UG->>DC: ContainerRename(tempName, originalName)
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->