### PR TITLE
feat: project status filter selector

### DIFF
--- a/backend/internal/huma/handlers/projects.go
+++ b/backend/internal/huma/handlers/projects.go
@@ -41,6 +41,7 @@ type ListProjectsInput struct {
 	Order         string `query:"order" default:"asc" doc:"Sort direction (asc or desc)"`
 	Start         int    `query:"start" default:"0" doc:"Start index for pagination"`
 	Limit         int    `query:"limit" default:"20" doc:"Number of items per page"`
+	Status        string `query:"status" doc:"Filter by status (comma-separated: running,stopped,partially running)"`
 }
 
 type ListProjectsOutput struct {
@@ -337,6 +338,9 @@ func (h *ProjectHandler) ListProjects(ctx context.Context, input *ListProjectsIn
 		PaginationParams: pagination.PaginationParams{
 			Start: input.Start,
 			Limit: input.Limit,
+		},
+		Filters: map[string]string{
+			"status": input.Status,
 		},
 	}
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -666,6 +666,7 @@
 	"projects_col_provider": "Provider",
 	"projects_provider_local": "Local",
 	"projects_provider_git": "Git",
+	"projects_status_partial": "Partially Running",
 	"compose_subtitle": "View and Manage Compose Projects",
 	"compose_services": "Services",
 	"compose_services_description": "Docker Compose services and their current status",

--- a/frontend/src/lib/components/arcane-table/arcane-table-toolbar.svelte
+++ b/frontend/src/lib/components/arcane-table/arcane-table-toolbar.svelte
@@ -2,7 +2,7 @@
 	import type { Table } from '@tanstack/table-core';
 	import { DataTableFacetedFilter, DataTableViewOptions } from './index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
-	import { imageUpdateFilters, usageFilters, severityFilters, templateTypeFilters } from './data.js';
+	import { imageUpdateFilters, usageFilters, severityFilters, templateTypeFilters, projectStatusFilters } from './data.js';
 	import { debounced } from '$lib/utils/utils.js';
 	import { ArcaneButton } from '$lib/components/arcane-button';
 	import { m } from '$lib/paraglide/messages';
@@ -38,6 +38,10 @@
 	);
 	const severityColumn = $derived(
 		table.getAllColumns().some((col) => col.id === 'severity') ? table.getColumn('severity') : undefined
+	);
+	const statusColumn = $derived(table.getAllColumns().some((col) => col.id === 'status') ? table.getColumn('status') : undefined);
+	const serviceCountColumn = $derived(
+		table.getAllColumns().some((col) => col.id === 'serviceCount') ? table.getColumn('serviceCount') : undefined
 	);
 	const typeColumn = $derived(table.getAllColumns().some((col) => col.id === 'type') ? table.getColumn('type') : undefined);
 
@@ -83,6 +87,9 @@
 				{#if severityColumn}
 					<DataTableFacetedFilter column={severityColumn} title={m.events_col_severity()} options={severityFilters} />
 				{/if}
+				{#if statusColumn && serviceCountColumn}
+					<DataTableFacetedFilter column={statusColumn} title={m.common_status()} options={projectStatusFilters} />
+				{/if}
 
 				{#if isFiltered}
 					<ArcaneButton
@@ -107,7 +114,7 @@
 		{#if hasSelection}
 			{#if hasBulkActions}
 				<div class="flex flex-wrap items-center gap-2">
-					{#each bulkActions as bulkAction}
+					{#each bulkActions as bulkAction (bulkAction.id)}
 						{@const actionType = bulkAction.action === 'up' ? 'start' : bulkAction.action === 'down' ? 'stop' : bulkAction.action}
 						<ArcaneButton
 							action={actionType}

--- a/frontend/src/lib/components/arcane-table/data.ts
+++ b/frontend/src/lib/components/arcane-table/data.ts
@@ -1,5 +1,16 @@
 import { m } from '$lib/paraglide/messages';
-import { GlobeIcon, FolderOpenIcon, VerifiedCheckIcon, AlertIcon, InfoIcon, CloseIcon, CheckIcon, UpdateIcon } from '$lib/icons';
+import {
+	GlobeIcon,
+	FolderOpenIcon,
+	VerifiedCheckIcon,
+	AlertIcon,
+	InfoIcon,
+	CloseIcon,
+	CheckIcon,
+	UpdateIcon,
+	StartIcon,
+	StopIcon
+} from '$lib/icons';
 
 export const usageFilters = [
 	{
@@ -60,5 +71,28 @@ export const templateTypeFilters = [
 		value: 'true',
 		label: m.templates_remote(),
 		icon: GlobeIcon
+	}
+];
+
+export const projectStatusFilters = [
+	{
+		value: 'running',
+		label: m.common_running(),
+		icon: StartIcon
+	},
+	{
+		value: 'stopped',
+		label: m.common_stopped(),
+		icon: StopIcon
+	},
+	{
+		value: 'partially running',
+		label: m.projects_status_partial(),
+		icon: AlertIcon
+	},
+	{
+		value: 'unknown',
+		label: m.common_unknown(),
+		icon: InfoIcon
 	}
 ];


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


Added project status filtering functionality that allows filtering by `running`, `stopped`, `partially running`, and `unknown` statuses. The feature supports comma-separated multiple status values.

**Key changes:**
- Backend accepts `status` query parameter and routes it through the pagination filters
- When status filter is present, all projects are loaded from DB and filtered in-memory after fetching live Docker status (necessary since status is computed from Docker, not stored in DB)
- Frontend adds status filter dropdown in the table toolbar with appropriate icons
- Search term WHERE clause is still applied before loading projects to reduce dataset size

**Implementation note:** The in-memory filtering approach is unavoidable for status filtering since project status is computed from live Docker container state rather than being stored in the database. This was already noted in previous review comments.


</details>
<details open><summary><h3>Confidence Score: 4/5</h3></summary>


- This PR is safe to merge with minimal risk - implements straightforward filtering logic with one conditional logic issue
- Score reflects clean implementation of status filtering with proper separation of concerns. The backend correctly handles the constraint that status is computed from Docker (not stored in DB), and the frontend properly integrates the filter UI. One logic issue found: status filter only appears when both status AND serviceCount columns exist, which unnecessarily couples unrelated columns
- frontend/src/lib/components/arcane-table/arcane-table-toolbar.svelte requires attention to fix the status filter condition
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/project_service.go | Implemented status filtering with in-memory filtering for live Docker status - loads all projects when status filter is present |
| frontend/src/lib/components/arcane-table/arcane-table-toolbar.svelte | Added status filter dropdown for projects table when both status and serviceCount columns are present, added key to bulkActions loop |

</details>


</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - GoLang Best Practices

---
description: 'Instructions for writing Go code following idiomatic Go pra... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->