### PR TITLE
feat: arcane-cli device code authentication

### DIFF
--- a/backend/internal/models/settings.go
+++ b/backend/internal/models/settings.go
@@ -72,23 +72,24 @@ type Settings struct {
 	DockerHost                 SettingVariable `key:"dockerHost,public,envOverride" meta:"label=Docker Host;type=text;keywords=docker,host,daemon,socket,unix,remote;category=internal;description=URI for Docker daemon"`
 
 	// Security category
-	AuthLocalEnabled          SettingVariable `key:"authLocalEnabled,public" meta:"label=Local Authentication;type=boolean;keywords=local,auth,authentication,username,password,login,credentials;category=security;description=Enable local username/password authentication" catmeta:"id=security;title=Security;icon=shield;url=/settings/security;description=Manage authentication and security settings"`
-	AuthSessionTimeout        SettingVariable `key:"authSessionTimeout" meta:"label=Session Timeout;type=number;keywords=session,timeout,expire,duration,lifetime,minutes,logout;category=security;description=How long user sessions remain active"`
-	AuthPasswordPolicy        SettingVariable `key:"authPasswordPolicy" meta:"label=Password Policy;type=select;keywords=password,policy,strength,complexity,requirements,security,rules;category=security;description=Set password strength requirements"`
-	AuthOidcConfig            SettingVariable `key:"authOidcConfig,sensitive,deprecated" meta:"label=OIDC Config;type=text;keywords=oidc,config,client,id,issuer,secret,oauth;category=security;description=OIDC provider configuration (deprecated - use individual fields)"`
-	OidcEnabled               SettingVariable `key:"oidcEnabled,public,envOverride" meta:"label=OIDC Authentication;type=boolean;keywords=oidc,openid,connect,sso,oauth,external,provider,federation;category=security;description=Enable OpenID Connect (OIDC) authentication"`
-	OidcClientId              SettingVariable `key:"oidcClientId,public,envOverride" meta:"label=OIDC Client ID;type=text;keywords=oidc,client,id,oauth,openid;category=security;description=OIDC provider client ID"`
-	OidcClientSecret          SettingVariable `key:"oidcClientSecret,sensitive,envOverride" meta:"label=OIDC Client Secret;type=password;keywords=oidc,client,secret,oauth,openid;category=security;description=OIDC provider client secret"`
-	OidcIssuerUrl             SettingVariable `key:"oidcIssuerUrl,public,envOverride" meta:"label=OIDC Issuer URL;type=text;keywords=oidc,issuer,url,oauth,openid,provider;category=security;description=OIDC provider issuer URL"`
-	OidcAuthorizationEndpoint SettingVariable `key:"oidcAuthorizationEndpoint,envOverride" meta:"label=OIDC Authorization Endpoint;type=text;keywords=oidc,authorization,endpoint,oauth,openid;category=security;description=Override OIDC authorization endpoint"`
-	OidcTokenEndpoint         SettingVariable `key:"oidcTokenEndpoint,envOverride" meta:"label=OIDC Token Endpoint;type=text;keywords=oidc,token,endpoint,oauth,openid;category=security;description=Override OIDC token endpoint"`
-	OidcUserinfoEndpoint      SettingVariable `key:"oidcUserinfoEndpoint,envOverride" meta:"label=OIDC Userinfo Endpoint;type=text;keywords=oidc,userinfo,endpoint,oauth,openid;category=security;description=Override OIDC userinfo endpoint"`
-	OidcJwksEndpoint          SettingVariable `key:"oidcJwksEndpoint,envOverride" meta:"label=OIDC JWKS Endpoint;type=text;keywords=oidc,jwks,keys,endpoint,oauth,openid;category=security;description=Override OIDC JWKS endpoint"`
-	OidcScopes                SettingVariable `key:"oidcScopes,public,envOverride" meta:"label=OIDC Scopes;type=text;keywords=oidc,scopes,oauth,openid,permissions;category=security;description=OIDC scopes to request"`
-	OidcAdminClaim            SettingVariable `key:"oidcAdminClaim,public,envOverride" meta:"label=OIDC Admin Claim;type=text;keywords=oidc,admin,claim,role,group;category=security;description=Claim name for admin role mapping"`
-	OidcAdminValue            SettingVariable `key:"oidcAdminValue,public,envOverride" meta:"label=OIDC Admin Value;type=text;keywords=oidc,admin,value,role,group;category=security;description=Claim value that grants admin access"`
-	OidcSkipTlsVerify         SettingVariable `key:"oidcSkipTlsVerify,public,envOverride" meta:"label=OIDC Skip TLS Verify;type=boolean;keywords=oidc,tls,verify,skip,insecure;category=security;description=Skip TLS verification for OIDC provider"`
-	OidcMergeAccounts         SettingVariable `key:"oidcMergeAccounts,public,envOverride" meta:"label=OIDC Account Merging;type=boolean;keywords=oidc,merge,link,accounts,email,match,existing,users,combine;category=security;description=Allow OIDC logins to merge with existing accounts by email"`
+	AuthLocalEnabled                SettingVariable `key:"authLocalEnabled,public" meta:"label=Local Authentication;type=boolean;keywords=local,auth,authentication,username,password,login,credentials;category=security;description=Enable local username/password authentication" catmeta:"id=security;title=Security;icon=shield;url=/settings/security;description=Manage authentication and security settings"`
+	AuthSessionTimeout              SettingVariable `key:"authSessionTimeout" meta:"label=Session Timeout;type=number;keywords=session,timeout,expire,duration,lifetime,minutes,logout;category=security;description=How long user sessions remain active"`
+	AuthPasswordPolicy              SettingVariable `key:"authPasswordPolicy" meta:"label=Password Policy;type=select;keywords=password,policy,strength,complexity,requirements,security,rules;category=security;description=Set password strength requirements"`
+	AuthOidcConfig                  SettingVariable `key:"authOidcConfig,sensitive,deprecated" meta:"label=OIDC Config;type=text;keywords=oidc,config,client,id,issuer,secret,oauth;category=security;description=OIDC provider configuration (deprecated - use individual fields)"`
+	OidcEnabled                     SettingVariable `key:"oidcEnabled,public,envOverride" meta:"label=OIDC Authentication;type=boolean;keywords=oidc,openid,connect,sso,oauth,external,provider,federation;category=security;description=Enable OpenID Connect (OIDC) authentication"`
+	OidcClientId                    SettingVariable `key:"oidcClientId,public,envOverride" meta:"label=OIDC Client ID;type=text;keywords=oidc,client,id,oauth,openid;category=security;description=OIDC provider client ID"`
+	OidcClientSecret                SettingVariable `key:"oidcClientSecret,sensitive,envOverride" meta:"label=OIDC Client Secret;type=password;keywords=oidc,client,secret,oauth,openid;category=security;description=OIDC provider client secret"`
+	OidcIssuerUrl                   SettingVariable `key:"oidcIssuerUrl,public,envOverride" meta:"label=OIDC Issuer URL;type=text;keywords=oidc,issuer,url,oauth,openid,provider;category=security;description=OIDC provider issuer URL"`
+	OidcAuthorizationEndpoint       SettingVariable `key:"oidcAuthorizationEndpoint,envOverride" meta:"label=OIDC Authorization Endpoint;type=text;keywords=oidc,authorization,endpoint,oauth,openid;category=security;description=Override OIDC authorization endpoint"`
+	OidcTokenEndpoint               SettingVariable `key:"oidcTokenEndpoint,envOverride" meta:"label=OIDC Token Endpoint;type=text;keywords=oidc,token,endpoint,oauth,openid;category=security;description=Override OIDC token endpoint"`
+	OidcUserinfoEndpoint            SettingVariable `key:"oidcUserinfoEndpoint,envOverride" meta:"label=OIDC Userinfo Endpoint;type=text;keywords=oidc,userinfo,endpoint,oauth,openid;category=security;description=Override OIDC userinfo endpoint"`
+	OidcJwksEndpoint                SettingVariable `key:"oidcJwksEndpoint,envOverride" meta:"label=OIDC JWKS Endpoint;type=text;keywords=oidc,jwks,keys,endpoint,oauth,openid;category=security;description=Override OIDC JWKS endpoint"`
+	OidcDeviceAuthorizationEndpoint SettingVariable `key:"oidcDeviceAuthorizationEndpoint,envOverride" meta:"label=OIDC Device Authorization Endpoint;type=text;keywords=oidc,device,authorization,endpoint,oauth,openid,cli;category=security;description=Override OIDC device authorization endpoint for CLI authentication"`
+	OidcScopes                      SettingVariable `key:"oidcScopes,public,envOverride" meta:"label=OIDC Scopes;type=text;keywords=oidc,scopes,oauth,openid,permissions;category=security;description=OIDC scopes to request"`
+	OidcAdminClaim                  SettingVariable `key:"oidcAdminClaim,public,envOverride" meta:"label=OIDC Admin Claim;type=text;keywords=oidc,admin,claim,role,group;category=security;description=Claim name for admin role mapping"`
+	OidcAdminValue                  SettingVariable `key:"oidcAdminValue,public,envOverride" meta:"label=OIDC Admin Value;type=text;keywords=oidc,admin,value,role,group;category=security;description=Claim value that grants admin access"`
+	OidcSkipTlsVerify               SettingVariable `key:"oidcSkipTlsVerify,public,envOverride" meta:"label=OIDC Skip TLS Verify;type=boolean;keywords=oidc,tls,verify,skip,insecure;category=security;description=Skip TLS verification for OIDC provider"`
+	OidcMergeAccounts               SettingVariable `key:"oidcMergeAccounts,public,envOverride" meta:"label=OIDC Account Merging;type=boolean;keywords=oidc,merge,link,accounts,email,match,existing,users,combine;category=security;description=Allow OIDC logins to merge with existing accounts by email"`
 
 	// Appearance category
 	MobileNavigationMode       SettingVariable `key:"mobileNavigationMode,public,local" meta:"label=Mobile Navigation Mode;type=select;keywords=mode,style,type,floating,docked,position,layout,design,appearance,bottom;category=appearance;description=Choose between floating or docked navigation on mobile" catmeta:"id=appearance;title=Appearance;icon=appearance;url=/settings/appearance;description=Customize navigation, theme, and interface behavior"`
@@ -267,10 +268,11 @@ type OidcConfig struct {
 	IssuerURL    string `json:"issuerUrl"`
 	Scopes       string `json:"scopes"`
 
-	AuthorizationEndpoint string `json:"authorizationEndpoint,omitempty"`
-	TokenEndpoint         string `json:"tokenEndpoint,omitempty"`
-	UserinfoEndpoint      string `json:"userinfoEndpoint,omitempty"`
-	JwksURI               string `json:"jwksUri,omitempty"`
+	AuthorizationEndpoint       string `json:"authorizationEndpoint,omitempty"`
+	TokenEndpoint               string `json:"tokenEndpoint,omitempty"`
+	UserinfoEndpoint            string `json:"userinfoEndpoint,omitempty"`
+	JwksURI                     string `json:"jwksUri,omitempty"`
+	DeviceAuthorizationEndpoint string `json:"deviceAuthorizationEndpoint,omitempty"`
 
 	// Admin mapping: evaluate this claim to grant admin.
 	// Examples:

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -86,17 +86,18 @@ func (s *AuthService) getAuthSettings(ctx context.Context) (*AuthSettings, error
 
 	if authSettings.OidcEnabled {
 		oidcConfig := &models.OidcConfig{
-			ClientID:              settings.OidcClientId.Value,
-			ClientSecret:          settings.OidcClientSecret.Value,
-			IssuerURL:             settings.OidcIssuerUrl.Value,
-			AuthorizationEndpoint: settings.OidcAuthorizationEndpoint.Value,
-			TokenEndpoint:         settings.OidcTokenEndpoint.Value,
-			UserinfoEndpoint:      settings.OidcUserinfoEndpoint.Value,
-			JwksURI:               settings.OidcJwksEndpoint.Value,
-			Scopes:                settings.OidcScopes.Value,
-			AdminClaim:            settings.OidcAdminClaim.Value,
-			AdminValue:            settings.OidcAdminValue.Value,
-			SkipTlsVerify:         settings.OidcSkipTlsVerify.IsTrue(),
+			ClientID:                    settings.OidcClientId.Value,
+			ClientSecret:                settings.OidcClientSecret.Value,
+			IssuerURL:                   settings.OidcIssuerUrl.Value,
+			AuthorizationEndpoint:       settings.OidcAuthorizationEndpoint.Value,
+			TokenEndpoint:               settings.OidcTokenEndpoint.Value,
+			UserinfoEndpoint:            settings.OidcUserinfoEndpoint.Value,
+			JwksURI:                     settings.OidcJwksEndpoint.Value,
+			DeviceAuthorizationEndpoint: settings.OidcDeviceAuthorizationEndpoint.Value,
+			Scopes:                      settings.OidcScopes.Value,
+			AdminClaim:                  settings.OidcAdminClaim.Value,
+			AdminValue:                  settings.OidcAdminValue.Value,
+			SkipTlsVerify:               settings.OidcSkipTlsVerify.IsTrue(),
 		}
 
 		if oidcConfig.ClientID != "" || oidcConfig.IssuerURL != "" {

--- a/backend/internal/utils/stringutils/stringutils.go
+++ b/backend/internal/utils/stringutils/stringutils.go
@@ -44,3 +44,12 @@ func TrimQuotes(s string) string {
 	}
 	return s
 }
+
+func GetStringOrDefault(m map[string]any, key, defaultValue string) string {
+	if val, ok := m[key]; ok {
+		if str, ok := val.(string); ok {
+			return str
+		}
+	}
+	return defaultValue
+}

--- a/cli/internal/types/endpoints.go
+++ b/cli/internal/types/endpoints.go
@@ -18,10 +18,12 @@ type ArcaneApiEndpoints struct {
 	AuthRefreshEndpoint  string
 
 	// OIDC
-	OIDCStatusEndpoint   string
-	OIDCConfigEndpoint   string
-	OIDCUrlEndpoint      string
-	OIDCCallbackEndpoint string
+	OIDCStatusEndpoint      string
+	OIDCConfigEndpoint      string
+	OIDCUrlEndpoint         string
+	OIDCCallbackEndpoint    string
+	OIDCDeviceCodeEndpoint  string
+	OIDCDeviceTokenEndpoint string
 
 	// API Keys
 	ApiKeysEndpoint string
@@ -176,10 +178,12 @@ var Endpoints = ArcaneApiEndpoints{
 	AuthRefreshEndpoint:  "/api/auth/refresh",
 
 	// OIDC
-	OIDCStatusEndpoint:   "/api/oidc/status",
-	OIDCConfigEndpoint:   "/api/oidc/config",
-	OIDCUrlEndpoint:      "/api/oidc/url",
-	OIDCCallbackEndpoint: "/api/oidc/callback",
+	OIDCStatusEndpoint:      "/api/oidc/status",
+	OIDCConfigEndpoint:      "/api/oidc/config",
+	OIDCUrlEndpoint:         "/api/oidc/url",
+	OIDCCallbackEndpoint:    "/api/oidc/callback",
+	OIDCDeviceCodeEndpoint:  "/api/oidc/device/code",
+	OIDCDeviceTokenEndpoint: "/api/oidc/device/token",
 
 	// API Keys
 	ApiKeysEndpoint: "/api/api-keys",
@@ -327,10 +331,12 @@ func (e ArcaneApiEndpoints) AuthPassword() string { return e.AuthPasswordEndpoin
 func (e ArcaneApiEndpoints) AuthRefresh() string  { return e.AuthRefreshEndpoint }
 
 // OIDC endpoints
-func (e ArcaneApiEndpoints) OIDCStatus() string   { return e.OIDCStatusEndpoint }
-func (e ArcaneApiEndpoints) OIDCConfig() string   { return e.OIDCConfigEndpoint }
-func (e ArcaneApiEndpoints) OIDCUrl() string      { return e.OIDCUrlEndpoint }
-func (e ArcaneApiEndpoints) OIDCCallback() string { return e.OIDCCallbackEndpoint }
+func (e ArcaneApiEndpoints) OIDCStatus() string      { return e.OIDCStatusEndpoint }
+func (e ArcaneApiEndpoints) OIDCConfig() string      { return e.OIDCConfigEndpoint }
+func (e ArcaneApiEndpoints) OIDCUrl() string         { return e.OIDCUrlEndpoint }
+func (e ArcaneApiEndpoints) OIDCCallback() string    { return e.OIDCCallbackEndpoint }
+func (e ArcaneApiEndpoints) OIDCDeviceCode() string  { return e.OIDCDeviceCodeEndpoint }
+func (e ArcaneApiEndpoints) OIDCDeviceToken() string { return e.OIDCDeviceTokenEndpoint }
 
 // API Key endpoints
 func (e ArcaneApiEndpoints) ApiKeys() string         { return e.ApiKeysEndpoint }

--- a/types/auth/oidc.go
+++ b/types/auth/oidc.go
@@ -159,6 +159,11 @@ type OidcConfigResponse struct {
 	// Required: true
 	UserinfoEndpoint string `json:"userinfoEndpoint"`
 
+	// DeviceAuthorizationEndpoint is the URL of the device authorization endpoint.
+	//
+	// Required: false
+	DeviceAuthorizationEndpoint string `json:"deviceAuthorizationEndpoint,omitempty"`
+
 	// Scopes is the space-separated list of OAuth scopes requested.
 	//
 	// Required: true
@@ -180,6 +185,83 @@ type OidcCallbackRequest struct {
 
 // OidcCallbackResponse contains the response from OIDC callback processing.
 type OidcCallbackResponse struct {
+	// Success indicates if the authentication was successful.
+	//
+	// Required: true
+	Success bool `json:"success"`
+
+	// Token is the JWT access token.
+	//
+	// Required: true
+	Token string `json:"token"`
+
+	// RefreshToken is the refresh token for obtaining new access tokens.
+	//
+	// Required: true
+	RefreshToken string `json:"refreshToken"`
+
+	// ExpiresAt is the expiration time of the access token.
+	//
+	// Required: true
+	ExpiresAt time.Time `json:"expiresAt"`
+
+	// User contains the authenticated user information.
+	//
+	// Required: true
+	User user.User `json:"user"`
+}
+
+// OidcDeviceAuthRequest is used to request a device authorization code.
+type OidcDeviceAuthRequest struct {
+	// RedirectUri is optional and kept for consistency with other auth flows.
+	//
+	// Required: false
+	RedirectUri string `json:"redirectUri,omitempty"`
+}
+
+// OidcDeviceAuthResponse contains the device authorization response.
+type OidcDeviceAuthResponse struct {
+	// DeviceCode is the device verification code.
+	//
+	// Required: true
+	DeviceCode string `json:"deviceCode"`
+
+	// UserCode is the end-user verification code.
+	//
+	// Required: true
+	UserCode string `json:"userCode"`
+
+	// VerificationUri is the end-user verification URI.
+	//
+	// Required: true
+	VerificationUri string `json:"verificationUri"`
+
+	// VerificationUriComplete is the end-user verification URI with user code included.
+	//
+	// Required: false
+	VerificationUriComplete string `json:"verificationUriComplete,omitempty"`
+
+	// ExpiresIn is the lifetime of the device_code and user_code in seconds.
+	//
+	// Required: true
+	ExpiresIn int `json:"expiresIn"`
+
+	// Interval is the minimum polling interval in seconds.
+	//
+	// Required: false
+	Interval int `json:"interval,omitempty"`
+}
+
+// OidcDeviceTokenRequest is used to exchange a device code for tokens.
+type OidcDeviceTokenRequest struct {
+	// DeviceCode is the device verification code from the authorization response.
+	//
+	// Required: true
+	DeviceCode string `json:"deviceCode"`
+}
+
+// OidcDeviceTokenResponse contains the response from device token exchange.
+type OidcDeviceTokenResponse struct {
 	// Success indicates if the authentication was successful.
 	//
 	// Required: true


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


This PR implements OAuth 2.0 Device Authorization Grant (RFC 8628) for CLI authentication, allowing users to authenticate the arcane-cli tool via a browser-based device code flow.

**Key changes:**
- Added two new API endpoints: `/api/oidc/device/code` (initiate flow) and `/api/oidc/device/token` (exchange device code)
- Implemented device authorization flow in `OidcService` with discovery support for the device authorization endpoint
- Added configuration support for device authorization endpoint with environment variable override
- Used `url.Values` for proper URL encoding in all HTTP requests (addressing previous review feedback)
- Added safe type extraction helper `GetStringOrDefault` for map[string]any responses
- Implemented proper error handling for OAuth error codes (`authorization_pending`, `slow_down`, `expired_token`, `access_denied`)

**Implementation notes:**
- The flow reuses existing authentication logic (`OidcLogin`, `verifyIDToken`, `buildUserInfo`) for consistency
- Device authorization endpoint is discovered from OIDC provider metadata if not explicitly configured
- Token exchange requests properly handle all standard OAuth device flow error responses
- CLI endpoints added to support the device authentication workflow


</details>
<details open><summary><h3>Confidence Score: 4/5</h3></summary>


- This PR is safe to merge with proper testing of the device authorization flow
- The implementation follows OAuth 2.0 RFC 8628 standards and reuses existing authentication patterns. URL encoding issues from previous reviews have been addressed. The code properly handles error cases and uses type-safe assertions. Score is 4 (not 5) because device authorization flows should be tested with actual OIDC providers to ensure compatibility
- backend/internal/services/oidc_service.go should be tested with multiple OIDC providers to ensure device authorization endpoint discovery works correctly
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/oidc_service.go | Implements device authorization flow with proper URL encoding and type assertions; addresses previous review comments about URL encoding |
| backend/internal/huma/handlers/oidc.go | Adds two new endpoints for device authorization flow with proper error handling and HTTP status codes |
| types/auth/oidc.go | Adds properly documented type definitions for device authorization request/response models |

</details>


</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - GoLang Best Practices

---
description: 'Instructions for writing Go code following idiomatic Go pra... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->