### PR TITLE
chore: Ensure HOST_PROJECT_ROOT is set in a Windows devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,12 +39,6 @@
       ]
     }
   },
-  /*
-    Setup bind mounts in docker - this eliminates the performance overhead of using files mounted from a Windows NTFS volume.  My testing
-    reduced the complete rebuild time of the devcontainer (not including docker image create), including download and add of all node modules 
-    from around 15 minutes to under 2 minutes - I feel this worth doing :-)  Changing the remoteUser to root allows write access to the 
-    bind mount target locations
-  */
   "mounts": [
    "source=node_modules,target=/workspace/node_modules,type=volume",
    "source=pnpm_store,target=/workspace/.pnpm-store,type=volume"
@@ -52,7 +46,7 @@
   "postCreateCommand": "npx -y corepack enable && pnpm install && cd backend && go mod download",
   "remoteUser": "root",
   "containerEnv": {
-    "TZ": "Pacific/Auckland"  // setup correct timezone - change as appropriate
+    "TZ": "Pacific/Auckland"
   },
   "remoteEnv": {
     "HOST_PROJECT_ROOT": "${localWorkspaceFolder}"


### PR DESCRIPTION
I was setting up the Arcane devcontainer on a Windows host.  I was facing an issue where the HOST_PROJECT_ROOT variable was not set when attempting to create the docker containers for arcane-backend-dev and arcane-front-end-dev.  This was causing the volume mounts to attempt a relative path mount, which was failing, falling back to creating a directory when the file didn't exist.

Solution was to setup HOST_PROJECT_ROOT variable in the devcontainer.json file, pointing to ${localWorkspaceFolder}.  This allows the volume mount to succeed, and both the frontend and backend containers start up successfully.

This was related to my discussion post #1656 .  This PR merges the change to ensure that HOST_PROJECT_ROOT is set.

Additionally, I removed the comments from my previous contribution in the devcontainer.json file.  While VSCode supports comments in a JAON file, the strict format of JSON files does not support comments, therefore I removed them.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Windows devcontainer setup issue by setting the `HOST_PROJECT_ROOT` environment variable and cleans up invalid JSON comments.

- Sets `HOST_PROJECT_ROOT` to `${localWorkspaceFolder}` in `remoteEnv`, which resolves to the local workspace path and ensures docker volume mounts work correctly in `docker/compose.dev.yaml`
- Removes JSON comments from `devcontainer.json` (while VS Code supports them, strict JSON parsers do not)
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The changes are straightforward configuration updates that fix a legitimate Windows devcontainer issue. Removing JSON comments improves JSON spec compliance, and setting `HOST_PROJECT_ROOT` using the standard `${localWorkspaceFolder}` variable is the correct approach for devcontainer environment configuration
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .devcontainer/devcontainer.json | Removes invalid JSON comments and adds `HOST_PROJECT_ROOT` environment variable to fix Windows devcontainer volume mount issues |

</details>


</details>


<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->