### PR TITLE
feat: current environment in title

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -18,6 +18,7 @@
 	import { invalidateAll } from '$app/navigation';
 	import { cn } from '$lib/utils';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import { environmentStore } from '$lib/stores/environment.store.svelte';
 
 	let {
 		data,
@@ -75,9 +76,15 @@
 	function handlePasswordChangeSuccess() {
 		invalidateAll();
 	}
+
+	const pageTitle = $derived(
+		environmentStore.selected
+			? `${m.layout_title()} | ${environmentStore.selected.name}`
+			: m.layout_title()
+	);
 </script>
 
-<svelte:head><title>{m.layout_title()}</title></svelte:head>
+<svelte:head><title>{pageTitle}</title></svelte:head>
 
 <div class={cn('flex min-h-dvh flex-col', isGlassEnabled ? 'bg-transparent' : 'bg-background')}>
 	{#if !settings && data.user}


### PR DESCRIPTION
Closes: #1308

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


Added current environment name to browser page title, displaying as "Arcane | [Environment Name]" when an environment is selected.

- Imported `environmentStore` from the environment store module
- Created reactive `pageTitle` variable using `$derived` rune that conditionally includes the selected environment name
- Falls back to default "Arcane" title when no environment is selected
- Implementation follows Svelte 5 conventions with proper use of runes


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- Small, focused change that correctly implements the requested feature using proper Svelte 5 syntax, handles edge cases (null environment), and follows established project conventions
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/routes/+layout.svelte | Added environment name to page title using `$derived` rune - correctly handles null case when no environment is selected |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->