### PR TITLE
fix: ssh git repos commit hash links incorrect

### DIFF
--- a/frontend/src/lib/utils/git.ts
+++ b/frontend/src/lib/utils/git.ts
@@ -1,0 +1,65 @@
+function stripGitSuffix(path: string): string {
+	return path.replace(/\.git\/?$/, '');
+}
+
+function trimTrailingSlash(value: string): string {
+	return value.replace(/\/+$/, '');
+}
+
+function commitSegmentForHost(hostname: string): string {
+	const host = hostname.toLowerCase();
+	if (host.includes('gitlab')) return '/-/commit/';
+	if (host.includes('bitbucket')) return '/commits/';
+	return '/commit/';
+}
+
+export function toGitWebUrl(raw: string): string | null {
+	const trimmed = raw.trim();
+	if (!trimmed) return null;
+
+	if (trimmed.includes('://')) {
+		try {
+			const parsed = new URL(trimmed);
+			if (!parsed.hostname) return null;
+			const path = stripGitSuffix(parsed.pathname);
+			if (!path || path === '/') return null;
+			const protocol = parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed.protocol : 'https:';
+			return `${protocol}//${parsed.hostname}${path}`;
+		} catch {
+			return null;
+		}
+	}
+
+	const scpMatch = /^(?:.+@)?([^:\/]+):(.+)$/.exec(trimmed);
+	if (scpMatch) {
+		const host = scpMatch[1];
+		const path = stripGitSuffix(scpMatch[2].replace(/^\/+/, ''));
+		if (!host || !path) return null;
+		return `https://${host}/${path}`;
+	}
+
+	const hostPathMatch = /^([^\/]+)\/(.+)$/.exec(trimmed);
+	if (hostPathMatch) {
+		const host = hostPathMatch[1];
+		const path = stripGitSuffix(hostPathMatch[2].replace(/^\/+/, ''));
+		if (!host || !path) return null;
+		return `https://${host}/${path}`;
+	}
+
+	return null;
+}
+
+export function toGitCommitUrl(repositoryUrl: string, commit: string): string | null {
+	const base = toGitWebUrl(repositoryUrl);
+	const trimmedCommit = commit.trim();
+	if (!base || !trimmedCommit) return null;
+
+	const normalizedBase = trimTrailingSlash(base);
+	try {
+		const host = new URL(normalizedBase).hostname;
+		const segment = commitSegmentForHost(host);
+		return `${normalizedBase}${segment}${encodeURIComponent(trimmedCommit)}`;
+	} catch {
+		return null;
+	}
+}

--- a/frontend/src/routes/(app)/environments/[id]/gitops/sync-table.svelte
+++ b/frontend/src/routes/(app)/environments/[id]/gitops/sync-table.svelte
@@ -15,6 +15,7 @@
 	import { format } from 'date-fns';
 	import { m } from '$lib/paraglide/messages';
 	import { gitOpsSyncService } from '$lib/services/gitops-sync-service';
+	import { toGitCommitUrl } from '$lib/utils/git';
 	import {
 		EllipsisIcon,
 		EditIcon as PencilIcon,
@@ -241,11 +242,12 @@
 
 {#snippet CommitCell({ value, item }: { value: any; item: GitOpsSync; row: Row<GitOpsSync> })}
 	{#if value}
+		{@const commitUrl = item.repository?.url ? toGitCommitUrl(item.repository.url, String(value)) : null}
 		<div class="flex items-center gap-1.5">
 			<HashIcon class="text-muted-foreground size-3.5" />
-			{#if item.repository?.url}
+			{#if commitUrl}
 				<a
-					href="{item.repository.url.replace(/\.git$/, '')}/commit/{value}"
+					href={commitUrl}
 					target="_blank"
 					class="hover:text-primary bg-muted text-muted-foreground rounded px-2 py-0.5 font-mono text-xs transition-colors"
 				>

--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -19,6 +19,7 @@
 	import { z } from 'zod/v4';
 	import { createForm } from '$lib/utils/form.utils';
 	import { m } from '$lib/paraglide/messages';
+	import { toGitCommitUrl } from '$lib/utils/git';
 	import { toSafeHref } from '$lib/utils/url';
 	import { PersistedState } from 'runed';
 	import EditableName from '../components/EditableName.svelte';
@@ -345,11 +346,14 @@
 				</div>
 				<div class="text-muted-foreground flex flex-wrap items-center gap-4 text-xs sm:col-start-2">
 					{#if project.lastSyncCommit}
+						{@const commitUrl = project.gitRepositoryURL
+							? toGitCommitUrl(project.gitRepositoryURL, project.lastSyncCommit)
+							: null}
 						<div class="flex items-center gap-1.5">
 							<span class="hidden sm:inline">{m.git_sync_commit()}:</span>
-							{#if project.gitRepositoryURL}
+							{#if commitUrl}
 								<a
-									href="{project.gitRepositoryURL.replace(/\.git$/, '')}/commit/{project.lastSyncCommit}"
+									href={commitUrl}
 									target="_blank"
 									class="hover:text-primary sm:bg-muted font-mono transition-colors sm:rounded sm:px-1.5 sm:py-0.5"
 								>
@@ -425,11 +429,14 @@
 										<br />
 										<div class="mt-2 flex flex-col gap-1">
 											{#if project.lastSyncCommit}
+												{@const commitUrl = project.gitRepositoryURL
+													? toGitCommitUrl(project.gitRepositoryURL, project.lastSyncCommit)
+													: null}
 												<div class="flex items-center gap-1.5 font-mono text-xs">
 													<span class="text-muted-foreground">{m.git_sync_commit()}:</span>
-													{#if project.gitRepositoryURL}
+													{#if commitUrl}
 														<a
-															href="{project.gitRepositoryURL.replace(/\.git$/, '')}/commit/{project.lastSyncCommit}"
+															href={commitUrl}
 															target="_blank"
 															class="bg-muted hover:text-primary rounded px-1.5 py-0.5 transition-colors"
 														>


### PR DESCRIPTION
Fixes: https://github.com/getarcaneapp/arcane/issues/1633

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes commit hash links for SSH-based git repositories by introducing a new utility module that properly handles different git URL formats (HTTP/HTTPS, SSH/SCP) and generates correct commit URLs for GitHub, GitLab, and Bitbucket.

**Changes:**
- Created `git.ts` utility with `toGitWebUrl` (converts git URLs to web URLs) and `toGitCommitUrl` (generates commit links)
- Replaced inline URL string manipulation in sync table and project pages with the new utility functions
- Handles SSH URLs like `git@github.com:user/repo.git` by converting to HTTPS web URLs
- Supports platform-specific commit URL patterns (`/commit/` for GitHub, `/-/commit/` for GitLab, `/commits/` for Bitbucket)
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge after addressing error handling in `toGitCommitUrl`
- The PR successfully fixes SSH repository URL handling with a well-structured utility. One minor issue: missing error handling in `toGitCommitUrl` when parsing the base URL
- frontend/src/lib/utils/git.ts - add error handling on line 58
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/utils/git.ts | New utility for converting git repository URLs (HTTP, SSH, SCP formats) to web URLs and commit links for GitHub, GitLab, and Bitbucket |
| frontend/src/routes/(app)/environments/[id]/gitops/sync-table.svelte | Refactored commit URL generation to use new `toGitCommitUrl` utility function, replacing simple string concatenation |
| frontend/src/routes/(app)/projects/[projectId]/+page.svelte | Refactored two instances of commit URL generation to use new `toGitCommitUrl` utility function |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->