### PR TITLE
fix: oidc insecure tls not working for self signed CA

### DIFF
--- a/backend/internal/services/oidc_service.go
+++ b/backend/internal/services/oidc_service.go
@@ -104,7 +104,11 @@ func (s *OidcService) getInsecureHttpClient() *http.Client {
 		insecureTransport = transport.Clone()
 	} else {
 		// Transport is nil or not *http.Transport - create a new default transport
-		insecureTransport = http.DefaultTransport.(*http.Transport).Clone()
+		if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+			insecureTransport = defaultTransport.Clone()
+		} else {
+			insecureTransport = &http.Transport{}
+		}
 	}
 
 	if insecureTransport.TLSClientConfig == nil {


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1439

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


Fixed OIDC authentication failing with self-signed certificates when `OIDC_SKIP_TLS_VERIFY=true` is set. The bug occurred because `getInsecureHttpClient()` only set `InsecureSkipVerify` when the transport was already an `*http.Transport`, but silently failed when the transport was `nil` (the default state). 

The fix properly handles the nil transport case by creating a new default transport and configuring it with `InsecureSkipVerify=true`. This ensures the TLS verification bypass works as intended for self-signed CA certificates.

- Restructured `getInsecureHttpClient()` to declare `insecureTransport` at function scope
- Added fallback logic to create default transport when `insecureClient.Transport` is nil or not `*http.Transport`
- Moved `InsecureSkipVerify` configuration outside the transport type check to apply in all cases
- Removed the warning log for non-transport cases since they're now properly handled


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The fix correctly handles the edge case where `insecureClient.Transport` is nil by creating a proper default transport with TLS config. The double-checked locking pattern ensures thread safety, and the fallback logic is sound. The change directly addresses the reported bug without introducing side effects.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/oidc_service.go | Fixed `getInsecureHttpClient()` to properly handle nil transport by creating default transport with InsecureSkipVerify enabled, resolving TLS verification bypass for self-signed certificates |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->