### PR TITLE
fix: container exec sessions not being cleaned up after websockets close

### DIFF
--- a/frontend/src/lib/components/terminal/terminal.svelte
+++ b/frontend/src/lib/components/terminal/terminal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, onDestroy } from 'svelte';
+	import { onMount } from 'svelte';
 	import { Terminal } from '@xterm/xterm';
 	import { FitAddon } from '@xterm/addon-fit';
 	import '@xterm/xterm/css/xterm.css';
@@ -24,6 +24,7 @@
 	let ws: WebSocket | null = null;
 	let isReconnecting = false;
 	let resizeObserver: ResizeObserver | null = null;
+	let isReady = $state(false);
 
 	const darkTheme = {
 		background: '#09090b',
@@ -165,8 +166,8 @@
 
 	onMount(() => {
 		initializeTerminal();
-		connectWebSocket();
 		window.addEventListener('resize', handleResize);
+		isReady = true;
 
 		return () => {
 			window.removeEventListener('resize', handleResize);
@@ -178,7 +179,7 @@
 	});
 
 	$effect(() => {
-		if (websocketUrl && terminal) {
+		if (isReady && websocketUrl && terminal) {
 			terminal.clear();
 			connectWebSocket();
 		}
@@ -190,12 +191,6 @@
 		}
 	});
 
-	onDestroy(() => {
-		resizeObserver?.disconnect();
-		isReconnecting = true;
-		ws?.close();
-		terminal?.dispose();
-	});
 </script>
 
 <div bind:this={container} class="terminal-container h-full w-full" style="height: {height}"></div>


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1597

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes container exec sessions not being cleaned up after WebSocket connections close by introducing proper lifecycle management for Docker exec sessions.

**Key Changes:**
- Introduced `ExecSession` struct in `container_service.go` with `sync.Once`-protected cleanup to ensure sessions are properly terminated when WebSockets close
- Refactored `ws_handler.go` exec handling into smaller internal functions with explicit cleanup via defer and context watching
- Added graceful shell termination (Ctrl-D + exit command) before closing the hijacked connection
- Fixed frontend terminal component to properly handle cleanup in `onMount` return instead of separate `onDestroy` hook
- Uses `context.Background()` for cleanup timeout to ensure cleanup proceeds even when parent context is cancelled

The implementation correctly handles double-cleanup scenarios (both defer and context watcher can call cleanup) by using `sync.Once` in `ExecSession.Close`.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with minor naming convention violations that should be addressed
- The core logic is sound with proper resource cleanup, sync.Once protection, and graceful termination. However, multiple unexported functions lack the required "Internal" suffix per project conventions, which are already noted in previous review threads.
- `backend/internal/api/ws_handler.go` requires attention for naming convention compliance
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/api/ws_handler.go | Refactored exec handling into separate internal functions with proper cleanup via defer and context watching |
| backend/internal/services/container_service.go | Introduced `ExecSession` struct to manage exec lifecycle with proper cleanup including graceful shell termination |
| frontend/src/lib/components/terminal/terminal.svelte | Removed redundant `onDestroy` hook and moved cleanup to `onMount` return, using `isReady` flag to control WebSocket connection timing |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->