### PR TITLE
refactor: cleanup unused setting key/values on startup

### DIFF
--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -81,6 +81,7 @@ func Bootstrap(ctx context.Context) error {
 		appServices.User.CreateDefaultAdmin,
 		appServices.Settings.MigrateOidcConfigToFields,
 		appServices.Notification.MigrateDiscordWebhookUrlToFields)
+	utils.CleanupUnknownSettings(appCtx, appServices.Settings)
 
 	// Handle agent auto-pairing with API key
 	if cfg.AgentMode && cfg.AgentToken != "" && cfg.ManagerApiUrl != "" {

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -159,7 +159,12 @@ func migrateDatabase(driver database.Driver, dbProvider string) error {
 	}
 
 	if errors.Is(err, migrate.ErrNoChange) {
-		slog.Info("Database schema is up to date")
+		version, dirty, versionErr := m.Version()
+		if versionErr != nil {
+			slog.Info("Database schema is up to date")
+		} else {
+			slog.Info("Database schema is up to date", "migrationVersion", version, "dirty", dirty)
+		}
 	} else {
 		slog.Info("Database migrations completed successfully")
 	}

--- a/backend/internal/utils/bootstrap_util.go
+++ b/backend/internal/utils/bootstrap_util.go
@@ -33,6 +33,10 @@ type SettingsManager interface {
 	EnsureDefaultSettings(ctx context.Context) error
 }
 
+type SettingsPruner interface {
+	PruneUnknownSettings(ctx context.Context) error
+}
+
 func InitializeDefaultSettings(ctx context.Context, cfg *config.Config, settingsMgr SettingsManager) {
 	slog.InfoContext(ctx, "Ensuring default settings are initialized")
 
@@ -46,6 +50,12 @@ func InitializeDefaultSettings(ctx context.Context, cfg *config.Config, settings
 		slog.WarnContext(ctx, "Failed to persist env-driven settings", "error", err.Error())
 	} else {
 		slog.DebugContext(ctx, "Persisted env-driven settings")
+	}
+}
+
+func CleanupUnknownSettings(ctx context.Context, settingsMgr SettingsPruner) {
+	if err := settingsMgr.PruneUnknownSettings(ctx); err != nil {
+		slog.ErrorContext(ctx, "Failed to prune unknown settings", "error", err.Error())
 	}
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


This PR implements a cleanup mechanism to remove stale/unknown setting keys from the database on application startup. The implementation uses reflection to extract all valid setting keys from the `models.Settings` struct and deletes any database entries that don't match.

**Key changes:**
- Adds `PruneUnknownSettings()` method that deletes settings not defined in `models.Settings` or the `encryptionKey` special case
- Uses reflection to dynamically build the allowed keys list from struct tags
- Includes comprehensive test coverage verifying both deletion of unknown keys and preservation of valid ones
- Cleanup runs after migrations and default settings initialization in the bootstrap process
- Improves database migration logging to include version and dirty flag

The implementation correctly handles all settings defined in `models.Settings`, including timeout settings, OIDC endpoints, job intervals, and internal keys, as they all have proper `key` struct tags.


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-tested, and follows Go best practices. All valid settings from `models.Settings` are correctly preserved via reflection-based key extraction. The cleanup runs at the appropriate time during bootstrap, and error handling is proper. The test coverage confirms expected behavior.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/settings_service.go | Adds `PruneUnknownSettings` method and `allowedSettingKeys` helper to clean up stale database settings |
| backend/internal/services/settings_service_test.go | Adds comprehensive test for prune functionality, verifying known keys are preserved and unknown keys are deleted |
| backend/internal/bootstrap/bootstrap.go | Calls cleanup function after migrations and default settings initialization |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->