### PR TITLE
fix: scan all vulnerabilities casuing lag/freezing

### DIFF
--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -48,12 +48,27 @@ type VulnerabilityService struct {
 	// scanLocks provides per-image locking to allow concurrent scans of different images
 	// while preventing duplicate scans of the same image
 	scanLocks sync.Map // map[string]*sync.Mutex
+	// trivyScanSlots limits concurrent Trivy scans to avoid cache/db contention
+	trivyScanSlots chan struct{}
 }
 
 // getImageLock returns a mutex for the given image ID, creating one if needed
 func (s *VulnerabilityService) getImageLock(imageID string) *sync.Mutex {
 	lock, _ := s.scanLocks.LoadOrStore(imageID, &sync.Mutex{})
 	return lock.(*sync.Mutex)
+}
+
+func (s *VulnerabilityService) acquireTrivyScanSlotInternal(ctx context.Context) (func(), error) {
+	if s.trivyScanSlots == nil {
+		return func() {}, nil
+	}
+
+	select {
+	case s.trivyScanSlots <- struct{}{}:
+		return func() { <-s.trivyScanSlots }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 // NewVulnerabilityService creates a new VulnerabilityService instance
@@ -64,6 +79,7 @@ func NewVulnerabilityService(db *database.DB, dockerService *DockerClientService
 		eventService:        eventService,
 		settingsService:     settingsService,
 		notificationService: notificationService,
+		trivyScanSlots:      make(chan struct{}, 1),
 	}
 }
 
@@ -637,7 +653,29 @@ func (s *VulnerabilityService) ScanAllImages(ctx context.Context, envID string, 
 		slog.InfoContext(ctx, "scheduled vulnerability scan: scanning image", "image", imageName, "imageId", imageID)
 
 		startTime := time.Now()
-		result, scanErr := s.execTrivyScanInContainer(ctx, containerID, imageName, imageID, scannerVersion)
+		releaseSlot, slotErr := s.acquireTrivyScanSlotInternal(ctx)
+		if slotErr != nil {
+			failed++
+			failedResult := &vulnerability.ScanResult{
+				ImageID:   imageID,
+				ImageName: imageName,
+				ScanTime:  time.Now(),
+				Status:    vulnerability.ScanStatusFailed,
+				Error:     slotErr.Error(),
+				Duration:  0,
+			}
+			if saveErr := s.saveScanResult(ctx, failedResult); saveErr != nil {
+				slog.WarnContext(ctx, "failed to save failed scan result", "error", saveErr)
+			}
+			s.logScheduledScanEvent(ctx, envID, imageID, imageName, user, false, slotErr.Error())
+			continue
+		}
+		var result *vulnerability.ScanResult
+		var scanErr error
+		func() {
+			defer releaseSlot()
+			result, scanErr = s.execTrivyScanInContainer(ctx, containerID, imageName, imageID, scannerVersion)
+		}()
 		duration := time.Since(startTime).Milliseconds()
 
 		if scanErr != nil {
@@ -1004,7 +1042,7 @@ func (s *VulnerabilityService) ensureTrivyCacheVolumeInternal(ctx context.Contex
 }
 
 // runTrivyScan executes Trivy scan on an image
-func (s *VulnerabilityService) getTrivyConfigFiles(ctx context.Context) (configContent, ignoreContent string, err error) {
+func (s *VulnerabilityService) getTrivyConfigFiles() (configContent, ignoreContent string, err error) {
 	if s.settingsService == nil {
 		return "", "", nil
 	}
@@ -1215,6 +1253,12 @@ func (s *VulnerabilityService) waitForTrivyContainer(
 }
 
 func (s *VulnerabilityService) runTrivyScan(ctx context.Context, trivyImage string, imageName string, imageID string) (*vulnerability.ScanResult, error) {
+	releaseSlot, err := s.acquireTrivyScanSlotInternal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer releaseSlot()
+
 	// Use per-image locking to allow concurrent scans of different images
 	lock := s.getImageLock(imageID)
 	lock.Lock()
@@ -1231,7 +1275,7 @@ func (s *VulnerabilityService) runTrivyScan(ctx context.Context, trivyImage stri
 	}
 
 	// Get Trivy config files if they exist
-	configContent, ignoreContent, err := s.getTrivyConfigFiles(ctx)
+	configContent, ignoreContent, err := s.getTrivyConfigFiles()
 	if err != nil {
 		slog.WarnContext(ctx, "failed to get trivy config files", "error", err)
 	}

--- a/frontend/src/lib/components/vulnerability/vulnerability-scan-item.svelte
+++ b/frontend/src/lib/components/vulnerability/vulnerability-scan-item.svelte
@@ -2,7 +2,6 @@
 	import * as ArcaneTooltip from '$lib/components/arcane-tooltip';
 	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import { ArcaneButton } from '$lib/components/arcane-button';
-	import StatusBadge from '$lib/components/badges/status-badge.svelte';
 	import { toast } from 'svelte-sonner';
 	import { onDestroy } from 'svelte';
 	import type { VulnerabilityScanSummary } from '$lib/types/vulnerability.type';
@@ -15,9 +14,10 @@
 		scanSummary?: VulnerabilityScanSummary;
 		imageId: string;
 		onScanned?: (data: VulnerabilityScanSummary) => void;
+		pollingEnabled?: boolean;
 	}
 
-	let { scanSummary = $bindable(), imageId, onScanned }: Props = $props();
+	let { scanSummary = $bindable(), imageId, onScanned, pollingEnabled = true }: Props = $props();
 
 	let isScanning = $state(false);
 	let isOpen = $state(false);
@@ -102,7 +102,7 @@
 					toast.success(m.vuln_scan_completed());
 				} else if (result.status === 'failed') {
 					toast.error(result.error || m.vuln_scan_failed());
-				} else {
+				} else if (pollingEnabled) {
 					beginPolling(true);
 				}
 			}
@@ -147,6 +147,10 @@
 	}
 
 	$effect(() => {
+		if (!pollingEnabled) {
+			stopScanPolling();
+			return;
+		}
 		const scanning = scanSummary?.status === 'scanning' || scanSummary?.status === 'pending';
 		if (scanning) {
 			beginPolling(false);

--- a/frontend/src/lib/services/vulnerability-service.ts
+++ b/frontend/src/lib/services/vulnerability-service.ts
@@ -3,6 +3,7 @@ import { environmentStore } from '$lib/stores/environment.store.svelte';
 import type {
 	VulnerabilityScanResult,
 	VulnerabilityScanSummary,
+	ScanSummariesResponse,
 	ScannerStatus,
 	Vulnerability,
 	VulnerabilityWithImage,
@@ -46,6 +47,18 @@ export class VulnerabilityService extends BaseAPIService {
 	async getScanSummary(imageId: string): Promise<VulnerabilityScanSummary> {
 		const envId = await environmentStore.getCurrentEnvironmentId();
 		return this.handleResponse(this.api.get(`/environments/${envId}/images/${imageId}/vulnerabilities/summary`));
+	}
+
+	/**
+	 * Get vulnerability scan summaries for multiple images (batch)
+	 */
+	async getScanSummaries(imageIds: string[]): Promise<ScanSummariesResponse> {
+		const envId = await environmentStore.getCurrentEnvironmentId();
+		return this.handleResponse(
+			this.api.post(`/environments/${envId}/images/vulnerabilities/summaries`, {
+				imageIds
+			})
+		);
 	}
 
 	/**

--- a/frontend/src/lib/types/vulnerability.type.ts
+++ b/frontend/src/lib/types/vulnerability.type.ts
@@ -63,6 +63,14 @@ export interface VulnerabilityScanSummary {
 	error?: string;
 }
 
+export interface ScanSummariesRequest {
+	imageIds: string[];
+}
+
+export interface ScanSummariesResponse {
+	summaries: Record<string, VulnerabilityScanSummary | undefined>;
+}
+
 export interface ScannerStatus {
 	available: boolean;
 	version?: string;

--- a/frontend/src/routes/(app)/containers/components/container-stats-manager.svelte.ts
+++ b/frontend/src/routes/(app)/containers/components/container-stats-manager.svelte.ts
@@ -99,7 +99,6 @@ export class ContainerStatsManager {
 	private syncConnections(): void {
 		if (!this.currentEnvId) return;
 		const connectedIds = new SvelteSet(this.connections.keys());
-
 		for (const id of this.desiredIds) {
 			if (!connectedIds.has(id)) {
 				this.connect(id, this.currentEnvId);

--- a/types/vulnerability/vulnerability.go
+++ b/types/vulnerability/vulnerability.go
@@ -248,6 +248,22 @@ type ScanSummary struct {
 	Error string `json:"error,omitempty"`
 }
 
+// ScanSummariesRequest is a batch request for scan summaries by image ID.
+type ScanSummariesRequest struct {
+	// ImageIDs is the list of Docker image IDs to fetch summaries for.
+	//
+	// Required: true
+	ImageIDs []string `json:"imageIds"`
+}
+
+// ScanSummariesResponse wraps summaries keyed by image ID.
+type ScanSummariesResponse struct {
+	// Summaries maps image ID to scan summary.
+	//
+	// Required: true
+	Summaries map[string]*ScanSummary `json:"summaries"`
+}
+
 // TrivyReport represents the JSON output structure from Trivy scanner
 type TrivyReport struct {
 	SchemaVersion int            `json:"SchemaVersion"`


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR addresses vulnerability scanning lag/freezing by implementing two key optimizations:

**Backend changes:**
- Added semaphore-based rate limiting (`trivyScanSlots`) to prevent concurrent Trivy scan contention, limiting to 1 scan at a time
- Implemented batch endpoint `/environments/{id}/images/vulnerabilities/summaries` to fetch multiple scan summaries in a single request
- Removed unused `ctx` parameter from `getTrivyConfigFiles()` (good cleanup)

**Frontend changes:**
- Replaced individual per-image polling with centralized batch polling in `image-table.svelte`
- Added `scanPollInFlight` guard to prevent overlapping batch requests
- Added `pollingEnabled` prop to `vulnerability-scan-item.svelte` to disable component-level polling when parent handles it
- Polling now checks for scanning images and stops when none are active

The implementation correctly addresses the N+1 polling problem that caused lag when scanning multiple images. The batch approach reduces API calls from N individual polls to 1 batch poll every 4 seconds.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minor concerns about the PR description completeness
- The implementation is solid and correctly addresses the performance issue. The batch polling logic is well-structured with proper in-flight guards and cleanup. The semaphore-based rate limiting on the backend follows Go best practices with defer for resource cleanup. The previous review threads already identified the key issues which appear to have been addressed. Minor deduction for incomplete PR description (missing related issue, changes made, and testing checklist).
- No files require special attention - the implementation is straightforward and follows existing patterns
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/vulnerability_service.go | Added semaphore-based rate limiting for Trivy scans and batch summary endpoint; slot release logic is properly protected with defer |
| backend/internal/huma/handlers/vulnerabilities.go | Added batch scan summaries endpoint with proper error handling and empty array handling |
| frontend/src/routes/(app)/images/image-table.svelte | Replaced per-image polling with batch polling to reduce API calls; in-flight guard and polling logic correctly implemented |
| frontend/src/lib/components/vulnerability/vulnerability-scan-item.svelte | Added `pollingEnabled` prop to allow parent component to manage polling, preventing duplicate polls |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->