### PR TITLE
fix: notifications on remote environments used incorrect urls

### DIFF
--- a/backend/internal/api/ws_handler.go
+++ b/backend/internal/api/ws_handler.go
@@ -120,7 +120,7 @@ func NewWebSocketHandler(
 		gpuMonitoringEnabled: cfg.GPUMonitoringEnabled,
 		gpuType:              cfg.GPUType,
 		wsUpgrader: websocket.Upgrader{
-			CheckOrigin:       httputil.ValidateWebSocketOrigin(cfg.AppUrl),
+			CheckOrigin:       httputil.ValidateWebSocketOrigin(cfg.GetAppURL()),
 			ReadBufferSize:    32 * 1024,
 			WriteBufferSize:   32 * 1024,
 			EnableCompression: true,

--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -100,7 +100,7 @@ func Bootstrap(ctx context.Context) error {
 func handleAgentBootstrapPairing(ctx context.Context, cfg *config.Config, httpClient *http.Client) error {
 	slog.InfoContext(ctx, "Agent mode detected with token, attempting auto-pairing", "managerUrl", cfg.ManagerApiUrl)
 
-	pairURL := strings.TrimRight(cfg.ManagerApiUrl, "/") + "/api/environments/pair"
+	pairURL := strings.TrimRight(cfg.GetManagerBaseURL(), "/") + "/api/environments/pair"
 
 	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -99,6 +99,35 @@ func (a AppEnvironment) IsTestEnvironment() bool {
 	return a == AppEnvironmentTest
 }
 
+// GetManagerBaseURL returns the base URL of the manager application.
+// It strips any trailing slashes or /api suffix from MANAGER_API_URL.
+func (c *Config) GetManagerBaseURL() string {
+	if c.ManagerApiUrl == "" {
+		return ""
+	}
+	managerURL := strings.TrimRight(c.ManagerApiUrl, "/")
+	managerURL = strings.TrimSuffix(managerURL, "/api")
+	return managerURL
+}
+
+// GetAppURL returns the effective application URL.
+// If in agent mode and APP_URL is not explicitly set, it returns the manager's URL.
+func (c *Config) GetAppURL() string {
+	// If APP_URL is explicitly set to something other than the default, use it
+	if os.Getenv("APP_URL") != "" {
+		return c.AppUrl
+	}
+
+	// If in agent mode and we have a manager URL, use the manager URL
+	if c.AgentMode {
+		if managerBase := c.GetManagerBaseURL(); managerBase != "" {
+			return managerBase
+		}
+	}
+
+	return c.AppUrl
+}
+
 func getBoolEnvOrDefault(key string, defaultValue bool) bool {
 	if v, ok := os.LookupEnv(key); ok && v != "" {
 		v = trimQuotes(v)

--- a/backend/internal/huma/handlers/environments.go
+++ b/backend/internal/huma/handlers/environments.go
@@ -868,7 +868,7 @@ func (h *EnvironmentHandler) GetDeploymentSnippets(ctx context.Context, input *G
 	}
 
 	// Generate snippets with placeholder for API key
-	snippets, err := h.environmentService.GenerateDeploymentSnippets(ctx, env.ID, h.cfg.AppUrl, "<YOUR_API_KEY>")
+	snippets, err := h.environmentService.GenerateDeploymentSnippets(ctx, env.ID, h.cfg.GetAppURL(), "<YOUR_API_KEY>")
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to generate deployment snippets", "environmentID", input.ID, "error", err.Error())
 		return nil, huma.Error500InternalServerError("Failed to generate deployment snippets")

--- a/backend/internal/middleware/cors_middleware.go
+++ b/backend/internal/middleware/cors_middleware.go
@@ -56,15 +56,17 @@ func deriveAllowedOrigins(cfg *config.Config, custom []string) []string {
 	}
 
 	var origins []string
-	if cfg != nil && cfg.AppUrl != "" {
-		appURL := cfg.AppUrl
-		if !strings.HasPrefix(appURL, "http://") && !strings.HasPrefix(appURL, "https://") {
-			appURL = "https://" + appURL
-		}
-		if u, err := url.Parse(appURL); err == nil {
-			origins = append(origins, u.Scheme+"://"+u.Host)
-		} else {
-			slog.Warn("Failed to parse APP_URL for CORS origins", "url", cfg.AppUrl, "error", err)
+	if cfg != nil {
+		appURL := cfg.GetAppURL()
+		if appURL != "" {
+			if !strings.HasPrefix(appURL, "http://") && !strings.HasPrefix(appURL, "https://") {
+				appURL = "https://" + appURL
+			}
+			if u, err := url.Parse(appURL); err == nil {
+				origins = append(origins, u.Scheme+"://"+u.Host)
+			} else {
+				slog.Warn("Failed to parse APP_URL for CORS origins", "url", appURL, "error", err)
+			}
 		}
 	}
 

--- a/backend/internal/services/notification_service.go
+++ b/backend/internal/services/notification_service.go
@@ -398,10 +398,11 @@ func (s *NotificationService) sendEmailNotification(ctx context.Context, imageRe
 }
 
 func (s *NotificationService) renderEmailTemplate(imageRef string, updateInfo *imageupdate.Response) (string, string, error) {
-	logoURL := s.config.AppUrl + logoURLPath
+	appURL := s.config.GetAppURL()
+	logoURL := appURL + logoURLPath
 	data := map[string]interface{}{
 		"LogoURL":       logoURL,
-		"AppURL":        s.config.AppUrl,
+		"AppURL":        appURL,
 		"Environment":   "Local Docker",
 		"ImageRef":      imageRef,
 		"HasUpdate":     updateInfo.HasUpdate,
@@ -605,10 +606,11 @@ func (s *NotificationService) sendEmailContainerUpdateNotification(ctx context.C
 }
 
 func (s *NotificationService) renderContainerUpdateEmailTemplate(containerName, imageRef, oldDigest, newDigest string) (string, string, error) {
-	logoURL := s.config.AppUrl + logoURLPath
+	appURL := s.config.GetAppURL()
+	logoURL := appURL + logoURLPath
 	data := map[string]interface{}{
 		"LogoURL":       logoURL,
-		"AppURL":        s.config.AppUrl,
+		"AppURL":        appURL,
 		"Environment":   "Local Docker",
 		"ContainerName": containerName,
 		"ImageRef":      imageRef,
@@ -765,10 +767,11 @@ func (s *NotificationService) sendTestEmail(ctx context.Context, config models.J
 }
 
 func (s *NotificationService) renderTestEmailTemplate() (string, string, error) {
-	logoURL := s.config.AppUrl + logoURLPath
+	appURL := s.config.GetAppURL()
+	logoURL := appURL + logoURLPath
 	data := map[string]interface{}{
 		"LogoURL": logoURL,
-		"AppURL":  s.config.AppUrl,
+		"AppURL":  appURL,
 	}
 
 	htmlContent, err := resources.FS.ReadFile("email-templates/test_html.tmpl")
@@ -1048,10 +1051,11 @@ func (s *NotificationService) renderBatchEmailTemplate(updates map[string]*image
 		imageList = append(imageList, imageRef)
 	}
 
-	logoURL := s.config.AppUrl + logoURLPath
+	appURL := s.config.GetAppURL()
+	logoURL := appURL + logoURLPath
 	data := map[string]interface{}{
 		"LogoURL":     logoURL,
-		"AppURL":      s.config.AppUrl,
+		"AppURL":      appURL,
 		"UpdateCount": len(updates),
 		"CheckTime":   time.Now().Format(time.RFC1123),
 		"ImageList":   imageList,

--- a/backend/internal/services/oidc_service.go
+++ b/backend/internal/services/oidc_service.go
@@ -145,7 +145,7 @@ func (s *OidcService) GenerateAuthURL(ctx context.Context, redirectTo string, or
 func (s *OidcService) GetOidcRedirectURL(origin string) string {
 	baseUrl := origin
 	if baseUrl == "" {
-		baseUrl = strings.TrimSuffix(s.config.AppUrl, "/")
+		baseUrl = strings.TrimSuffix(s.config.GetAppURL(), "/")
 	}
 	return baseUrl + "/auth/oidc/callback"
 }

--- a/docker/examples/compose.agent.yaml
+++ b/docker/examples/compose.agent.yaml
@@ -6,7 +6,8 @@ services:
       - "3553:3553"
     environment:
       - AGENT_MODE=true
-      - AGENT_BOOTSTRAP_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxx
+      - AGENT_TOKEN=arc_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+      - MANAGER_API_URL=http://10.1.1.4:3552
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - agent-data:/app/data


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1281

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


This PR fixes a critical bug where notification emails from remote Docker agents contained incorrect links pointing to `localhost:3552` instead of the configured manager instance URL. The fix introduces a smart URL resolution system that ensures agents always reference the manager's URL in notifications and other URL-dependent features.


</details>
<h4>Changes Made</h4>

- **Core URL Resolution Logic**: Added `GetManagerBaseURL()` and `GetAppURL()` methods to `config.go` that implement intelligent URL selection. `GetAppURL()` returns the manager's base URL for agents (when `AGENT_MODE=true` and `MANAGER_API_URL` is set), otherwise returns the configured `APP_URL`.

- **Notification URLs**: Updated all email template rendering methods in `notification_service.go` to use `GetAppURL()`, ensuring both the logo URL (`/api/app-images/logo-email`) and dashboard links reference the correct instance.

- **WebSocket & CORS**: Updated WebSocket origin validation in `ws_handler.go` and CORS origin derivation in `cors_middleware.go` to use the smart URL resolution, preventing origin validation issues for remote agents.

- **OIDC Authentication**: Fixed OIDC redirect URL construction in `oidc_service.go` to use `GetAppURL()`.

- **Agent Bootstrap**: Updated agent pairing logic in `bootstrap.go` to normalize the manager URL before constructing the pairing endpoint.

- **Deployment Instructions**: Updated deployment snippet generation in `environments.go` to use the correct application URL.

- **Documentation**: Updated example Docker Compose configuration to use `AGENT_TOKEN` (consistent naming) and demonstrate correct agent setup.

<h4>Root Cause</h4>

The issue occurred because agents defaulted to using `http://localhost:3552` (the default `APP_URL`) when constructing URLs for notifications and other features. Since agents are typically in isolated networks, localhost is not accessible to email recipients.

<h4>Solution Architecture</h4>

The fix ensures a two-tier URL resolution strategy:
1. If `APP_URL` is explicitly set in the environment, use it
2. If in agent mode and `MANAGER_API_URL` is configured, use the manager's base URL
3. Otherwise, fall back to the configured `APP_URL`

This allows agents to automatically discover and use the manager's URL without requiring explicit configuration while maintaining backward compatibility with deployments that explicitly set `APP_URL`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk - it implements a straightforward, well-scoped fix with comprehensive coverage across all affected URL construction points.
- The PR scores a 5/5 confidence because: (1) the fix is logically sound and directly addresses the reported issue from #1281; (2) all affected locations are updated consistently (notification URLs, WebSocket validation, CORS, OIDC, agent bootstrap, deployment snippets); (3) the `GetAppURL()` method is implemented with proper fallback logic that maintains backward compatibility; (4) no error handling was broken or introduced; (5) the changes follow Go best practices with explicit error handling; (6) the example configuration is updated to reflect the fix; (7) the scope is appropriately limited to URL resolution without scope creep.
- No files require special attention - all changes are straightforward URL resolution updates with consistent patterns applied across the codebase.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/config/config.go | Added two helper methods: `GetManagerBaseURL()` normalizes the manager URL by trimming slashes and `/api` suffix, and `GetAppURL()` implements smart URL resolution that returns the manager base URL for agents in agent mode, fallback to AppUrl otherwise. Correctly addresses the core issue. |
| backend/internal/services/notification_service.go | Updated four template rendering methods (`renderEmailTemplate`, `renderContainerUpdateEmailTemplate`, `renderTestEmailTemplate`, `renderBatchEmailTemplate`) to use `s.config.GetAppURL()` instead of directly accessing config fields. Ensures notification URLs correctly reference the manager instance for remote agents. |
| backend/internal/api/ws_handler.go | Updated WebSocket origin validation in `NewWebSocketHandler` to use `cfg.GetAppURL()` instead of `cfg.AppUrl`. Ensures proper origin validation for remote environments. |
| backend/internal/middleware/cors_middleware.go | Updated CORS origin derivation in `deriveAllowedOrigins` to use `cfg.GetAppURL()` instead of `cfg.AppUrl`. Ensures CORS configuration correctly reflects the effective application URL for agents. |
| backend/internal/services/oidc_service.go | Updated OIDC redirect URL in `GetOidcRedirectURL` to use `s.config.GetAppURL()` instead of directly accessing config fields. Ensures OIDC callbacks reference the correct URL for remote environments. |
| backend/internal/bootstrap/bootstrap.go | Updated agent bootstrap pairing to use `cfg.GetManagerBaseURL()` instead of `cfg.ManagerApiUrl` directly. Correctly normalizes the manager URL by removing slashes and `/api` suffix before constructing the pairing endpoint URL. |
| backend/internal/huma/handlers/environments.go | Updated deployment snippet generation to use `h.cfg.GetAppURL()` instead of direct config access. Ensures deployment instructions contain correct URLs for agents. |
| docker/examples/compose.agent.yaml | Updated environment variable naming from `AGENT_BOOTSTRAP_TOKEN` to `AGENT_TOKEN` for consistency with the codebase. Example configuration correctly demonstrates agent mode setup with manager URL. |

</details>


</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - GoLang Best Practices

Follow idiomatic Go patterns and conventions
Handle errors explicitly, don’t ... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->