### PR TITLE
fix: keyboard shortcuts dont work for non qwerty layouts

### DIFF
--- a/frontend/src/lib/utils/keyboard-shortcut.utils.ts
+++ b/frontend/src/lib/utils/keyboard-shortcut.utils.ts
@@ -41,6 +41,11 @@ export function matchesShortcutEvent(keys: ShortcutKey[], event: KeyboardEvent, 
 	const key = event.key.toLowerCase();
 	if (MODIFIER_KEYS.has(key)) return false;
 
+	const expectedCode = getExpectedCode(nonModifierKeys[0]);
+	if (expectedCode) {
+		return event.code.toLowerCase() === expectedCode;
+	}
+
 	return key === nonModifierKeys[0];
 }
 
@@ -67,4 +72,14 @@ function formatShortcutKey(key: ShortcutKey, isMac: boolean): string {
 		default:
 			return key.length === 1 ? key.toUpperCase() : key;
 	}
+}
+
+function getExpectedCode(key: string): string | null {
+	if (/^[0-9]$/.test(key)) {
+		return `digit${key}`;
+	}
+	if (/^[a-z]$/.test(key)) {
+		return `key${key}`;
+	}
+	return null;
 }


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1618

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes keyboard shortcuts not working for non-QWERTY layouts by comparing the physical key position (`event.code`) instead of the character value (`event.key`). 

The solution adds a `getExpectedCode` helper function that maps alphanumeric keys to their expected code values (e.g., "1" → "digit1", "g" → "keyg"). The `matchesShortcutEvent` function now checks `event.code` for alphanumeric keys before falling back to `event.key` for other keys.

- Fixed shortcuts (mod+1-9, mod+0, mod+g, etc.) now work consistently across different keyboard layouts
- Properly handles both digit and letter key shortcuts using physical key positions
- Falls back to character-based matching for non-alphanumeric keys
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The change is a focused bug fix that correctly addresses keyboard layout issues. The implementation properly uses `event.code` for physical key matching on alphanumeric keys while maintaining backward compatibility for other keys. The logic is sound and follows best practices.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/utils/keyboard-shortcut.utils.ts | Added `getExpectedCode` helper to match keyboard shortcuts by physical key position (`event.code`) instead of character value (`event.key`), fixing shortcuts for non-QWERTY layouts |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->