### PR TITLE
fix: adjust database connection pool settings

### DIFF
--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -84,9 +84,10 @@ func Initialize(ctx context.Context, databaseURL string) (*DB, error) {
 	}
 
 	// Set connection pool settings
-	sqlDB.SetMaxIdleConns(10)
-	sqlDB.SetMaxOpenConns(100)
-	sqlDB.SetConnMaxLifetime(time.Hour)
+	sqlDB.SetMaxIdleConns(5)
+	sqlDB.SetMaxOpenConns(20)
+	sqlDB.SetConnMaxLifetime(5 * time.Minute)
+	sqlDB.SetConnMaxIdleTime(3 * time.Minute)
 
 	return db, nil
 }


### PR DESCRIPTION
Reduced connection pool settings for database connections.

## What This PR Implements

**Related issue**
Was tracking an issue where local PostgreSQL instance was becoming unresponsive, tracked down to Arcane keeping 100 connections open against the 100 connection limit of PostgreSQL. While upping the PostgreSQL connection limit is easy, I am also of the opinion that 100 connections is excessive. Recommended are some more sane defaults.

## Related Issue
None. I tracked this on my own and looked at why it kept happening on a default install of PostgreSQL 18.x on both Arch and Alpine.

## Changes Made
Set the maximum idle connections to 5 from 10
Set the maximum open connections to 20 from 100
Set the maximum lifetime of connections to 5 minutes from 1 hour
Set the maximum idle time of connections to 3 minutes

## Testing Done
Ran custom image on local instance -- no detrimental issues noted on my scaled down setup.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reduces database connection pool settings to prevent PostgreSQL connection exhaustion. The changes are conservative and well-reasoned:

- **Max open connections**: 100 → 20 (80% reduction)
- **Max idle connections**: 10 → 5 (50% reduction)  
- **Connection max lifetime**: 1 hour → 5 minutes
- **Connection max idle time**: not set → 3 minutes (new)

The motivation is solid - default PostgreSQL 18.x installations have a 100 connection limit, and Arcane was consuming all available connections. The new limits (20 max open) leave plenty of headroom for other applications and database maintenance operations.

The reduced lifetime and idle timeouts (5 and 3 minutes respectively) will cause more frequent connection recycling but prevent stale connections and help detect database issues faster. For most web applications, 20 concurrent database connections is sufficient unless handling extremely high load.

**Note**: These settings apply to both PostgreSQL and SQLite connections in the codebase. SQLite is single-writer, so the reduced pool is appropriate. For PostgreSQL deployments expecting high concurrent load, consider making these values configurable via environment variables.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The connection pool adjustments are conservative and address a real issue (PostgreSQL connection exhaustion). The values chosen (20 max open, 5 max idle) are reasonable defaults for typical workloads and leave substantial headroom below PostgreSQL's 100 connection limit. The author tested on a local instance without issues. The changes are isolated to a single configuration point with no logic modifications.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/database/database.go | Reduced connection pool limits from 100 to 20 max open connections, 10 to 5 max idle connections, and added connection lifetime/idle timeouts. Changes are well-justified and safe. |

</details>


</details>


<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->