### PR TITLE
fix: spinner not centered on oidc callback page

### DIFF
--- a/frontend/src/routes/(auth)/oidc/callback/+page.svelte
+++ b/frontend/src/routes/(auth)/oidc/callback/+page.svelte
@@ -119,14 +119,14 @@
 
 <div class="bg-background flex min-h-screen items-center justify-center">
 	<div class="w-full max-w-md space-y-8">
-		<div class="text-center">
+		<div class="flex flex-col items-center text-center">
 			{#if isProcessing}
-				<Spinner />
+				<Spinner class="text-primary size-12" />
 				<h2 class="mt-6 text-2xl font-bold">{m.auth_processing_login()}</h2>
 				<p class="text-muted-foreground mt-2 text-sm">{m.auth_processing_login_description()}</p>
 			{:else if error}
-				<div class="text-destructive">
-					<svg class="mx-auto h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<div class="text-destructive flex flex-col items-center">
+					<svg class="h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 						<path
 							stroke-linecap="round"
 							stroke-linejoin="round"

--- a/frontend/src/routes/(auth)/oidc/login/+page.svelte
+++ b/frontend/src/routes/(auth)/oidc/login/+page.svelte
@@ -4,6 +4,7 @@
 	import { page } from '$app/state';
 	import { m } from '$lib/paraglide/messages';
 	import { authService } from '$lib/services/auth-service';
+	import { Spinner } from '$lib/components/ui/spinner/index.js';
 
 	let isRedirecting = $state(true);
 	let error = $state('');
@@ -43,14 +44,14 @@
 
 <div class="bg-background flex min-h-screen items-center justify-center">
 	<div class="w-full max-w-md space-y-8">
-		<div class="text-center">
+		<div class="flex flex-col items-center text-center">
 			{#if isRedirecting && !error}
-				<div class="border-primary mx-auto h-12 w-12 animate-spin rounded-full border-b-2"></div>
+				<Spinner class="text-primary size-12" />
 				<h2 class="mt-6 text-2xl font-bold">{m.auth_oidc_redirecting_title()}</h2>
 				<p class="text-muted-foreground mt-2 text-sm">{m.auth_oidc_redirecting_description()}</p>
 			{:else if error}
-				<div class="text-destructive">
-					<svg class="mx-auto h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<div class="text-destructive flex flex-col items-center">
+					<svg class="h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 						<path
 							stroke-linecap="round"
 							stroke-linejoin="round"


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

Fixed spinner centering issues on OIDC authentication pages by adding proper flexbox layout to parent containers.

**Key changes:**
- Added `flex flex-col items-center` to parent divs to properly center child elements
- Replaced custom spinner implementation in login page with reusable `Spinner` component
- Added explicit sizing (`size-12`) and color (`text-primary`) to Spinner components for consistency
- Removed `mx-auto` from error SVG icons in favor of flex-based centering
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no risks
- The changes are purely cosmetic UI fixes that improve visual consistency. The code follows Svelte 5 conventions, uses the proper reusable Spinner component, and applies standard Tailwind flexbox utilities for centering. No logic changes, no security concerns, and the implementation is clean and maintainable.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/routes/(auth)/oidc/callback/+page.svelte | Fixed spinner centering by adding flex container and explicit sizing/color to Spinner component |
| frontend/src/routes/(auth)/oidc/login/+page.svelte | Replaced custom spinner div with Spinner component and fixed centering with flex container |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->