### PR TITLE
fix: absolute/relative path mapping issues

### DIFF
--- a/backend/internal/utils/pathmapper/path_mapper_test.go
+++ b/backend/internal/utils/pathmapper/path_mapper_test.go
@@ -40,7 +40,8 @@ func TestPathMapper_AbsolutePathWithRelativePrefix_NoTranslation(t *testing.T) {
 	// When containerPrefix is relative but the volume path is absolute and outside the prefix,
 	// the path should be returned unchanged (not error).
 	// This happens with compose includes that use project_directory with absolute paths.
-	pm := NewPathMapper("data/projects", "/host/projects")
+	// NOTE: In production, containerPrefix should always be absolute, but we test the fallback behavior
+	pm := NewPathMapper("/app/data/projects", "/host/projects")
 	result, err := pm.ContainerToHost("/home/user/docker/project/data")
 	require.NoError(t, err)
 	assert.Equal(t, "/home/user/docker/project/data", result)
@@ -48,8 +49,9 @@ func TestPathMapper_AbsolutePathWithRelativePrefix_NoTranslation(t *testing.T) {
 
 func TestPathMapper_BugScenario_RelativePrefixAbsoluteVolumes(t *testing.T) {
 	// Reproduces the exact bug scenario from issue:
-	// relative containerPrefix with absolute host volume paths
-	pm := NewPathMapper("data/projects", "/host/projects")
+	// containerPrefix (should be absolute in production) with absolute host volume paths
+	// This tests the behavior when paths are outside the container prefix
+	pm := NewPathMapper("/app/data/projects", "/host/projects")
 
 	tests := []struct {
 		name     string


### PR DESCRIPTION


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes path mapping issues when the container directory is relative but volume paths are absolute. The fix adds checks to detect when paths have mismatched absolute/relative forms and skips translation in those cases, returning the path unchanged.

**Key Changes:**
- **path_mapper.go**: Added logic to detect when `containerPath` and `containerPrefix` have different absolute/relative forms (lines 42-49). When both are absolute, added a prefix check to skip translation for paths outside the container prefix (lines 51-57).
- **project_service.go**: Ensured `containerDirResolved` is always converted to an absolute path before creating the PathMapper (lines 77-80), preventing `filepath.Rel` errors.
- **path_mapper_test.go**: Added comprehensive tests covering the bug scenario from issue #1405, verifying that absolute paths are returned unchanged when the container prefix is relative.

**How it fits with the codebase:**
The PathMapper is used throughout the project service to translate container paths to host paths for Docker Compose projects. This is critical for handling non-matching mounts (e.g., Windows host with Linux container). The fix ensures the mapper gracefully handles edge cases where compose includes use `project_directory` with absolute paths while Arcane is configured with relative paths.

### Confidence Score: 3/5

- Moderately safe - fixes the reported issue but introduces a potential path containment bug
- The PR successfully addresses the immediate issue (#1405) by preventing filepath.Rel errors when mixing absolute/relative paths. However, there's a P1 logic issue with using unsafe string prefix checking for path containment (line 53 in path_mapper.go), which could cause incorrect behavior in edge cases. The redundant filepath.Abs call is a minor style issue. The fix is well-tested for the reported scenario but the prefix checking bug needs attention.
- backend/internal/utils/pathmapper/path_mapper.go - needs safer path containment checking logic

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| backend/internal/utils/pathmapper/path_mapper.go | 3/5 | Added logic to handle mismatched absolute/relative paths and prevent filepath.Rel errors. Contains a potential bug with unsafe string prefix checking for path containment. |
| backend/internal/services/project_service.go | 4/5 | Added filepath.Abs call to ensure containerDirResolved is absolute before passing to PathMapper, fixing relative path issues. Contains redundant filepath.Abs call noted in previous thread. |
| backend/internal/utils/pathmapper/path_mapper_test.go | 5/5 | Added comprehensive test cases covering absolute/relative path mismatches and the bug scenario from issue #1405. Tests verify paths are returned unchanged when they fall outside the container prefix. |

</details>


</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| backend/internal/utils/pathmapper/path_mapper.go | 3/5 | Added logic to handle mismatched absolute/relative paths and prevent filepath.Rel errors. Contains a potential bug with unsafe string prefix checking for path containment. |
| backend/internal/services/project_service.go | 4/5 | Added filepath.Abs call to ensure containerDirResolved is absolute before passing to PathMapper, fixing relative path issues. Contains redundant filepath.Abs call noted in previous thread. |
| backend/internal/utils/pathmapper/path_mapper_test.go | 5/5 | Added comprehensive test cases covering absolute/relative path mismatches and the bug scenario from issue #1405. Tests verify paths are returned unchanged when they fall outside the container prefix. |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->