### PR TITLE
fix: dashboard stats showing container limits

### DIFF
--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -124,7 +124,7 @@ func setupRouter(cfg *config.Config, appServices *Services) *gin.Engine {
 	})
 
 	// Remaining Gin handlers (WebSocket/streaming)
-	api.NewWebSocketHandler(apiGroup, appServices.Project, appServices.Container, appServices.System, authMiddleware, cfg)
+	api.NewWebSocketHandler(apiGroup, appServices.Project, appServices.Container, appServices.System, appServices.Docker, authMiddleware, cfg)
 
 	if cfg.Environment != "production" {
 		for _, registerFunc := range registerPlaywrightRoutes {

--- a/backend/internal/huma/handlers/system.go
+++ b/backend/internal/huma/handlers/system.go
@@ -12,7 +12,6 @@ import (
 	humamw "github.com/getarcaneapp/arcane/backend/internal/huma/middleware"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/getarcaneapp/arcane/backend/internal/services"
-	"github.com/getarcaneapp/arcane/backend/internal/utils/docker"
 	"github.com/getarcaneapp/arcane/types/base"
 	containertypes "github.com/getarcaneapp/arcane/types/container"
 	"github.com/getarcaneapp/arcane/types/dockerinfo"
@@ -279,25 +278,6 @@ func (h *SystemHandler) GetDockerInfo(ctx context.Context, input *GetDockerInfoI
 	if err != nil {
 		return nil, huma.Error500InternalServerError((&common.DockerInfoError{Err: err}).Error())
 	}
-
-	cpuCount := info.NCPU
-	memTotal := info.MemTotal
-
-	// Check for cgroup limits (LXC, Docker, etc.)
-	if cgroupLimits, err := docker.DetectCgroupLimits(); err == nil {
-		if limit := cgroupLimits.MemoryLimit; limit > 0 {
-			limitInt := int64(limit)
-			if memTotal == 0 || limitInt < memTotal {
-				memTotal = limitInt
-			}
-		}
-		if cgroupLimits.CPUCount > 0 && (cpuCount == 0 || cgroupLimits.CPUCount < cpuCount) {
-			cpuCount = cgroupLimits.CPUCount
-		}
-	}
-
-	info.NCPU = cpuCount
-	info.MemTotal = memTotal
 
 	return &GetDockerInfoOutput{
 		Body: dockerinfo.Info{


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1110

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


This PR refactors the memory stats collection to prioritize Docker API data over cgroup detection. It introduces a new `getHostInfo()` method with 5-minute caching and moves limit detection logic from the REST endpoint into the WebSocket handler for centralized control.

**Key Changes:**
- Added `getHostInfo()` method to fetch CPU and memory limits from Docker API with caching
- Removed cgroup detection from `GetDockerInfo()` REST endpoint  
- Modified `collectSystemStats()` to try Docker API first, falling back to `applyCgroupLimits()`
- Injected `DockerClientService` into WebSocketHandler

**Issue Identified:**
The memory usage scaling logic assumes host memory usage scales proportionally to container memory limits, which produces inaccurate percentages in memory-constrained containers. Using actual cgroup memory usage values (when available) would be more accurate than proportional scaling.


</details>
<details open><summary><h3>Confidence Score: 2/5</h3></summary>


- This PR has a critical logic issue with memory usage calculation that will produce inaccurate stats in containerized environments
- The memory usage scaling approach (line 613) is fundamentally flawed for container scenarios. It assumes host-wide memory usage scales proportionally to container limits, but actual container memory usage may differ significantly. This defeats the purpose of the fix. The fallback to `applyCgroupLimits()` correctly uses actual cgroup memory usage values when Docker API is unavailable, but the primary path uses incorrect scaling. This will continue to show inaccurate memory percentages in many containerized deployments.
- backend/internal/api/ws_handler.go - Memory usage scaling logic needs to use actual container memory usage instead of proportional scaling
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/api/ws_handler.go | Added Docker API integration to WebSocketHandler with caching. However, the memory usage scaling logic (line 613) proportionally scales host memory usage to container limits, which may not accurately reflect actual container memory usage. Should use cgroup memory usage values instead when available, similar to applyCgroupLimits(). |
| backend/internal/bootstrap/router_bootstrap.go | Simple parameter addition to pass dockerService to WebSocketHandler constructor. No issues found. |
| backend/internal/huma/handlers/system.go | Removed cgroup limit detection from REST endpoint. Changes are correct - limit detection is now handled in WebSocket handler only. |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->