### PR TITLE
fix: duplicated project/container logs when refreshing log viewer

### DIFF
--- a/frontend/src/routes/(app)/containers/components/ContainerLogsPanel.svelte
+++ b/frontend/src/routes/(app)/containers/components/ContainerLogsPanel.svelte
@@ -40,11 +40,8 @@
 		onClear();
 	}
 
-	function handleRefresh() {
-		viewer?.stopLogStream();
-		setTimeout(() => {
-			viewer?.startLogStream();
-		}, 100);
+	async function handleRefresh() {
+		await viewer?.clearLogs({ hard: true, restart: true });
 	}
 
 	// Sync isStreaming from viewer callbacks

--- a/frontend/src/routes/(app)/projects/components/ProjectLogsPanel.svelte
+++ b/frontend/src/routes/(app)/projects/components/ProjectLogsPanel.svelte
@@ -34,9 +34,8 @@
 		viewer?.clearLogs();
 	}
 
-	function handleRefresh() {
-		viewer?.stopLogStream();
-		viewer?.startLogStream();
+	async function handleRefresh() {
+		await viewer?.clearLogs({ hard: true, restart: true });
 	}
 
 	$effect(() => {
@@ -97,7 +96,6 @@
 			height="calc(100vh - 320px)"
 			onStart={handleStart}
 			onStop={handleStop}
-			onClear={handleClear}
 		/>
 	</Card.Content>
 </Card.Root>


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1540

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes duplicated logs when refreshing the log viewer by implementing a session tracking mechanism. The core fix adds `streamSession` and `currentStreamSession` counters in `log-viewer.svelte` that assign unique session IDs to each WebSocket connection. All WebSocket callbacks now validate the session ID before processing messages, preventing old connections from adding duplicate log entries after a refresh triggers a new connection.

Key improvements:
- Added `connecting` state flag to prevent concurrent connection attempts
- Made `stopLogStream()` async with 50ms delay to ensure proper WebSocket cleanup
- Updated `clearLogs()` to properly await stop before restart
- Simplified refresh handlers in both panel components to use the `clearLogs({ hard: true, restart: true })` API
- Enhanced the `$effect` block that handles stream key changes to properly await cleanup before restarting
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with minor timing considerations
- The session tracking approach effectively prevents duplicate logs. The 50ms delay in stopLogStream provides time for WebSocket cleanup, though this is a timing assumption that could theoretically fail under extreme conditions. The logic is sound and the changes are well-structured.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/components/logs/log-viewer.svelte | Implemented session tracking to prevent duplicate logs during refresh by adding session IDs that invalidate old WebSocket connections |
| frontend/src/routes/(app)/containers/components/ContainerLogsPanel.svelte | Simplified refresh handler to use clearLogs API instead of manual stop/start sequence |
| frontend/src/routes/(app)/projects/components/ProjectLogsPanel.svelte | Updated refresh handler to use clearLogs API and removed redundant onClear callback from LogViewer |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->