### PR TITLE
fix: use image pull timeout for project pull

### DIFF
--- a/backend/internal/huma/handlers/projects.go
+++ b/backend/internal/huma/handlers/projects.go
@@ -700,10 +700,16 @@ func (h *ProjectHandler) PullProjectImages(ctx context.Context, input *PullProje
 
 			if err := h.projectService.PullProjectImages(humaCtx.Context(), input.ProjectID, writer, nil); err != nil {
 				_, _ = fmt.Fprintf(writer, `{"error":%q}`+"\n", err.Error())
+				if f, ok := writer.(http.Flusher); ok {
+					f.Flush()
+				}
 				return
 			}
 
 			_, _ = writer.Write([]byte(`{"status":"complete"}` + "\n"))
+			if f, ok := writer.(http.Flusher); ok {
+				f.Flush()
+			}
 		},
 	}, nil
 }


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work

<details open><summary><h3>Greptile Summary</h3></summary>


This PR adds timeout handling for Docker image pull operations and ensures HTTP response flushing in streaming endpoints.

**Key changes:**
- Added configurable timeout support for `PullProjectImages` and `EnsureProjectImagesPresent` methods using the `DOCKER_IMAGE_PULL_TIMEOUT` setting
- Implemented proper context cancellation with defer cleanup pattern (addressing previous review feedback)
- Added deadline exceeded detection to provide users with clear timeout error messages
- Added HTTP response flushing to ensure streaming responses are sent without buffering delays

**Code quality:**
- Follows existing timeout patterns established in the codebase (consistent with `container_service.go`)
- Properly scopes context with anonymous function pattern to ensure cleanup happens for each image
- Uses idiomatic Go practices with defer for resource cleanup


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge. It adds well-implemented timeout handling for Docker operations and proper HTTP flushing, with no functional issues or regressions detected.
- The changes are focused, well-implemented, and address a real operational need (preventing indefinite hangs on image pulls). The code follows established patterns in the codebase, properly handles resource cleanup with defer, and correctly implements streaming response flushing. The timeout detection provides better error messages to users. The implementation is consistent with Go best practices and the project's existing timeout utilities.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/huma/handlers/projects.go | Added HTTP response flushing after writing error and success messages to ensure streaming responses are sent immediately to clients without buffering delays. |
| backend/internal/services/project_service.go | Added Docker image pull timeout handling using configurable settings. Properly uses defer for context cancellation cleanup, detects timeout errors for better error messages, and maintains consistency with existing timeout patterns in the codebase. |

</details>


</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - GoLang Best Practices

---
description: 'Instructions for writing Go code following idiomatic Go pra... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->