### PR TITLE
fix: oidc form incorrectly parsing numbers preventing saving

### DIFF
--- a/frontend/src/lib/services/settings-service.ts
+++ b/frontend/src/lib/services/settings-service.ts
@@ -122,15 +122,6 @@ export default class SettingsService extends BaseAPIService {
 		}
 		if (value === 'true') return true;
 		if (value === 'false') return false;
-		// Only parse numbers for known numeric fields
-		const numericFields = [
-			'authSessionTimeout',
-			'environmentHealthInterval',
-			'autoUpdateInterval',
-			'pollingInterval',
-			'maxImageUploadSize'
-		];
-		if (numericFields.includes(key) && /^-?\d+(\.\d+)?$/.test(value)) return Number(value);
 		return value;
 	}
 }

--- a/frontend/src/routes/(app)/settings/general/+page.svelte
+++ b/frontend/src/routes/(app)/settings/general/+page.svelte
@@ -15,7 +15,7 @@
 	const isReadOnly = $derived.by(() => $settingsStore?.uiConfigDisabled);
 
 	const formSchema = z.object({
-		environmentHealthInterval: z.number().int().min(1).max(60)
+		environmentHealthInterval: z.coerce.number().int().min(1).max(60)
 	});
 
 	let { formInputs } = $derived(

--- a/frontend/src/routes/(app)/settings/security/+page.svelte
+++ b/frontend/src/routes/(app)/settings/security/+page.svelte
@@ -26,8 +26,8 @@
 	const formSchema = z
 		.object({
 			authLocalEnabled: z.boolean(),
-			authSessionTimeout: z
-				.number(m.security_session_timeout_required())
+			authSessionTimeout: z.coerce
+				.number()
 				.int(m.security_session_timeout_integer())
 				.min(15, m.security_session_timeout_min())
 				.max(1440, m.security_session_timeout_max()),
@@ -56,7 +56,7 @@
 
 	const formDefaults = $derived({
 		authLocalEnabled: currentSettings.authLocalEnabled,
-		authSessionTimeout: Number(currentSettings.authSessionTimeout),
+		authSessionTimeout: currentSettings.authSessionTimeout,
 		authPasswordPolicy: currentSettings.authPasswordPolicy,
 		oidcEnabled: currentSettings.oidcEnabled,
 		oidcMergeAccounts: currentSettings.oidcMergeAccounts,


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1208

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


Fixed the OIDC configuration bug where numeric-looking string values (like client IDs containing only digits) were incorrectly parsed as numbers, causing form validation to fail with type mismatches.

## Changes Made
- Modified `settings-service.ts` to use an allowlist of known numeric fields instead of parsing all numeric-looking strings as numbers
- Added explicit `Number()` conversion for `authSessionTimeout` in the form defaults to ensure consistent typing
- Added error message displays for all OIDC input fields to improve UX when validation fails

## Impact
Users can now successfully save OIDC configuration even when using numeric client IDs, and will see clear error messages if validation fails.


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The fix is targeted, well-scoped, and directly addresses the root cause. The allowlist approach prevents regression while maintaining proper type parsing for legitimate numeric fields. The added error displays improve UX without changing logic.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/services/settings-service.ts | Fixed `parseValue` to only convert known numeric fields to numbers, preventing OIDC string fields from being incorrectly parsed |
| frontend/src/routes/(app)/settings/security/+page.svelte | Added explicit `Number()` conversion for `authSessionTimeout` and error message displays for OIDC fields |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->