### PR TITLE
feat: sidebar keyboard shortcuts for easier and quicker navigation

### DIFF
--- a/frontend/src/lib/components/sidebar/sidebar-itemgroup.svelte
+++ b/frontend/src/lib/components/sidebar/sidebar-itemgroup.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import * as Collapsible from '$lib/components/ui/collapsible/index.js';
+	import * as Kbd from '$lib/components/ui/kbd/index.js';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { page } from '$app/state';
 	import { useSidebar } from '$lib/components/ui/sidebar/context.svelte.js';
+	import { formatShortcutKeys, type ShortcutKey } from '$lib/utils/keyboard-shortcut.utils';
 	import { ArrowRightIcon } from '$lib/icons';
 
 	let {
@@ -14,10 +16,12 @@
 			title: string;
 			url: string;
 			icon?: typeof ArrowRightIcon;
+			shortcut?: ShortcutKey[];
 			items?: {
 				title: string;
 				url: string;
 				icon?: typeof ArrowRightIcon;
+				shortcut?: ShortcutKey[];
 			}[];
 		}[];
 	} = $props();
@@ -66,6 +70,22 @@
 	}
 </script>
 
+{#snippet Shortcut({ keys }: { keys?: ShortcutKey[] })}
+	{@const displayKeys = keys ? formatShortcutKeys(keys) : []}
+	{#if displayKeys.length}
+		<Kbd.Group
+			class="text-muted-foreground ml-auto items-center gap-1 group-data-[collapsible=icon]:hidden group-data-[collapsible=icon]:group-data-[hovered=true]:inline-flex"
+		>
+			{#each displayKeys as key, index}
+				<Kbd.Root>{key}</Kbd.Root>
+				{#if index < displayKeys.length - 1}
+					<span class="text-muted-foreground/70 text-[10px]">+</span>
+				{/if}
+			{/each}
+		</Kbd.Group>
+	{/if}
+{/snippet}
+
 <Sidebar.Group>
 	<Sidebar.GroupLabel>{label}</Sidebar.GroupLabel>
 	<Sidebar.Menu>
@@ -82,6 +102,7 @@
 										<Icon />
 									{/if}
 									<span>{item.title}</span>
+									{@render Shortcut({ keys: item.shortcut })}
 								</a>
 							{/snippet}
 						</Sidebar.MenuButton>
@@ -103,6 +124,7 @@
 											<SubIcon />
 										{/if}
 										<span>{subItem.title}</span>
+										{@render Shortcut({ keys: subItem.shortcut })}
 									</a>
 								{/snippet}
 							</Sidebar.MenuButton>
@@ -133,6 +155,7 @@
 														<Icon />
 													{/if}
 													<span>{item.title}</span>
+													{@render Shortcut({ keys: item.shortcut })}
 													<ArrowRightIcon
 														class="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
 													/>
@@ -157,6 +180,7 @@
 																<SubIcon />
 															{/if}
 															<span>{subItem.title}</span>
+															{@render Shortcut({ keys: subItem.shortcut })}
 														</a>
 													{/snippet}
 												</Sidebar.MenuSubButton>
@@ -178,6 +202,7 @@
 									<Icon />
 								{/if}
 								<span>{item.title}</span>
+								{@render Shortcut({ keys: item.shortcut })}
 							</a>
 						{/snippet}
 					</Sidebar.MenuButton>

--- a/frontend/src/lib/components/ui/kbd/index.ts
+++ b/frontend/src/lib/components/ui/kbd/index.ts
@@ -1,0 +1,10 @@
+import Root from "./kbd.svelte";
+import Group from "./kbd-group.svelte";
+
+export {
+	Root,
+	Group,
+	//
+	Root as Kbd,
+	Group as KbdGroup,
+};

--- a/frontend/src/lib/components/ui/kbd/kbd-group.svelte
+++ b/frontend/src/lib/components/ui/kbd/kbd-group.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<kbd
+	bind:this={ref}
+	data-slot="kbd-group"
+	class={cn("inline-flex items-center gap-1", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</kbd>

--- a/frontend/src/lib/components/ui/kbd/kbd.svelte
+++ b/frontend/src/lib/components/ui/kbd/kbd.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<kbd
+	bind:this={ref}
+	data-slot="kbd"
+	class={cn(
+		"bg-muted text-muted-foreground pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm px-1 font-sans text-xs font-medium select-none",
+		"[&_svg:not([class*='size-'])]:size-3",
+		"[[data-slot=tooltip-content]_&]:bg-background/20 [[data-slot=tooltip-content]_&]:text-background dark:[[data-slot=tooltip-content]_&]:bg-background/10",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</kbd>

--- a/frontend/src/lib/config/navigation-config.ts
+++ b/frontend/src/lib/config/navigation-config.ts
@@ -18,43 +18,47 @@ import {
 	GitBranchIcon
 } from '$lib/icons';
 import { m } from '$lib/paraglide/messages';
+import type { ShortcutKey } from '$lib/utils/keyboard-shortcut.utils';
 
 export type NavigationItem = {
 	title: string;
 	url: string;
 	icon: any;
+	shortcut?: ShortcutKey[];
 	items?: NavigationItem[];
 };
 
 export const navigationItems: Record<string, NavigationItem[]> = {
 	managementItems: [
-		{ title: m.dashboard_title(), url: '/dashboard', icon: DashboardIcon },
-		{ title: m.projects_title(), url: '/projects', icon: ProjectsIcon },
-		{ title: m.environments_title(), url: '/environments', icon: EnvironmentsIcon },
-		{ title: m.customize_title(), url: '/customize', icon: CustomizeIcon }
+		{ title: m.dashboard_title(), url: '/dashboard', icon: DashboardIcon, shortcut: ['mod', '1'] },
+		{ title: m.projects_title(), url: '/projects', icon: ProjectsIcon, shortcut: ['mod', '2'] },
+		{ title: m.environments_title(), url: '/environments', icon: EnvironmentsIcon, shortcut: ['mod', '3'] },
+		{ title: m.customize_title(), url: '/customize', icon: CustomizeIcon, shortcut: ['mod', '4'] }
 	],
 	resourceItems: [
-		{ title: m.containers_title(), url: '/containers', icon: ContainersIcon },
-		{ title: m.images_title(), url: '/images', icon: ImagesIcon },
-		{ title: m.networks_title(), url: '/networks', icon: NetworksIcon },
-		{ title: m.volumes_title(), url: '/volumes', icon: VolumesIcon }
+		{ title: m.containers_title(), url: '/containers', icon: ContainersIcon, shortcut: ['mod', '5'] },
+		{ title: m.images_title(), url: '/images', icon: ImagesIcon, shortcut: ['mod', '6'] },
+		{ title: m.networks_title(), url: '/networks', icon: NetworksIcon, shortcut: ['mod', '7'] },
+		{ title: m.volumes_title(), url: '/volumes', icon: VolumesIcon, shortcut: ['mod', '8'] }
 	],
 	settingsItems: [
 		{
 			title: m.events_title(),
 			url: '/events',
-			icon: EventsIcon
+			icon: EventsIcon,
+			shortcut: ['mod', '9']
 		},
 		{
 			title: m.settings_title(),
 			url: '/settings',
 			icon: SettingsIcon,
+			shortcut: ['mod', '0'],
 			items: [
-				{ title: m.api_key_page_title(), url: '/settings/api-keys', icon: ApiKeyIcon },
-				{ title: m.appearance_title(), url: '/settings/appearance', icon: ApperanceIcon },
-				{ title: m.notifications_title(), url: '/settings/notifications', icon: NotificationsIcon },
-				{ title: m.security_title(), url: '/settings/security', icon: SecurityIcon },
-				{ title: m.users_title(), url: '/settings/users', icon: UsersIcon }
+				{ title: m.api_key_page_title(), url: '/settings/api-keys', icon: ApiKeyIcon, shortcut: ['mod', 'shift', '1'] },
+				{ title: m.appearance_title(), url: '/settings/appearance', icon: ApperanceIcon, shortcut: ['mod', 'shift', '2'] },
+				{ title: m.notifications_title(), url: '/settings/notifications', icon: NotificationsIcon, shortcut: ['mod', 'shift', '3'] },
+				{ title: m.security_title(), url: '/settings/security', icon: SecurityIcon, shortcut: ['mod', 'shift', '4'] },
+				{ title: m.users_title(), url: '/settings/users', icon: UsersIcon, shortcut: ['mod', 'shift', '5'] }
 			]
 		}
 	]
@@ -110,9 +114,10 @@ export function getManagementItems(environmentId: string): NavigationItem[] {
 	return [
 		...navigationItems.managementItems,
 		{
-			title: m.git_syncs_title?.() ?? 'Git Sync',
+			title: m.git_syncs_title(),
 			url: `/environments/${environmentId}/gitops`,
-			icon: GitBranchIcon
+			icon: GitBranchIcon,
+			shortcut: ['mod', 'g']
 		}
 	];
 }

--- a/frontend/src/lib/utils/keyboard-shortcut.utils.ts
+++ b/frontend/src/lib/utils/keyboard-shortcut.utils.ts
@@ -1,0 +1,70 @@
+import { browser } from '$app/environment';
+
+export type ShortcutKey = 'mod' | 'shift' | 'alt' | 'ctrl' | 'meta' | string;
+
+const MODIFIER_KEYS = new Set(['mod', 'shift', 'alt', 'ctrl', 'meta']);
+
+export function isMacOS(): boolean {
+	if (!browser) return false;
+	const platform = navigator?.platform?.toLowerCase() ?? '';
+	const userAgent = navigator?.userAgent?.toLowerCase() ?? '';
+	return platform.includes('mac') || userAgent.includes('mac');
+}
+
+export function formatShortcutKeys(keys: ShortcutKey[], isMac = isMacOS()): string[] {
+	return keys.map((key) => formatShortcutKey(key, isMac));
+}
+
+export function matchesShortcutEvent(keys: ShortcutKey[], event: KeyboardEvent, isMac = isMacOS()): boolean {
+	const normalizedKeys = keys.map((key) => key.toLowerCase());
+	const requiredModifiers = {
+		shift: normalizedKeys.includes('shift'),
+		alt: normalizedKeys.includes('alt'),
+		ctrl: normalizedKeys.includes('ctrl'),
+		meta: normalizedKeys.includes('meta'),
+		mod: normalizedKeys.includes('mod')
+	};
+
+	const requiredCtrl = requiredModifiers.ctrl || (!isMac && requiredModifiers.mod);
+	const requiredMeta = requiredModifiers.meta || (isMac && requiredModifiers.mod);
+	const requiredShift = requiredModifiers.shift;
+	const requiredAlt = requiredModifiers.alt;
+
+	if (event.shiftKey !== requiredShift) return false;
+	if (event.altKey !== requiredAlt) return false;
+	if (event.ctrlKey !== requiredCtrl) return false;
+	if (event.metaKey !== requiredMeta) return false;
+
+	const nonModifierKeys = normalizedKeys.filter((key) => !MODIFIER_KEYS.has(key));
+	if (nonModifierKeys.length !== 1) return false;
+
+	const key = event.key.toLowerCase();
+	if (MODIFIER_KEYS.has(key)) return false;
+
+	return key === nonModifierKeys[0];
+}
+
+export function isEditableTarget(target: EventTarget | null): boolean {
+	if (!(target instanceof HTMLElement)) return false;
+	const tagName = target.tagName.toLowerCase();
+	if (['input', 'textarea', 'select'].includes(tagName)) return true;
+	if (target.isContentEditable) return true;
+	return !!target.closest('[contenteditable="true"]');
+}
+
+function formatShortcutKey(key: ShortcutKey, isMac: boolean): string {
+	switch (key) {
+		case 'mod':
+			return isMac ? '⌘' : 'Ctrl';
+		case 'shift':
+			return isMac ? '⇧' : 'Shift';
+		case 'alt':
+			return isMac ? '⌥' : 'Alt';
+		case 'ctrl':
+			return isMac ? '⌃' : 'Ctrl';
+		case 'meta':
+			return isMac ? '⌘' : 'Win';
+		default:
+			return key.length === 1 ? key.toUpperCase() : key;
+	}
+}

--- a/frontend/src/routes/(app)/settings/+layout.svelte
+++ b/frontend/src/routes/(app)/settings/+layout.svelte
@@ -5,11 +5,13 @@
 	import { ArcaneButton } from '$lib/components/arcane-button/index.js';
 	import { SettingsIcon, ArrowRightIcon, ArrowLeftIcon } from '$lib/icons';
 	import { useSidebar } from '$lib/components/ui/sidebar/context.svelte.js';
+	import * as Kbd from '$lib/components/ui/kbd/index.js';
 	import { m } from '$lib/paraglide/messages';
 	import settingsStore from '$lib/stores/config-store';
 	import { IsMobile } from '$lib/hooks/is-mobile.svelte.js';
 	import { IsTablet } from '$lib/hooks/is-tablet.svelte.js';
 	import { getEffectiveNavigationSettings } from '$lib/utils/navigation.utils';
+	import { formatShortcutKeys, type ShortcutKey } from '$lib/utils/keyboard-shortcut.utils';
 	import { cn } from '$lib/utils';
 	import { navigationItems } from '$lib/config/navigation-config';
 	import MobileFloatingFormActions from '$lib/components/form/mobile-floating-form-actions.svelte';
@@ -38,7 +40,8 @@
 			settingsEntry?.items?.map((item) => ({
 				href: item.url,
 				label: item.title,
-				icon: item.icon
+				icon: item.icon,
+				shortcut: item.shortcut
 			})) ?? []
 		);
 	});
@@ -179,6 +182,20 @@
 	}
 </script>
 
+{#snippet Shortcut({ keys }: { keys?: ShortcutKey[] })}
+	{@const displayKeys = keys ? formatShortcutKeys(keys) : []}
+	{#if displayKeys.length}
+		<Kbd.Group class="text-muted-foreground ml-auto items-center gap-1">
+			{#each displayKeys as key, index}
+				<Kbd.Root>{key}</Kbd.Root>
+				{#if index < displayKeys.length - 1}
+					<span class="text-muted-foreground/70 text-[10px]">+</span>
+				{/if}
+			{/each}
+		</Kbd.Group>
+	{/if}
+{/snippet}
+
 <div class="flex h-full min-h-full flex-col md:flex-row">
 	<!-- Desktop Sidebar -->
 	<aside class={cn('relative hidden w-64 shrink-0 self-stretch md:block md:h-full md:min-h-full', 'backdrop-blur-sm')}>
@@ -197,6 +214,7 @@
 					>
 						<item.icon class="size-4" />
 						{item.label}
+						{@render Shortcut({ keys: item.shortcut })}
 					</a>
 				{/each}
 			</nav>


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds keyboard shortcuts to the sidebar navigation for faster navigation across the application. Users can now use `Cmd+1-9` (or `Ctrl+1-9` on Windows/Linux) to navigate to main sections, `Cmd+0` for settings, `Cmd+Shift+1-5` for settings subsections, and `Cmd+G` for git syncs.

**Key changes:**
- Created new `Kbd` UI components for displaying keyboard shortcuts
- Added keyboard shortcut utilities for event matching and platform-specific formatting
- Implemented global keyboard shortcut handler in app layout with proper safeguards (ignores mobile/tablet, editable fields)
- Enhanced navigation config with shortcut definitions for all navigation items
- Updated sidebar components to display shortcuts next to menu items

**Issue found:**
- `settings/+layout.svelte` updates `$state` inside `$effect` block, violating Svelte 5 runes best practices (custom rule 8e0bee41)
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with one Svelte 5 runes violation that should be addressed
- The implementation is solid with proper event handling, platform detection, and UI integration. However, the `$state` update inside `$effect` in settings layout violates Svelte 5 best practices and needs fixing to prevent potential re-render issues
- frontend/src/routes/(app)/settings/+layout.svelte needs the `$effect` block refactored to use `$derived` instead of updating `$state`
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/utils/keyboard-shortcut.utils.ts | New utility file providing keyboard shortcut helpers for matching events and formatting display keys |
| frontend/src/lib/config/navigation-config.ts | Added keyboard shortcuts to navigation items (Cmd+1-9, Cmd+0, Cmd+Shift+1-5, Cmd+G) |
| frontend/src/routes/(app)/+layout.svelte | Implements global keyboard shortcut handler with navigation logic and editable target exclusion |
| frontend/src/routes/(app)/settings/+layout.svelte | Displays shortcuts in settings sidebar, contains `$state` updates in `$effect` block (rule 8e0bee41) |

</details>


</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - What: Avoid updating `$state` inside `$effect` blocks; use `$derived` for computed values instead.

... ([source](https://app.greptile.com/review/custom-context?memory=8e0bee41-b073-4a49-a01c-2c2c8782b420))

<!-- /greptile_comment -->