### PR TITLE
fix: generic webhooks do not allow ports

### DIFF
--- a/backend/internal/utils/notifications/generic_sender_test.go
+++ b/backend/internal/utils/notifications/generic_sender_test.go
@@ -30,6 +30,28 @@ func TestBuildGenericURL(t *testing.T) {
 			wantURL: "generic://webhook.example.com/notify?disabletls=yes&template=json",
 		},
 		{
+			name: "webhook without scheme defaults to HTTPS",
+			config: models.GenericConfig{
+				WebhookURL: "webhook.example.com/notify",
+			},
+			wantURL: "generic://webhook.example.com/notify?disabletls=no&template=json",
+		},
+		{
+			name: "webhook without scheme with port",
+			config: models.GenericConfig{
+				WebhookURL: "webhook.example.com:8080/notify",
+			},
+			wantURL: "generic://webhook.example.com:8080/notify?disabletls=no&template=json",
+		},
+		{
+			name: "webhook without scheme with DisableTLS",
+			config: models.GenericConfig{
+				WebhookURL: "webhook.example.com/notify",
+				DisableTLS: true,
+			},
+			wantURL: "generic://webhook.example.com/notify?disabletls=yes&template=json",
+		},
+		{
 			name: "webhook with port",
 			config: models.GenericConfig{
 				WebhookURL: "https://webhook.example.com:8443/api/notify",
@@ -62,12 +84,12 @@ func TestBuildGenericURL(t *testing.T) {
 			wantURL: "generic://webhook.example.com/notify?disabletls=no&messagekey=body&template=json&titlekey=subject",
 		},
 		{
-			name: "webhook with DisableTLS",
+			name: "webhook with DisableTLS ignored for HTTPS",
 			config: models.GenericConfig{
 				WebhookURL: "https://webhook.example.com/notify",
 				DisableTLS: true,
 			},
-			wantURL: "generic://webhook.example.com/notify?disabletls=yes&template=json",
+			wantURL: "generic://webhook.example.com/notify?disabletls=no&template=json",
 		},
 		{
 			name: "webhook with single custom header",
@@ -227,7 +249,7 @@ func TestBuildGenericURL_DisableTLSFlag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := models.GenericConfig{
-				WebhookURL: "https://webhook.example.com/notify",
+				WebhookURL: "webhook.example.com/notify",
 				DisableTLS: tt.disableTLS,
 			}
 

--- a/frontend/src/lib/types/notification-providers.ts
+++ b/frontend/src/lib/types/notification-providers.ts
@@ -79,7 +79,6 @@ export interface GenericFormValues extends BaseProviderFormValues {
 	titleKey: string;
 	messageKey: string;
 	customHeaders: string;
-	disableTls: boolean;
 }
 
 export interface AppriseFormValues {
@@ -355,7 +354,6 @@ export function genericSettingsToFormValues(settings?: NotificationSettings): Ge
 		titleKey: (cfg?.titleKey as string) || 'title',
 		messageKey: (cfg?.messageKey as string) || 'message',
 		customHeaders: customHeadersStr,
-		disableTls: (cfg?.disableTls as boolean) ?? false,
 		eventImageUpdate: events?.image_update ?? true,
 		eventContainerUpdate: events?.container_update ?? true
 	};
@@ -414,7 +412,6 @@ export function genericFormValuesToSettings(values: GenericFormValues): Notifica
 			titleKey: values.titleKey,
 			messageKey: values.messageKey,
 			customHeaders: customHeaders,
-			disableTls: values.disableTls,
 			events: {
 				image_update: values.eventImageUpdate,
 				container_update: values.eventContainerUpdate

--- a/frontend/src/routes/(app)/settings/notifications/providers/GenericProviderForm.svelte
+++ b/frontend/src/routes/(app)/settings/notifications/providers/GenericProviderForm.svelte
@@ -7,8 +7,6 @@
 	import type { GenericFormValues } from '$lib/types/notification-providers';
 	import ProviderFormWrapper from './ProviderFormWrapper.svelte';
 	import EventSubscriptions from './EventSubscriptions.svelte';
-	import { Checkbox } from '$lib/components/ui/checkbox';
-	import { Label } from '$lib/components/ui/label';
 
 	interface Props {
 		values: GenericFormValues;
@@ -28,7 +26,6 @@
 			titleKey: z.string(),
 			messageKey: z.string(),
 			customHeaders: z.string(),
-			disableTls: z.boolean(),
 			eventImageUpdate: z.boolean(),
 			eventContainerUpdate: z.boolean()
 		})
@@ -131,17 +128,6 @@
 		autocomplete="off"
 		helpText={m.notifications_generic_custom_headers_help()}
 	/>
-
-	<div class="flex items-center space-x-2">
-		<Checkbox id="generic-disable-tls" bind:checked={values.disableTls} {disabled} />
-		<Label
-			for="generic-disable-tls"
-			class="text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-		>
-			{m.notifications_generic_disable_tls_label()}
-		</Label>
-	</div>
-	<p class="text-muted-foreground -mt-1 text-xs">{m.notifications_generic_disable_tls_help()}</p>
 
 	<EventSubscriptions
 		providerId="generic"


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1497

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


This PR fixes issue #1497 where generic webhooks ignored port numbers and only used the TLS toggle to determine ports (443/80). The solution refactors URL handling to respect the user-provided URL scheme (http/https) and port directly, while using the `DisableTLS` flag only as a fallback for schemeless URLs.

**Key changes:**
- Backend now parses URLs to extract scheme and port from user input, falling back to inferring scheme from `DisableTLS` only when no scheme is present
- TLS setting is now determined by the URL scheme (`http` → `disabletls=yes`, `https` → `disabletls=no`) rather than the `DisableTLS` config field
- Frontend removes the TLS toggle entirely, making the URL scheme the single source of truth
- Comprehensive test coverage added for schemeless URLs with/without ports

**Testing:**
Tests cover all scenarios including `https://host:8443`, `http://host:8000`, `host:8080` (defaults to https), and `host` (defaults based on `DisableTLS`).


</details>
<details open><summary><h3>Confidence Score: 4/5</h3></summary>


- Safe to merge with one minor consideration for backward compatibility
- The implementation correctly fixes the port handling issue and has comprehensive test coverage. The logic for parsing URLs and determining TLS settings is sound. However, this is a breaking change for existing users who have `https://` URLs but set `DisableTLS=true` - they will now use HTTPS instead of HTTP. The PR correctly changes this behavior (as indicated by the updated test case), but existing configurations may need migration.
- No files require special attention - the implementation is clean and well-tested
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/utils/notifications/generic_sender.go | Revised URL parsing to respect scheme and port from user input; `DisableTLS` now only acts as fallback for schemeless URLs |
| backend/internal/utils/notifications/generic_sender_test.go | Added comprehensive test cases for schemeless URLs with/without ports and updated test for `DisableTLS` being ignored when explicit scheme is provided |
| frontend/src/lib/types/notification-providers.ts | Removed `disableTls` field from `GenericFormValues` interface and related conversion functions |
| frontend/src/routes/(app)/settings/notifications/providers/GenericProviderForm.svelte | Removed `disableTls` checkbox and related UI components from the form |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->