### PR TITLE
fix: sync timeout settings to all environments

### DIFF
--- a/backend/internal/services/environment_service.go
+++ b/backend/internal/services/environment_service.go
@@ -150,6 +150,20 @@ func (s *EnvironmentService) ListEnvironmentsPaginated(ctx context.Context, para
 	return out, paginationResp, nil
 }
 
+// ListRemoteEnvironments returns all non-local, enabled environments for syncing purposes.
+func (s *EnvironmentService) ListRemoteEnvironments(ctx context.Context) ([]models.Environment, error) {
+	var envs []models.Environment
+	err := s.db.WithContext(ctx).
+		Model(&models.Environment{}).
+		Where("id != ?", "0").
+		Where("enabled = ?", true).
+		Find(&envs).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list remote environments: %w", err)
+	}
+	return envs, nil
+}
+
 func (s *EnvironmentService) UpdateEnvironment(ctx context.Context, id string, updates map[string]interface{}, userID, username *string) (*models.Environment, error) {
 	now := time.Now()
 	updates["updated_at"] = &now

--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -37,6 +37,7 @@ type SettingsService struct {
 	OnAutoUpdateSettingsChanged     func(ctx context.Context)
 	OnProjectsDirectoryChanged      func(ctx context.Context)
 	OnScheduledPruneSettingsChanged func(ctx context.Context)
+	OnTimeoutSettingsChanged        func(ctx context.Context, timeoutSettings map[string]string)
 }
 
 func NewSettingsService(ctx context.Context, db *database.DB) (*SettingsService, error) {
@@ -430,7 +431,7 @@ func (s *SettingsService) UpdateSettings(ctx context.Context, updates settings.U
 		return nil, fmt.Errorf("failed to load current settings: %w", err)
 	}
 
-	valuesToUpdate, changedPolling, changedAutoUpdate, changedScheduledPrune, err := s.prepareUpdateValues(updates, cfg, defaultCfg)
+	valuesToUpdate, changedPolling, changedAutoUpdate, changedScheduledPrune, changedTimeouts, err := s.prepareUpdateValues(updates, cfg, defaultCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -464,11 +465,24 @@ func (s *SettingsService) UpdateSettings(ctx context.Context, updates settings.U
 	if slices.ContainsFunc(valuesToUpdate, func(sv models.SettingVariable) bool { return sv.Key == "projectsDirectory" }) && s.OnProjectsDirectoryChanged != nil {
 		s.OnProjectsDirectoryChanged(ctx)
 	}
+	if len(changedTimeouts) > 0 && s.OnTimeoutSettingsChanged != nil {
+		s.OnTimeoutSettingsChanged(ctx, changedTimeouts)
+	}
 
 	return settings.ToSettingVariableSlice(false, false), nil
 }
 
-func (s *SettingsService) prepareUpdateValues(updates settings.Update, cfg, defaultCfg *models.Settings) ([]models.SettingVariable, bool, bool, bool, error) {
+// timeoutSettingKeys defines the keys for timeout settings that should be synced to agents
+var timeoutSettingKeys = []string{
+	"dockerApiTimeout",
+	"dockerImagePullTimeout",
+	"gitOperationTimeout",
+	"httpClientTimeout",
+	"registryTimeout",
+	"proxyRequestTimeout",
+}
+
+func (s *SettingsService) prepareUpdateValues(updates settings.Update, cfg, defaultCfg *models.Settings) ([]models.SettingVariable, bool, bool, bool, map[string]string, error) {
 	rt := reflect.TypeOf(updates)
 	rv := reflect.ValueOf(updates)
 	valuesToUpdate := make([]models.SettingVariable, 0)
@@ -476,6 +490,7 @@ func (s *SettingsService) prepareUpdateValues(updates settings.Update, cfg, defa
 	changedPolling := false
 	changedAutoUpdate := false
 	changedScheduledPrune := false
+	changedTimeouts := make(map[string]string)
 
 	for i := 0; i < rt.NumField(); i++ {
 		field := rt.Field(i)
@@ -495,7 +510,7 @@ func (s *SettingsService) prepareUpdateValues(updates settings.Update, cfg, defa
 		cronFields := []string{"scheduledPruneInterval", "autoUpdateInterval", "pollingInterval", "environmentHealthInterval", "eventCleanupInterval", "analyticsHeartbeatInterval"}
 		if slices.Contains(cronFields, key) && value != "" {
 			if _, err := cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow).Parse(value); err != nil {
-				return nil, false, false, false, fmt.Errorf("invalid cron expression for %s: %w", key, err)
+				return nil, false, false, false, nil, fmt.Errorf("invalid cron expression for %s: %w", key, err)
 			}
 		}
 
@@ -514,7 +529,7 @@ func (s *SettingsService) prepareUpdateValues(updates settings.Update, cfg, defa
 		if errors.Is(err, models.SettingSensitiveForbiddenError{}) {
 			continue
 		} else if err != nil {
-			return nil, false, false, false, fmt.Errorf("failed to update in-memory config for key '%s': %w", key, err)
+			return nil, false, false, false, nil, fmt.Errorf("failed to update in-memory config for key '%s': %w", key, err)
 		}
 
 		valuesToUpdate = append(valuesToUpdate, models.SettingVariable{
@@ -530,9 +545,14 @@ func (s *SettingsService) prepareUpdateValues(updates settings.Update, cfg, defa
 		case "scheduledPruneEnabled", "scheduledPruneInterval", "scheduledPruneContainers", "scheduledPruneImages", "scheduledPruneVolumes", "scheduledPruneNetworks", "scheduledPruneBuildCache":
 			changedScheduledPrune = true
 		}
+
+		// Track timeout setting changes
+		if slices.Contains(timeoutSettingKeys, key) {
+			changedTimeouts[key] = valueToSave
+		}
 	}
 
-	return valuesToUpdate, changedPolling, changedAutoUpdate, changedScheduledPrune, nil
+	return valuesToUpdate, changedPolling, changedAutoUpdate, changedScheduledPrune, changedTimeouts, nil
 }
 
 func (s *SettingsService) persistSettings(ctx context.Context, values []models.SettingVariable) error {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1045,7 +1045,7 @@
 	"disk_usage_save_failed": "Failed to update disk usage path",
 	"directory_path": "Directory Path",
 	"_comment_settings_timeouts": "=== SETTINGS - TIMEOUTS ===",
-	"timeouts_settings": "Timeout Settings",
+	"timeouts_settings": "Timeouts",
 	"timeouts_settings_description": "Configure operation timeouts for slow networks or hardware. All values are in seconds.",
 	"timeouts_save": "Timeout settings updated successfully",
 	"docker_api_timeout": "Docker API Timeout",

--- a/frontend/src/lib/config/navigation-config.ts
+++ b/frontend/src/lib/config/navigation-config.ts
@@ -1,7 +1,7 @@
 import {
 	ApiKeyIcon,
 	ApperanceIcon,
-	DockerBrandIcon,
+	JobsIcon,
 	UsersIcon,
 	SecurityIcon,
 	NotificationsIcon,
@@ -63,7 +63,8 @@ export const navigationItems: Record<string, NavigationItem[]> = {
 					shortcut: ['mod', 'shift', '3']
 				},
 				{ title: m.security_title(), url: '/settings/security', icon: SecurityIcon, shortcut: ['mod', 'shift', '4'] },
-				{ title: m.users_title(), url: '/settings/users', icon: UsersIcon, shortcut: ['mod', 'shift', '5'] }
+				{ title: m.timeouts_settings(), url: '/settings/timeouts', icon: JobsIcon, shortcut: ['mod', 'shift', '5'] },
+				{ title: m.users_title(), url: '/settings/users', icon: UsersIcon, shortcut: ['mod', 'shift', '6'] }
 			]
 		}
 	]

--- a/types/settings/settings.go
+++ b/types/settings/settings.go
@@ -241,4 +241,34 @@ type Update struct {
 	//
 	// Required: false
 	KeyboardShortcutsEnabled *string `json:"keyboardShortcutsEnabled,omitempty"`
+
+	// DockerApiTimeout is the timeout for Docker API operations in seconds.
+	//
+	// Required: false
+	DockerApiTimeout *string `json:"dockerApiTimeout,omitempty"`
+
+	// DockerImagePullTimeout is the timeout for Docker image pulls in seconds.
+	//
+	// Required: false
+	DockerImagePullTimeout *string `json:"dockerImagePullTimeout,omitempty"`
+
+	// GitOperationTimeout is the timeout for Git clone/fetch operations in seconds.
+	//
+	// Required: false
+	GitOperationTimeout *string `json:"gitOperationTimeout,omitempty"`
+
+	// HttpClientTimeout is the default timeout for HTTP requests in seconds.
+	//
+	// Required: false
+	HttpClientTimeout *string `json:"httpClientTimeout,omitempty"`
+
+	// RegistryTimeout is the timeout for container registry operations in seconds.
+	//
+	// Required: false
+	RegistryTimeout *string `json:"registryTimeout,omitempty"`
+
+	// ProxyRequestTimeout is the timeout for proxied requests to remote environments in seconds.
+	//
+	// Required: false
+	ProxyRequestTimeout *string `json:"proxyRequestTimeout,omitempty"`
 }


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1627

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements automatic syncing of timeout settings from the main instance to all remote agent environments when timeout values are changed.

**Key Changes:**
- Added callback mechanism in `SettingsService` that triggers when any of 6 timeout settings are changed (`dockerApiTimeout`, `dockerImagePullTimeout`, `gitOperationTimeout`, `httpClientTimeout`, `registryTimeout`, `proxyRequestTimeout`)
- Created `syncTimeoutSettingsToAgentsInternal` function that sends updated timeout settings to all enabled remote environments via proxy requests
- Added `ListRemoteEnvironments` helper to query non-local, enabled environments
- Uses `context.WithoutCancel` to ensure sync completes even if parent request is canceled
- Frontend changes add timeouts as a separate navigation item with keyboard shortcut

**Implementation:**
The sync runs in a background goroutine and logs warnings if syncing to any environment fails, but continues to process remaining environments.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The implementation is clean, follows existing patterns in the codebase, handles errors gracefully, and uses appropriate context management. The sync happens asynchronously so it won't block the main settings update flow.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/bootstrap/jobs_bootstrap.go | adds callback to sync timeout settings to remote agents when changed, function follows naming convention |
| backend/internal/services/settings_service.go | tracks timeout setting changes and triggers callback with changed values |
| backend/internal/services/environment_service.go | added helper method to list remote environments for sync purposes |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->