### PR TITLE
fix: allow litteral quotes in oidc env values

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -54,9 +54,9 @@ func Load() *Config {
 		EncryptionKey: getEnvOrDefault("ENCRYPTION_KEY", "arcane-dev-key-32-characters!!!"),
 
 		OidcEnabled:      getBoolEnvOrDefault("OIDC_ENABLED", false),
-		OidcClientID:     os.Getenv("OIDC_CLIENT_ID"),
-		OidcClientSecret: os.Getenv("OIDC_CLIENT_SECRET"),
-		OidcIssuerURL:    os.Getenv("OIDC_ISSUER_URL"),
+		OidcClientID:     getEnvOrDefault("OIDC_CLIENT_ID", ""),
+		OidcClientSecret: getEnvOrDefault("OIDC_CLIENT_SECRET", ""),
+		OidcIssuerURL:    getEnvOrDefault("OIDC_ISSUER_URL", ""),
 		OidcScopes:       getEnvOrDefault("OIDC_SCOPES", "openid email profile"),
 		OidcAdminClaim:   getEnvOrDefault("OIDC_ADMIN_CLAIM", ""),
 		OidcAdminValue:   getEnvOrDefault("OIDC_ADMIN_VALUE", ""),
@@ -77,9 +77,18 @@ func Load() *Config {
 
 func getEnvOrDefault[T interface{ ~string }](key string, defaultValue T) T {
 	if value := os.Getenv(key); value != "" {
-		return T(value)
+		return T(trimQuotes(value))
 	}
 	return defaultValue
+}
+
+func trimQuotes(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
 }
 
 func (a AppEnvironment) IsProdEnvironment() bool {
@@ -92,6 +101,7 @@ func (a AppEnvironment) IsTestEnvironment() bool {
 
 func getBoolEnvOrDefault(key string, defaultValue bool) bool {
 	if v, ok := os.LookupEnv(key); ok && v != "" {
+		v = trimQuotes(v)
 		if b, err := strconv.ParseBool(v); err == nil {
 			return b
 		}

--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -190,7 +190,7 @@ func (s *SettingsService) loadDatabaseConfigFromEnv(ctx context.Context, db *dat
 				mask = fmt.Sprintf("%d chars", len(val))
 			}
 			slog.DebugContext(ctx, "loadDatabaseConfigFromEnv: env override found", "key", key, "env", envVarName, "valueMasked", mask)
-			rv.Field(i).FieldByName("Value").SetString(val)
+			rv.Field(i).FieldByName("Value").SetString(utils.TrimQuotes(val))
 			continue
 		} else if val, ok := settingsMap[key]; ok {
 			// Fallback to database if environment variable is not set
@@ -245,7 +245,7 @@ func (s *SettingsService) applyEnvOverrides(ctx context.Context, dest *models.Se
 		envVarName := utils.CamelCaseToScreamingSnakeCase(key)
 		if val, ok := os.LookupEnv(envVarName); ok && val != "" {
 			slog.DebugContext(ctx, "applyEnvOverrides: applying env override", "key", key, "env", envVarName)
-			rv.Field(i).FieldByName("Value").SetString(val)
+			rv.Field(i).FieldByName("Value").SetString(utils.TrimQuotes(val))
 		}
 	}
 }
@@ -598,6 +598,7 @@ func (s *SettingsService) PersistEnvSettingsIfMissing(ctx context.Context) error
 			if !ok {
 				continue
 			}
+			envVal = utils.TrimQuotes(envVal)
 
 			var existing models.SettingVariable
 			err := tx.Where("key = ?", key).First(&existing).Error

--- a/backend/internal/utils/string_util.go
+++ b/backend/internal/utils/string_util.go
@@ -42,3 +42,12 @@ func GenerateRandomString(length int) string {
 	}
 	return base64.URLEncoding.EncodeToString(bytes)[:length]
 }
+
+func TrimQuotes(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1264

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


This PR fixes OIDC login failures when the issuer URL is configured with a non-standard port (e.g., `https://auth.my-homelab:123`). The issue occurred because environment variables wrapped in quotes (e.g., `OIDC_ISSUER_URL="https://auth.my-homelab:123"`) were not being stripped of their quotes before URL parsing, causing the Go URL parser to fail with "first path segment in URL cannot contain colon".

**Changes:**
- Added public `TrimQuotes()` utility function to `string_util.go` that removes leading/trailing quotes (both single and double)
- Modified `config.go` to apply quote trimming to all environment variable parsing via `getEnvOrDefault()` and `getBoolEnvOrDefault()`
- Changed three OIDC environment variables to use `getEnvOrDefault()` instead of raw `os.Getenv()` for consistent quote handling
- Applied quote trimming in three locations in `settings_service.go` for consistent environment variable processing across all settings loading paths


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with no identified issues. It makes targeted, minimal changes to fix a specific bug without introducing side effects or security concerns.
- The PR directly addresses the reported issue by implementing a consistent quote-trimming mechanism across environment variable parsing. The implementation is straightforward and idiomatic Go: the `TrimQuotes()` function correctly validates input length before accessing string indices, and quote trimming is applied uniformly across all environment variable loading paths (config load, settings override, and database persistence). No edge cases were identified that would cause problems—the function safely returns the original string if quotes are not present, and the changes follow the existing codebase patterns. The fix is minimal, focused, and eliminates the root cause without unnecessary complexity.
- No files require special attention. All changes are straightforward and follow Go best practices.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/utils/string_util.go | Added public `TrimQuotes()` function to strip leading/trailing quotes from strings. Implementation correctly handles both double and single quotes, checking length and matching pairs before trimming. Exported function mirrors the local `trimQuotes()` implementation already in config.go, enabling code reuse across the codebase. |
| backend/internal/config/config.go | Modified `getEnvOrDefault()` to call `trimQuotes()` on environment variable values, and updated `getBoolEnvOrDefault()` to trim quotes before parsing. Changed three OIDC environment variables (`OidcClientID`, `OidcClientSecret`, `OidcIssuerURL`) from direct `os.Getenv()` to `getEnvOrDefault()` calls. This ensures environment variables wrapped in quotes (e.g., `OIDC_ISSUER_URL="https://auth.my-homelab:123"`) are properly parsed. |
| backend/internal/services/settings_service.go | Applied `utils.TrimQuotes()` in three locations: `loadDatabaseConfigFromEnv()` (line 193), `applyEnvOverrides()` (line 248), and `PersistEnvSettingsIfMissing()` (line 601). These changes ensure environment variable values are consistently trimmed of quotes when loading settings from environment variables, maintaining consistency with the config package approach. |

</details>


</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - GoLang Best Practices

Follow idiomatic Go patterns and conventions
Handle errors explicitly, don’t ... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->