### PR TITLE
fix: add witdth constraint

### DIFF
--- a/frontend/src/lib/components/mobile-nav/styles.css
+++ b/frontend/src/lib/components/mobile-nav/styles.css
@@ -22,6 +22,9 @@
 	backface-visibility: hidden;
 	/* Prevent body scroll leak */
 	contain: layout style paint;
+	/* Constrain width on small screens */
+	width: 98%;
+	max-width: 28rem;
 }
 
 /* Floating navigation specific positioning */


### PR DESCRIPTION
On smaller screens (small is relative, I had this issue on an iPhone 14 pro max) the floating navbar overflows. Added constraint to 98% to fix this issue. Fixes #1327

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


Fixed mobile navbar overflow on smaller screens by constraining the floating navigation bar width to 98% with a maximum width of 28rem (448px). Previously, the navigation bar could extend beyond the viewport boundaries on devices like iPhone 14 Pro Max in portrait mode.

- Added `width: 98%` to provide breathing room on both sides
- Added `max-width: 28rem` to maintain consistent sizing across devices
- Change applies to `.mobile-nav-base` class affecting both floating and docked navigation modes
- Properly addresses issue #1327 without affecting desktop or larger mobile displays


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- Simple, focused CSS change that directly addresses the reported issue. The solution uses standard responsive design practices (percentage-based width with max-width constraint) without affecting existing functionality or introducing breaking changes
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/components/mobile-nav/styles.css | Added width constraint (98% with 28rem max-width) to fix mobile viewport overflow issue |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->