### PR TITLE
fix: disable copy button on non-ssl instances

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.podman.io/image/v5 v5.38.0
 	golang.org/x/crypto v0.46.0
+	golang.org/x/net v0.47.0
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sync v0.19.0
 	golang.org/x/text v0.32.0
@@ -198,7 +199,6 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.3 // indirect
 	golang.org/x/arch v0.21.0 // indirect
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect
-	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/term v0.38.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -213,6 +213,7 @@
 	"common_field_required": "{field} is required",
 	"common_copied": "Copied to clipboard",
 	"common_copy_failed": "Failed to copy to clipboard",
+	"common_copy_https_required": "Copying requires a secure connection (HTTPS)",
 	"_comment_resources": "=== RESOURCE NAMES ===",
 	"resource_volume": "volume",
 	"resource_volume_cap": "Volume",

--- a/frontend/src/lib/components/ui/copy-button/copy-button.svelte
+++ b/frontend/src/lib/components/ui/copy-button/copy-button.svelte
@@ -9,6 +9,9 @@
 	import { scale } from 'svelte/transition';
 	import type { CopyButtonProps } from './types';
 	import { CopyIcon, CloseIcon, CheckIcon } from '$lib/icons';
+	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { onMount } from 'svelte';
+	import { m } from '$lib/paraglide/messages';
 
 	let {
 		ref = $bindable(null),
@@ -26,42 +29,79 @@
 	const clipboard = new UseClipboard();
 
 	const resolvedSize = $derived(size === 'icon' && children ? 'default' : size);
+
+	let isSecure = $state(true);
+
+	onMount(() => {
+		isSecure = window.isSecureContext || window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+	});
 </script>
 
-<ArcaneButton
-	bind:ref
-	action="base"
-	tone={variant === 'ghost' ? 'ghost' : variant === 'outline' ? 'outline' : 'outline'}
-	size={resolvedSize}
-	{tabindex}
-	class={cn('flex items-center gap-2', className)}
-	type="button"
-	name="copy"
-	onclick={async () => {
-		const status = await clipboard.copy(text);
+{#if isSecure}
+	<ArcaneButton
+		bind:ref
+		action="base"
+		tone={variant === 'ghost' ? 'ghost' : variant === 'outline' ? 'outline' : 'outline'}
+		size={resolvedSize}
+		{tabindex}
+		class={cn('flex items-center gap-2', className)}
+		type="button"
+		name="copy"
+		onclick={async () => {
+			const status = await clipboard.copy(text);
 
-		onCopy?.(status);
-	}}
->
-	{#if clipboard.status === 'success'}
-		<div in:scale={{ duration: animationDuration, start: 0.85 }}>
-			<CheckIcon tabindex={-1} />
-			<span class="sr-only">Copied</span>
-		</div>
-	{:else if clipboard.status === 'failure'}
-		<div in:scale={{ duration: animationDuration, start: 0.85 }}>
-			<CloseIcon tabindex={-1} />
-			<span class="sr-only">Failed to copy</span>
-		</div>
-	{:else}
-		<div in:scale={{ duration: animationDuration, start: 0.85 }}>
-			{#if icon}
-				{@render icon()}
-			{:else}
-				<CopyIcon tabindex={-1} />
-			{/if}
-			<span class="sr-only">Copy</span>
-		</div>
-	{/if}
-	{@render children?.()}
-</ArcaneButton>
+			onCopy?.(status);
+		}}
+	>
+		{#if clipboard.status === 'success'}
+			<div in:scale={{ duration: animationDuration, start: 0.85 }}>
+				<CheckIcon tabindex={-1} />
+				<span class="sr-only">Copied</span>
+			</div>
+		{:else if clipboard.status === 'failure'}
+			<div in:scale={{ duration: animationDuration, start: 0.85 }}>
+				<CloseIcon tabindex={-1} />
+				<span class="sr-only">Failed to copy</span>
+			</div>
+		{:else}
+			<div in:scale={{ duration: animationDuration, start: 0.85 }}>
+				{#if icon}
+					{@render icon()}
+				{:else}
+					<CopyIcon tabindex={-1} />
+				{/if}
+				<span class="sr-only">Copy</span>
+			</div>
+		{/if}
+		{@render children?.()}
+	</ArcaneButton>
+{:else}
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			<ArcaneButton
+				bind:ref
+				action="base"
+				tone={variant === 'ghost' ? 'ghost' : variant === 'outline' ? 'outline' : 'outline'}
+				size={resolvedSize}
+				{tabindex}
+				class={cn('flex cursor-not-allowed items-center gap-2 opacity-50', className)}
+				type="button"
+				name="copy"
+				disabled
+			>
+				<div in:scale={{ duration: animationDuration, start: 0.85 }}>
+					{#if icon}
+						{@render icon()}
+					{:else}
+						<CopyIcon tabindex={-1} />
+					{/if}
+					<span class="sr-only">Copy</span>
+				</div>
+				{@render children?.()}
+			</ArcaneButton>
+		</Tooltip.Trigger>
+		<Tooltip.Content>
+			<p>{m.common_copy_https_required()}</p>
+		</Tooltip.Content>
+	</Tooltip.Root>
+{/if}


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1295

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


This PR addresses the clipboard API issue on non-HTTPS connections by detecting insecure contexts and disabling the copy button with an informative tooltip. The fix correctly uses `window.isSecureContext` to detect if the Clipboard API is available, while also allowing localhost/127.0.0.1 exceptions. When disabled, the button shows a tooltip explaining that HTTPS is required for copying.


</details>
<details open><summary><h3>Confidence Score: 4/5</h3></summary>


- This PR is safe to merge with minimal risk - it properly handles a browser security constraint
- The implementation correctly addresses the reported issue by checking for secure context. However, there's a minor reactivity concern: the `isSecure` check happens only on mount, so it won't update if the protocol changes dynamically (though this is an edge case)
- Pay attention to `frontend/src/lib/components/ui/copy-button/copy-button.svelte` - verify the disabled state styling meets UX expectations
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/components/ui/copy-button/copy-button.svelte | Added security context check to disable copy button on non-HTTPS connections with tooltip explanation |
| frontend/messages/en.json | Added localized message for HTTPS requirement warning |
| backend/go.mod | Moved `golang.org/x/net` from indirect to direct dependency |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->