### PR TITLE
fix: oidc validation missing fileds making it unable to save

### DIFF
--- a/backend/internal/huma/handlers/settings.go
+++ b/backend/internal/huma/handlers/settings.go
@@ -290,7 +290,8 @@ func (h *SettingsHandler) UpdateSettings(ctx context.Context, input *UpdateSetti
 			req.OidcClientSecret != nil || req.OidcIssuerUrl != nil ||
 			req.OidcScopes != nil || req.OidcAdminClaim != nil ||
 			req.OidcAdminValue != nil || req.OidcMergeAccounts != nil ||
-			req.OidcSkipTlsVerify != nil {
+			req.OidcSkipTlsVerify != nil || req.OidcAutoRedirectToProvider != nil ||
+			req.OidcProviderName != nil || req.OidcProviderLogoUrl != nil {
 			return nil, huma.Error403Forbidden((&common.AuthSettingsUpdateError{}).Error())
 		}
 

--- a/frontend/src/lib/utils/settings.util.ts
+++ b/frontend/src/lib/utils/settings.util.ts
@@ -9,7 +9,23 @@ const LOCAL_SETTING_KEYS = new Set([
 	'accentColor',
 	'mobileNavigationMode',
 	'mobileNavigationShowLabels',
-	'sidebarHoverExpansion'
+	'sidebarHoverExpansion',
+	'authLocalEnabled',
+	'authSessionTimeout',
+	'authPasswordPolicy',
+	'authOidcConfig',
+	'oidcEnabled',
+	'oidcMergeAccounts',
+	'oidcSkipTlsVerify',
+	'oidcAutoRedirectToProvider',
+	'oidcClientId',
+	'oidcClientSecret',
+	'oidcIssuerUrl',
+	'oidcScopes',
+	'oidcAdminClaim',
+	'oidcAdminValue',
+	'oidcProviderName',
+	'oidcProviderLogoUrl'
 ]);
 
 export function isLocalSetting(key: string): boolean {


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1583

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where three new OIDC settings (`oidcAutoRedirectToProvider`, `oidcProviderName`, `oidcProviderLogoUrl`) were not properly classified as auth settings, causing validation failures when attempting to save OIDC configuration.

- Backend: added validation checks for the three new OIDC fields to prevent updates on non-local environments (matching the pattern used for other auth settings)
- Frontend: added all auth-related settings to the `LOCAL_SETTING_KEYS` set to ensure they are routed to environment 0 (main instance) rather than remote environments

The changes are minimal, consistent with existing patterns, and correctly address the issue.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no risk
- The changes are straightforward bug fixes that add missing validation checks following established patterns in the codebase. Both files simply add the three new OIDC fields to existing validation lists, maintaining consistency with how other auth settings are handled. No logic changes, no new functionality, just completing an incomplete implementation.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/huma/handlers/settings.go | Added validation for three new OIDC fields (`OidcAutoRedirectToProvider`, `OidcProviderName`, `OidcProviderLogoUrl`) to prevent updates on non-local environments |
| frontend/src/lib/utils/settings.util.ts | Added all auth-related settings to `LOCAL_SETTING_KEYS` set, including the three new OIDC fields |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->