### PR TITLE
fix: unable to save env in git synced project

### DIFF
--- a/frontend/src/lib/services/project-service.ts
+++ b/frontend/src/lib/services/project-service.ts
@@ -88,13 +88,18 @@ export class ProjectService extends BaseAPIService {
 		return res.data.data;
 	}
 
-	async updateProject(projectId: string, name: string, composeContent: string, envContent?: string): Promise<Project> {
+	async updateProject(projectId: string, name?: string, composeContent?: string, envContent?: string): Promise<Project> {
 		const envId = await environmentStore.getCurrentEnvironmentId();
-		const payload = {
-			name,
-			composeContent,
-			envContent
-		};
+		const payload: Record<string, string> = {};
+		if (name !== undefined) {
+			payload.name = name;
+		}
+		if (composeContent !== undefined) {
+			payload.composeContent = composeContent;
+		}
+		if (envContent !== undefined) {
+			payload.envContent = envContent;
+		}
 		return this.handleResponse(this.api.put(`/environments/${envId}/projects/${projectId}`, payload));
 	}
 

--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -175,14 +175,17 @@
 	async function handleSaveChanges() {
 		if (!project || !hasChanges) return;
 
-		const validated = form.validate();
+		const formValues = form.data();
+		const validated = isGitOpsManaged ? formValues : form.validate();
 		if (!validated) return;
 
 		const { name, composeContent, envContent } = validated;
+		const namePayload = isGitOpsManaged ? undefined : name;
+		const composePayload = isGitOpsManaged ? undefined : composeContent;
 
 		// First update the main project files
 		handleApiResultWithCallbacks({
-			result: await tryCatch(projectService.updateProject(projectId, name, composeContent, envContent)),
+			result: await tryCatch(projectService.updateProject(projectId, namePayload, composePayload, envContent)),
 			message: m.common_save_failed(),
 			setLoadingState: (value) => (isLoading.saving = value),
 			onSuccess: async (updatedStack: Project) => {


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1437

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


Fixed the bug preventing `.env` file updates in git-synced projects by modifying the update logic to conditionally send only the `envContent` field.

**Key changes:**
- Modified `updateProject` service method to accept all parameters as optional and only include defined fields in the API payload
- Updated the save handler to skip form validation for git-synced projects (since `name` and `composeContent` are read-only) and pass `undefined` for these fields
- This allows the backend to receive only the `envContent` field, avoiding validation errors on omitted fields

The fix correctly handles the constraint that git-synced projects have read-only `name` and `composeContent` fields (managed by git), while still allowing users to edit and save environment variables.


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The fix is well-designed and correctly addresses the root cause. The backend API already supports optional fields for partial updates, and this change aligns the frontend with that capability. The conditional logic properly handles both git-synced and non-git-synced projects.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/services/project-service.ts | Changed `updateProject` parameters to optional and conditionally build payload to avoid sending undefined fields |
| frontend/src/routes/(app)/projects/[projectId]/+page.svelte | Skip form validation for git-synced projects and conditionally pass name/compose fields to allow env-only updates |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->