### PR TITLE
fix: pre-mature pull completed message in popover

### DIFF
--- a/frontend/src/lib/components/progress-popover.svelte
+++ b/frontend/src/lib/components/progress-popover.svelte
@@ -15,7 +15,9 @@
 		getPullPhase,
 		getLayerStats,
 		showImageLayersState,
-		isIndeterminatePhase
+		isIndeterminatePhase,
+		getAggregatePullPhase,
+		getAggregateStatus
 	} from '$lib/utils/pull-progress';
 	import { DownloadIcon, BoxIcon, ArrowDownIcon, VerifiedCheckIcon, CloseIcon } from '$lib/icons';
 	import { IsMobile } from '$lib/hooks/is-mobile.svelte.js';
@@ -90,8 +92,14 @@
 	const isIndeterminate = $derived(isIndeterminatePhase(layers, progress));
 	const isIndeterminateGeneric = $derived(mode !== 'pull' && loading && !isComplete && !error);
 
+	// Derive aggregate status for display
+	const aggregateStatus = $derived(getAggregateStatus(layers, statusText, hasReachedComplete || isComplete));
+
 	// Derive the current phase from status text using utility (pull-mode only)
 	const currentPhase = $derived.by((): PullPhase => {
+		if (Object.keys(layers).length > 0) {
+			return getAggregatePullPhase(layers, hasReachedComplete || isComplete, !!error);
+		}
 		return getPullPhase(statusText, hasReachedComplete || isComplete, !!error);
 	});
 
@@ -163,14 +171,14 @@
 				{#if error}
 					{error}
 				{:else if mode !== 'pull'}
-					{statusText || subtitle}
+					{aggregateStatus || subtitle}
 				{:else if layerStats.total > 0}
-					{statusText || subtitle}
+					{aggregateStatus || subtitle}
 					<span class="text-muted-foreground">
 						· {m.progress_layers_status({ completed: layerStats.completed, total: layerStats.total })}</span
 					>
 				{:else}
-					{hasReachedComplete ? 100 : percent}% · {statusText || subtitle}
+					{hasReachedComplete ? 100 : percent}% · {aggregateStatus || subtitle}
 				{/if}
 			</Item.Description>
 		</Item.Content>

--- a/frontend/src/lib/components/sheets/image-pull-sheet.svelte
+++ b/frontend/src/lib/components/sheets/image-pull-sheet.svelte
@@ -20,7 +20,8 @@
 		getLayerStats,
 		getPullPhase,
 		showImageLayersState,
-		isIndeterminatePhase
+		isIndeterminatePhase,
+		getAggregateStatus
 	} from '$lib/utils/pull-progress';
 	import { ArrowDownIcon, SuccessIcon, DownloadIcon } from '$lib/icons';
 
@@ -50,8 +51,8 @@
 	let layerProgress = $state<Record<string, LayerProgress>>({});
 	let hasReachedComplete = $state(false);
 	let currentImageName = $state('');
-
 	const layerStats = $derived(getLayerStats(layerProgress, hasReachedComplete));
+	const aggregateStatus = $derived(getAggregateStatus(layerProgress, pullStatusText, hasReachedComplete));
 	const showPullUI = $derived(isPulling || hasReachedComplete || !!pullError);
 	const isIndeterminate = $derived(isIndeterminatePhase(layerProgress, pullProgress));
 	let prevOpen = $state(false);
@@ -249,9 +250,15 @@
 								{#if hasReachedComplete}
 									{m.progress_pull_completed()}
 								{:else if layerStats.total > 0}
-									{m.progress_layers_status({ completed: layerStats.completed, total: layerStats.total })}
+									<span class="flex items-center gap-1.5">
+										<span>{aggregateStatus}</span>
+										<span class="text-muted-foreground font-normal">•</span>
+										<span class="text-muted-foreground font-normal">
+											{m.progress_layers_status({ completed: layerStats.completed, total: layerStats.total })}
+										</span>
+									</span>
 								{:else}
-									{pullStatusText || m.common_action_pulling()}
+									{aggregateStatus || m.common_action_pulling()}
 								{/if}
 							</p>
 							{#if !isIndeterminate || hasReachedComplete}


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1549

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes issue #1549 by preventing premature "Pull complete" messages during Docker image pulls. The solution centralizes status detection logic and introduces aggregate status calculation based on all layer states rather than relying on a single status text string.

**Key improvements:**
- Refined `isLayerComplete()` to only recognize true completion statuses (`pull complete`, `already exists`, `downloaded newer image`, `image is up to date`)
- Refactored `calculateOverallProgress()` to use weighted layer states (extracting: 95%, verifying: 92%, download complete: 85%, downloading: up to 85%)
- Added `getAggregateStatus()` and `getAggregatePullPhase()` functions to compute accurate status from all layers
- Updated UI components to use aggregate status instead of raw `statusText`, ensuring consistent and accurate progress display
- Simplified `areAllLayersComplete()` to use the centralized `isLayerComplete()` function
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The changes are well-structured and solve the premature completion message issue by centralizing status logic. The refactoring improves code maintainability by using aggregate functions instead of relying on individual status text, and the weighted progress calculation provides more accurate feedback.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/utils/pull-progress.ts | Refactored progress calculation to use weighted layer states and added aggregate status functions to prevent premature completion messages |
| frontend/src/lib/components/progress-popover.svelte | Integrated new aggregate status and phase functions to display accurate pull progress status |
| frontend/src/lib/components/sheets/image-pull-sheet.svelte | Updated to use aggregate status function for consistent pull progress display |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->