### PR TITLE
refactor: update environment page to use settings form util

### DIFF
--- a/frontend/src/lib/utils/form.utils.ts
+++ b/frontend/src/lib/utils/form.utils.ts
@@ -77,9 +77,11 @@ export function createForm<T extends z.ZodType<any, any>>(schema: T, initialValu
 				// Trim values for submission, but don't mutate the store value in-place.
 				return [key, trimValue(input.value)];
 			})
-		) as z.infer<T>;
+		);
 
-		return values;
+		// Parse through schema to apply coercion (e.g., z.coerce.number())
+		const result = schema.safeParse(values);
+		return (result.success ? result.data : values) as z.infer<T>;
 	}
 
 	function reset() {


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


This PR refactors the environment page to use the new `createSettingsForm` utility, consolidating form state management and reducing boilerplate. The refactoring successfully replaces manual form value tracking with a centralized utility and converts state-mutating `$effect` blocks to `$derived` values (addressing Svelte 5 best practices).

**Key changes:**
- Replaced ~200 lines of manual form state management with `createSettingsForm` utility
- Added custom save handler support in `UseSettingsForm` for environment-specific logic
- Converted state-mutating `$effect` blocks to `$derived` and event handlers
- Added schema coercion support in `form.utils.ts` for proper `z.coerce` handling

**Critical issues found:**
- Form is recreated on every `currentSettings` change (line 187) causing loss of user input and potential memory leaks from uncleaned subscriptions
- `pollingIntervalMode` and `shellSelectValue` are `$derived` (read-only) but bound with `bind:value`, causing runtime errors when the selects try to update them

These bugs will prevent the form from working correctly in production.


</details>
<details open><summary><h3>Confidence Score: 1/5</h3></summary>


- This PR has critical logic errors that will break form functionality
- The refactoring has good intentions but introduces three critical bugs: (1) form recreation on every settings change loses user input, (2-3) read-only derived values bound to form inputs cause runtime errors. These are blocking issues.
- frontend/src/routes/(app)/environments/[id]/+page.svelte requires immediate fixes for form initialization and derived state bindings
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/routes/(app)/environments/[id]/+page.svelte | Refactored to use settings form utility, but has critical bugs: form recreates on every change (loses input), and read-only derived values bound to inputs |
| frontend/src/lib/hooks/use-settings-form.svelte.ts | Added custom save handler and improved TypeScript generics for environment-specific settings |
| frontend/src/lib/utils/settings-form.util.ts | Added custom save handler support and improved error message handling |
| frontend/src/lib/utils/form.utils.ts | Added schema coercion to properly handle z.coerce transformations during data extraction |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->