### PR TITLE
fix: editor cursor missalignment

### DIFF
--- a/frontend/src/lib/components/monaco-code-editor/editor.svelte
+++ b/frontend/src/lib/components/monaco-code-editor/editor.svelte
@@ -111,8 +111,8 @@
 				strings: true
 			},
 			suggestOnTriggerCharacters: true,
-			fontFamily:
-				'"Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+			fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", "Courier New", monospace',
+			fontLigatures: false,
 			padding: { top: 10, bottom: 10 },
 			scrollbar: autoHeight
 				? {


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1389

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

Fixes cursor misalignment in Monaco editor by removing Geist Mono from the font fallback chain and explicitly disabling font ligatures. 

- Removed `"Geist Mono"` from `fontFamily` configuration
- Added `fontLigatures: false` to prevent ligature-related cursor positioning issues
- Font now falls back to system monospace fonts starting with `ui-monospace`

The changes are straightforward and address a known issue where custom fonts with ligatures can cause cursor misalignment in Monaco editor.

### Confidence Score: 5/5

- This PR is safe to merge with no risk
- The changes are minimal, well-targeted, and address a specific UI bug. Removing the custom font and disabling ligatures are standard solutions for Monaco editor cursor misalignment issues. No logic changes or breaking modifications were made.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| frontend/src/lib/components/monaco-code-editor/editor.svelte | 5/5 | Fixed cursor misalignment by removing Geist Mono font and disabling ligatures in Monaco editor configuration |

</details>


</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| frontend/src/lib/components/monaco-code-editor/editor.svelte | 5/5 | Fixed cursor misalignment by removing Geist Mono font and disabling ligatures in Monaco editor configuration |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->