### PR TITLE
fix: allow job schedules to be changed per environment

### DIFF
--- a/backend/internal/huma/huma.go
+++ b/backend/internal/huma/huma.go
@@ -351,7 +351,7 @@ func registerHandlers(api huma.API, svc *Services) {
 	handlers.RegisterImages(api, dockerSvc, imageSvc, imageUpdateSvc, settingsSvc)
 	handlers.RegisterImageUpdates(api, imageUpdateSvc)
 	handlers.RegisterSettings(api, settingsSvc, settingsSearchSvc, environmentSvc, cfg)
-	handlers.RegisterJobSchedules(api, jobScheduleSvc)
+	handlers.RegisterJobSchedules(api, jobScheduleSvc, environmentSvc)
 	handlers.RegisterVolumes(api, dockerSvc, volumeSvc)
 	handlers.RegisterContainers(api, containerSvc, dockerSvc)
 	handlers.RegisterNetworks(api, networkSvc, dockerSvc)

--- a/backend/internal/middleware/environment_middleware.go
+++ b/backend/internal/middleware/environment_middleware.go
@@ -30,6 +30,8 @@ const (
 	managementEndpointAgentPair      = "/agent/pair"
 	managementEndpointVersion        = "/version"
 	managementEndpointSettings       = "/settings"
+	managementEndpointJobSchedules   = "/job-schedules"
+	managementEndpointJobs           = "/jobs"
 
 	errEnvironmentNotFound      = "Environment not found"
 	errEnvironmentDisabled      = "Environment is disabled"
@@ -179,6 +181,8 @@ func (m *EnvironmentMiddleware) hasResourcePath(c *gin.Context, envID string) bo
 		managementEndpointAgentPair,
 		managementEndpointVersion,
 		managementEndpointSettings,
+		managementEndpointJobSchedules,
+		managementEndpointJobs,
 	}
 
 	for _, endpoint := range managementEndpoints {

--- a/frontend/src/lib/components/job-card/job-card.svelte
+++ b/frontend/src/lib/components/job-card/job-card.svelte
@@ -14,6 +14,7 @@
 
 	let {
 		job,
+		environmentId = '0',
 		isAgent = false,
 		onScheduleUpdate,
 		children,
@@ -21,6 +22,7 @@
 		headerAccessory
 	}: {
 		job: JobStatus;
+		environmentId?: string;
 		isAgent?: boolean;
 		onScheduleUpdate?: () => void;
 		children?: Snippet;
@@ -47,7 +49,7 @@
 		if (!canRun) return;
 
 		isRunning = true;
-		const result = await tryCatch(jobScheduleService.runJob(job.id));
+		const result = await tryCatch(jobScheduleService.runJob(job.id, environmentId));
 		isRunning = false;
 
 		if (result.error || !result.data?.success) {
@@ -137,5 +139,5 @@
 </Card.Root>
 
 {#if showScheduleDialog}
-	<JobScheduleDialog {job} bind:open={showScheduleDialog} onUpdate={handleScheduleUpdated} />
+	<JobScheduleDialog {job} {environmentId} bind:open={showScheduleDialog} onUpdate={handleScheduleUpdated} />
 {/if}

--- a/frontend/src/lib/components/job-card/job-schedule-dialog.svelte
+++ b/frontend/src/lib/components/job-card/job-schedule-dialog.svelte
@@ -11,10 +11,12 @@
 
 	let {
 		job,
+		environmentId = '0',
 		open = $bindable(false),
 		onUpdate
 	}: {
 		job: JobStatus;
+		environmentId?: string;
 		open?: boolean;
 		onUpdate?: () => void;
 	} = $props();
@@ -58,7 +60,7 @@
 
 		isLoading = true;
 		const update = { [job.settingsKey]: scheduleValue };
-		const result = await tryCatch(jobScheduleService.updateJobSchedules(update));
+		const result = await tryCatch(jobScheduleService.updateJobSchedules(update, environmentId));
 		isLoading = false;
 
 		if (result.error) {

--- a/frontend/src/lib/services/job-schedule-service.ts
+++ b/frontend/src/lib/services/job-schedule-service.ts
@@ -2,20 +2,20 @@ import BaseAPIService from './api-service';
 import type { JobSchedules, JobSchedulesUpdate, JobListResponse, JobRunResponse } from '$lib/types/job-schedule.type';
 
 class JobScheduleService extends BaseAPIService {
-	async getJobSchedules(): Promise<JobSchedules> {
-		return this.handleResponse(this.api.get('/job-schedules'));
+	async getJobSchedules(environmentId: string = '0'): Promise<JobSchedules> {
+		return this.handleResponse(this.api.get(`/environments/${environmentId}/job-schedules`));
 	}
 
-	async updateJobSchedules(update: JobSchedulesUpdate): Promise<JobSchedules> {
-		return this.handleResponse(this.api.put('/job-schedules', update));
+	async updateJobSchedules(update: JobSchedulesUpdate, environmentId: string = '0'): Promise<JobSchedules> {
+		return this.handleResponse(this.api.put(`/environments/${environmentId}/job-schedules`, update));
 	}
 
-	async listJobs(): Promise<JobListResponse> {
-		return this.handleResponse(this.api.get('/jobs'));
+	async listJobs(environmentId: string = '0'): Promise<JobListResponse> {
+		return this.handleResponse(this.api.get(`/environments/${environmentId}/jobs`));
 	}
 
-	async runJob(jobId: string): Promise<JobRunResponse> {
-		return this.handleResponse(this.api.post(`/jobs/${jobId}/run`));
+	async runJob(jobId: string, environmentId: string = '0'): Promise<JobRunResponse> {
+		return this.handleResponse(this.api.post(`/environments/${environmentId}/jobs/${jobId}/run`));
 	}
 }
 

--- a/frontend/src/lib/types/job-schedule.type.ts
+++ b/frontend/src/lib/types/job-schedule.type.ts
@@ -2,6 +2,10 @@ export type JobSchedules = {
 	environmentHealthInterval: string;
 	eventCleanupInterval: string;
 	analyticsHeartbeatInterval: string;
+	autoUpdateInterval: string;
+	pollingInterval: string;
+	scheduledPruneInterval: string;
+	gitopsSyncInterval: string;
 };
 
 export type JobSchedulesUpdate = Partial<JobSchedules>;

--- a/frontend/src/routes/(app)/environments/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/environments/[id]/+page.svelte
@@ -38,40 +38,54 @@
 
 	let activeTab = $state('details');
 
-	const tabItems: TabItem[] = [
-		{
-			value: 'details',
-			label: m.environments_overview_title(),
-			icon: EnvironmentsIcon
-		},
-		{
-			value: 'general',
-			label: m.general_title(),
-			icon: SettingsIcon
-		},
-		{
-			value: 'docker',
-			label: m.environments_docker_settings_title(),
-			icon: DockerBrandIcon
-		},
-		{
-			value: 'jobs',
-			label: m.jobs_title(),
-			icon: JobsIcon
-		},
-		{
-			value: 'agent',
-			label: m.environments_agent_config_title(),
-			icon: ApiKeyIcon
-		},
-		{
+	const tabItems = $derived.by((): TabItem[] => {
+		const items: TabItem[] = [
+			{
+				value: 'details',
+				label: m.environments_overview_title(),
+				icon: EnvironmentsIcon
+			},
+			{
+				value: 'general',
+				label: m.general_title(),
+				icon: SettingsIcon
+			},
+			{
+				value: 'docker',
+				label: m.environments_docker_settings_title(),
+				icon: DockerBrandIcon
+			},
+			{
+				value: 'jobs',
+				label: m.jobs_title(),
+				icon: JobsIcon
+			}
+		];
+
+		if (environment.id !== '0') {
+			items.push({
+				value: 'agent',
+				label: m.environments_agent_config_title(),
+				icon: ApiKeyIcon
+			});
+		}
+
+		items.push({
 			value: 'gitops',
 			label: m.git_syncs_title(),
 			icon: GitBranchIcon
-		}
-	];
+		});
 
-	const tabValues = new Set(tabItems.map((tab) => tab.value));
+		return items;
+	});
+
+	const tabValues = $derived(new Set(tabItems.map((tab) => tab.value)));
+
+	$effect(() => {
+		if (!tabValues.has(activeTab)) {
+			activeTab = 'details';
+		}
+	});
 
 	$effect(() => {
 		const tabFromUrl = page.url.searchParams.get('tab');

--- a/types/jobschedule/jobschedule.go
+++ b/types/jobschedule/jobschedule.go
@@ -10,6 +10,10 @@ type Config struct {
 	EnvironmentHealthInterval  string `json:"environmentHealthInterval"`
 	EventCleanupInterval       string `json:"eventCleanupInterval"`
 	AnalyticsHeartbeatInterval string `json:"analyticsHeartbeatInterval"`
+	AutoUpdateInterval         string `json:"autoUpdateInterval"`
+	PollingInterval            string `json:"pollingInterval"`
+	ScheduledPruneInterval     string `json:"scheduledPruneInterval"`
+	GitopsSyncInterval         string `json:"gitopsSyncInterval"`
 }
 
 // Update is used to update job schedule intervals (in minutes).
@@ -19,6 +23,10 @@ type Update struct {
 	EnvironmentHealthInterval  *string `json:"environmentHealthInterval,omitempty"`
 	EventCleanupInterval       *string `json:"eventCleanupInterval,omitempty"`
 	AnalyticsHeartbeatInterval *string `json:"analyticsHeartbeatInterval,omitempty"`
+	AutoUpdateInterval         *string `json:"autoUpdateInterval,omitempty"`
+	PollingInterval            *string `json:"pollingInterval,omitempty"`
+	ScheduledPruneInterval     *string `json:"scheduledPruneInterval,omitempty"`
+	GitopsSyncInterval         *string `json:"gitopsSyncInterval,omitempty"`
 }
 
 // JobStatus represents the current status and metadata for a background job.


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables per-environment job schedule configuration by routing job schedule API calls through environment-specific paths (`/environments/{id}/job-schedules` and `/environments/{id}/jobs`). 

**Key changes:**
- Backend handlers now accept environment ID and proxy requests to remote agents when ID != "0"
- Added four new job schedule fields: `autoUpdateInterval`, `pollingInterval`, `scheduledPruneInterval`, and `gitopsSyncInterval`
- Removed `AgentMode` check from schedule updates to allow per-environment configuration
- Frontend components pass `environmentId` through the component tree to API service calls
- Conditionally hide the Agent tab for local environment (ID "0")
- Job list is now sorted by ID for stable UI ordering

The implementation follows a consistent pattern: when the environment ID is "0" (local), operations execute locally; otherwise, requests are proxied to the remote agent using the existing `EnvironmentService.ProxyRequest` infrastructure.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge
- The implementation is clean, well-structured, and follows established patterns in the codebase. The code correctly handles environment-based routing, maintains backward compatibility, and includes proper error handling throughout. No security issues, logic errors, or problematic patterns were identified.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/huma/handlers/job_schedules.go | Added environment-based routing for job schedules - all endpoints now include environment ID parameter and proxy requests to remote agents when ID != "0" |
| backend/internal/services/job_service.go | Added four new job schedule fields and sorted job list by ID for stable UI ordering; removed AgentMode check from updates to allow per-environment configuration |
| backend/internal/middleware/environment_middleware.go | Added `/job-schedules` and `/jobs` to management endpoints list to prevent them from being proxied through middleware |
| frontend/src/lib/services/job-schedule-service.ts | Updated all API methods to include environment ID in URL path, defaulting to '0' for local environment |
| frontend/src/routes/(app)/environments/[id]/components/JobsTab.svelte | Added environment ID parameter to job service calls; improved loading UX by only showing spinner on first load and preserving previous data on refresh errors |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->