### PR TITLE
fix: allow HTTP_PROXY and HTTPS_PROXY environment variables

### DIFF
--- a/backend/internal/services/container_registry_service.go
+++ b/backend/internal/services/container_registry_service.go
@@ -45,10 +45,14 @@ type ContainerRegistryService struct {
 }
 
 func NewContainerRegistryService(db *database.DB) *ContainerRegistryService {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = http.ProxyFromEnvironment
+
 	return &ContainerRegistryService{
 		db: db,
 		httpClient: &http.Client{
-			Timeout: registryCheckTimeout,
+			Timeout:   registryCheckTimeout,
+			Transport: transport,
 		},
 		cache: make(map[string]*cache.Cache[string]),
 	}

--- a/backend/internal/utils/registry/client.go
+++ b/backend/internal/utils/registry/client.go
@@ -10,5 +10,8 @@ type Client struct {
 }
 
 func NewClient() *Client {
-	return &Client{http: &http.Client{}}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = http.ProxyFromEnvironment
+
+	return &Client{http: &http.Client{Transport: transport}}
 }


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/944

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>


This PR enables proxy support for container registry connections by configuring HTTP clients to respect `HTTP_PROXY` and `HTTPS_PROXY` environment variables. The fix addresses issue #944 where users behind corporate proxies could not connect to registries like docker.io.

Changes:
- Modified `registry.NewClient()` to clone `DefaultTransport` and set `Proxy` to `http.ProxyFromEnvironment`
- Updated `ContainerRegistryService` constructor to use the same proxy-aware transport configuration
- Both changes follow the existing pattern in `backend/internal/utils/http/client.go` which already uses `ProxyFromEnvironment`

The implementation is consistent with Go's standard library conventions and matches the existing proxy configuration pattern used elsewhere in the codebase.


</details>
<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The changes are minimal, follow existing patterns in the codebase, and use standard library functions correctly. The implementation matches the proxy configuration pattern already used in `utils/http/client.go`, ensuring consistency. No breaking changes or security concerns identified.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/utils/registry/client.go | Added `ProxyFromEnvironment` to HTTP transport for proxy support |
| backend/internal/services/container_registry_service.go | Configured HTTP client with proxy-aware transport for registry operations |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->