### PR TITLE
fix: certain jobs not being adding to job scheduler

### DIFF
--- a/backend/pkg/scheduler/scheduler.go
+++ b/backend/pkg/scheduler/scheduler.go
@@ -49,7 +49,7 @@ func (js *JobScheduler) StartScheduler() {
 			slog.InfoContext(js.context, "Job finished", "name", currentJob.Name())
 		})
 		if err != nil {
-			slog.ErrorContext(js.context, "Failed to schedule job", "name", currentJob.Name(), "error", err)
+			slog.ErrorContext(js.context, "Failed to schedule job", "name", currentJob.Name(), "schedule", schedule, "error", err)
 			continue
 		}
 


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where certain background jobs (`imagePollingJob`, `autoUpdateJob`, `scheduledPruneJob`, and `gitOpsSyncJob`) were not being dynamically rescheduled when their interval settings changed at runtime.

**Key changes:**
- Refactored `setupJobScheduleCallbacks` to accept all job instances and added switch cases for previously missing jobs (`pollingInterval`, `autoUpdateInterval`, `scheduledPruneInterval`, `gitopsSyncInterval`)
- Extracted callback logic into new `handleJobScheduleChange` helper function to improve code organization
- Added cron expression validation in `scheduled_prune_job.go` to catch invalid schedules early and fall back to a safe default
- Enhanced error logging in `scheduler.go` to include the schedule string for better debugging

The changes ensure all registered jobs can be rescheduled when their settings change without requiring a full application restart, improving the system's runtime configurability.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The changes are well-structured and fix a legitimate bug where jobs weren't being rescheduled. The refactoring improves code organization, adds validation for cron expressions, and enhances logging. All changes follow Go best practices and maintain consistency with existing patterns in the codebase.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/bootstrap/jobs_bootstrap.go | Refactored job scheduling callbacks to handle all jobs dynamically, fixing missing job reschedule handlers for `imagePollingJob`, `autoUpdateJob`, `scheduledPruneJob`, and `gitOpsSyncJob` |
| backend/pkg/scheduler/scheduled_prune_job.go | Added cron expression validation to prevent invalid schedules from being registered, improving robustness and error handling |
| backend/pkg/scheduler/scheduler.go | Enhanced error logging to include the schedule string, making it easier to debug job scheduling failures |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->