### PR TITLE
fix: mismtached memory counts based on cached memory

### DIFF
--- a/frontend/src/lib/components/meter-metric.svelte
+++ b/frontend/src/lib/components/meter-metric.svelte
@@ -14,6 +14,7 @@
 		loading?: boolean;
 		showAbsoluteValues?: boolean;
 		formatAbsoluteValue?: (value: number) => string;
+		formatUsageValue?: (value: number) => string;
 	}
 
 	let {
@@ -26,10 +27,16 @@
 		icon,
 		loading = false,
 		showAbsoluteValues = false,
-		formatAbsoluteValue = (v) => v.toString()
+		formatAbsoluteValue = (v) => v.toString(),
+		formatUsageValue
 	}: Props = $props();
 
 	const percentage = $derived(currentValue !== undefined && !loading && maxValue > 0 ? (currentValue / maxValue) * 100 : 0);
+	const usageValueText = $derived.by(() => {
+		if (currentValue === undefined) return m.common_na();
+		if (formatUsageValue) return formatUsageValue(currentValue);
+		return `${percentage.toFixed(1)}%`;
+	});
 </script>
 
 <Card.Root class="flex h-full flex-col">
@@ -67,7 +74,7 @@
 					<div class="flex items-center gap-2 whitespace-nowrap">
 						<div class="bg-primary size-2 shrink-0 rounded-full"></div>
 						<span class="text-muted-foreground text-xs">{m.dashboard_meter_usage()}</span>
-						<span class="text-foreground text-sm font-semibold tabular-nums">{percentage.toFixed(1)}%</span>
+						<span class="text-foreground text-sm font-semibold tabular-nums">{usageValueText}</span>
 					</div>
 					{#if showAbsoluteValues && currentValue !== undefined && maxValue !== undefined && formatAbsoluteValue}
 						<div class="flex items-center gap-2 whitespace-nowrap">

--- a/frontend/src/lib/utils/container-stats.utils.ts
+++ b/frontend/src/lib/utils/container-stats.utils.ts
@@ -16,7 +16,7 @@ export function calculateCPUPercent(stats: ContainerStats | null): number {
 export function calculateMemoryPercent(stats: ContainerStats | null): number {
 	if (!stats?.memory_stats) return 0;
 
-	const usage = stats.memory_stats.usage || 0;
+	const usage = calculateMemoryUsage(stats);
 	const limit = stats.memory_stats.limit || 0;
 
 	if (limit > 0) {
@@ -24,4 +24,12 @@ export function calculateMemoryPercent(stats: ContainerStats | null): number {
 		return Math.min(Math.max(percent, 0), 100);
 	}
 	return 0;
+}
+
+export function calculateMemoryUsage(stats: ContainerStats | null): number {
+	if (!stats?.memory_stats) return 0;
+
+	const usage = stats.memory_stats.usage || 0;
+	const inactiveFile = stats.memory_stats.stats?.inactive_file || 0;
+	return Math.max(usage - inactiveFile, 0);
 }

--- a/frontend/src/routes/(app)/containers/[containerId]/+page.svelte
+++ b/frontend/src/routes/(app)/containers/[containerId]/+page.svelte
@@ -26,6 +26,7 @@
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import IconImage from '$lib/components/icon-image.svelte';
 	import { getArcaneIconUrlFromLabels } from '$lib/utils/arcane-labels';
+	import { calculateMemoryUsage } from '$lib/utils/container-stats.utils';
 	import {
 		ArrowLeftIcon,
 		AlertIcon,
@@ -162,7 +163,7 @@
 		}
 		return stats?.cpu_stats?.online_cpus || 0;
 	});
-	const memoryUsageBytes = $derived(stats?.memory_stats?.usage || 0);
+	const memoryUsageBytes = $derived(calculateMemoryUsage(stats));
 	const memoryLimitBytes = $derived(stats?.memory_stats?.limit || 0);
 	const memoryUsageFormatted = $derived(bytes.format(memoryUsageBytes || 0) || '0 B');
 	const memoryLimitFormatted = $derived(bytes.format(memoryLimitBytes || 0) || '0 B');

--- a/frontend/src/routes/(app)/containers/components/container-stats-manager.svelte.ts
+++ b/frontend/src/routes/(app)/containers/components/container-stats-manager.svelte.ts
@@ -1,7 +1,11 @@
-import { createContainerStatsWebSocket } from '../../../../lib/utils/ws';
+import { createContainerStatsWebSocket } from '$lib/utils/ws';
 import type { ContainerStats } from '$lib/types/container.type';
-import { calculateCPUPercent, calculateMemoryPercent } from '../../../../lib/utils/container-stats.utils';
-import type { ReconnectingWebSocket } from '../../../../lib/utils/ws';
+import {
+	calculateCPUPercent,
+	calculateMemoryPercent,
+	calculateMemoryUsage
+} from '$lib/utils/container-stats.utils';
+import type { ReconnectingWebSocket } from '$lib/utils/ws';
 
 export class ContainerStatsManager {
 	private connections = new Map<string, ReconnectingWebSocket<ContainerStats>>();
@@ -61,7 +65,7 @@ export class ContainerStatsManager {
 		const stats = this.stats.get(containerId);
 		if (!stats) return undefined;
 		return {
-			usage: stats.memory_stats?.usage || 0,
+			usage: calculateMemoryUsage(stats),
 			limit: stats.memory_stats?.limit || 0
 		};
 	}

--- a/frontend/src/routes/(app)/dashboard/+page.svelte
+++ b/frontend/src/routes/(app)/dashboard/+page.svelte
@@ -342,6 +342,7 @@
 					maxValue={currentStats?.memoryTotal}
 					showAbsoluteValues={true}
 					formatAbsoluteValue={(v) => bytes.format(v, { unitSeparator: ' ' }) ?? '-'}
+					formatUsageValue={(v) => bytes.format(v, { unitSeparator: ' ' }) ?? '-'}
 					loading={isLoading.loadingStats || !hasInitialStatsLoaded}
 				/>
 


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes memory usage calculations by subtracting cached memory (`inactive_file`) from raw memory usage, aligning with Docker CLI behavior. The changes introduce a new `calculateMemoryUsage` utility function and update memory display formatting.

- Added `calculateMemoryUsage` function to properly calculate memory by excluding cached pages
- Updated `calculateMemoryPercent` to use the new utility function
- Enhanced `meter-metric` component with `formatUsageValue` prop for custom value formatting
- Applied memory calculation fix across dashboard and container stats manager
- Improved import paths in container-stats-manager to use `$lib` alias
</details>


<details open><summary><h3>Confidence Score: 4.5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The memory calculation fix is correct and aligns with Docker's approach. The implementation is clean with only minor code duplication in one file.
- Pay attention to `frontend/src/routes/(app)/containers/[containerId]/+page.svelte` which has duplicated logic that could be refactored
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/utils/container-stats.utils.ts | added `calculateMemoryUsage` function to subtract inactive_file (cached memory) from usage |
| frontend/src/routes/(app)/containers/[containerId]/+page.svelte | duplicated memory calculation logic inline instead of using utility function |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->