### PR TITLE
fix: use consistent X-Arcane-Agent-Token header for agent authentication

### DIFF
--- a/backend/internal/services/environment_service.go
+++ b/backend/internal/services/environment_service.go
@@ -534,17 +534,11 @@ func (s *EnvironmentService) SyncRegistriesToEnvironment(ctx context.Context, en
 
 	req.Header.Set("Content-Type", "application/json")
 
-	// Use appropriate auth header based on environment type
+	// Always use X-Arcane-Agent-Token for agent authentication.
+	// The agent validates this header against its stored agentToken.
 	if environment.AccessToken != nil && *environment.AccessToken != "" {
-		// For API key-based environments, AccessToken contains the API key
-		if environment.ApiKeyID != nil && *environment.ApiKeyID != "" {
-			req.Header.Set("X-API-KEY", *environment.AccessToken)
-			slog.DebugContext(ctx, "Set API key header for sync request")
-		} else {
-			// Legacy bootstrap token-based environments
-			req.Header.Set("X-Arcane-Agent-Token", *environment.AccessToken)
-			slog.DebugContext(ctx, "Set agent token header for sync request")
-		}
+		req.Header.Set("X-Arcane-Agent-Token", *environment.AccessToken)
+		slog.DebugContext(ctx, "Set agent token header for sync request")
 	} else {
 		slog.WarnContext(ctx, "No access token available for environment sync", "environmentID", environmentID)
 	}
@@ -607,13 +601,10 @@ func (s *EnvironmentService) ProxyRequest(ctx context.Context, envID string, met
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	// Use appropriate auth header
+	// Always use X-Arcane-Agent-Token for agent authentication.
+	// The agent validates this header against its stored agentToken.
 	if environment.AccessToken != nil && *environment.AccessToken != "" {
-		if environment.ApiKeyID != nil && *environment.ApiKeyID != "" {
-			req.Header.Set("X-API-KEY", *environment.AccessToken)
-		} else {
-			req.Header.Set("X-Arcane-Agent-Token", *environment.AccessToken)
-		}
+		req.Header.Set("X-Arcane-Agent-Token", *environment.AccessToken)
 	}
 
 	resp, err := s.httpClient.Do(req)


### PR DESCRIPTION
## Summary

Fixes an issue where the manager would send `X-API-KEY` header to agents when the environment was created with the new API key-based pairing flow, but agents only validate the `X-Arcane-Agent-Token` header against their stored `agentToken`.

This caused **401 Unauthorized errors** on endpoints like:
- `/api/environments/:id/settings`
- `/api/container-registries/sync`

...after successful agent pairing, while other endpoints like `/containers` and `/images` worked fine.

## Root Cause

The environment middleware (`remenv.SetAgentToken`) always uses `X-Arcane-Agent-Token` header for proxied requests. However, `ProxyRequest()` and `SyncRegistriesToEnvironment()` were using `X-API-KEY` header when `ApiKeyID` was set on the environment.

Agents validate incoming requests via `tryAgentAuth()` which only checks the `X-Arcane-Agent-Token` header against `cfg.AgentToken` (loaded from `settings.agentToken`). The agent's `api_keys` table is empty, so `X-API-KEY` validation fails.

## Changes

Modified `backend/internal/services/environment_service.go`:
- `SyncRegistriesToEnvironment()` - Always use `X-Arcane-Agent-Token`
- `ProxyRequest()` - Always use `X-Arcane-Agent-Token`

This makes authentication consistent with the environment middleware proxy.

## Testing

- [x] Backend compiles successfully
- [x] Existing tests pass

Fixes #1262

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


This PR fixes a critical authentication bug where manager-to-agent requests failed with 401 errors after API key-based pairing. The issue was caused by inconsistent header usage: `SyncRegistriesToEnvironment()` and `ProxyRequest()` sent `X-API-KEY` for API key-based environments, but agents only validate `X-Arcane-Agent-Token` (checked in `tryAgentAuth()` at backend/internal/huma/middleware/auth.go:126). Since agents don't have populated `api_keys` tables, `X-API-KEY` authentication always failed.

The fix standardizes both functions to always use `X-Arcane-Agent-Token`, matching the behavior of the environment middleware proxy (`remenv.SetAgentToken()` at backend/internal/middleware/environment_middleware.go:270).

**Key changes:**
- Removed conditional logic that chose between `X-API-KEY` and `X-Arcane-Agent-Token` based on `ApiKeyID`
- Both functions now consistently use `X-Arcane-Agent-Token` header
- Added clear comments explaining the authentication mechanism

The fix is well-aligned with the codebase architecture and resolves the reported issue where endpoints like `/api/environments/:id/settings` and `/api/container-registries/sync` failed with 401 while others worked.


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The fix correctly aligns authentication behavior across two functions with the existing middleware pattern. The change is well-documented, addresses a specific bug with clear root cause analysis, and simplifies the authentication logic by removing conditional branching
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/environment_service.go | Standardizes agent authentication to use `X-Arcane-Agent-Token` header consistently in `SyncRegistriesToEnvironment()` and `ProxyRequest()`, fixing 401 errors with API key-based agent pairing |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->