### PR TITLE
feat: show projects and containers used by images column

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
-	github.com/clipperhouse/uax29/v2 v2.3.0 // indirect
+	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/containerd/console v1.0.5 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -56,8 +56,7 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
-github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuhIGpJy4=
-github.com/clipperhouse/uax29/v2 v2.3.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
+github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w94cO8U=
 github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004 h1:lkAMpLVBDaj17e85keuznYcH5rqI438v41pKcBl4ZxQ=
 github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -564,6 +564,7 @@
 	"images_pull_no_tag": "Cannot pull image without repository tag",
 	"images_untagged": "Untagged",
 	"images_repository": "Repository",
+	"images_used_by": "Used By",
 	"images_updates": "Updates",
 	"images_os": "OS",
 	"images_tag": "Tag",

--- a/frontend/src/lib/components/image-update-item.svelte
+++ b/frontend/src/lib/components/image-update-item.svelte
@@ -438,7 +438,7 @@
 {#if effectiveUpdateInfo}
 	<ArcaneTooltip.Root bind:open={isOpen}>
 		<ArcaneTooltip.Trigger>
-			<span class="mr-2 inline-flex size-4 items-center justify-center align-middle">
+			<span class="mr-2 inline-flex size-4 items-center justify-center align-middle" data-testid="image-update-trigger">
 				{#if hasError}
 					<AlertIcon class="size-4 text-red-500" />
 				{:else if !effectiveUpdateInfo?.hasUpdate}
@@ -467,7 +467,7 @@
 {:else if isLoadingInBackground || isChecking}
 	<ArcaneTooltip.Root>
 		<ArcaneTooltip.Trigger>
-			<span class="mr-2 inline-flex size-4 items-center justify-center">
+			<span class="mr-2 inline-flex size-4 items-center justify-center" data-testid="image-update-trigger">
 				<Spinner class="size-4 text-blue-400" />
 			</span>
 		</ArcaneTooltip.Trigger>
@@ -480,7 +480,7 @@
 {:else}
 	<ArcaneTooltip.Root interactive>
 		<ArcaneTooltip.Trigger>
-			<span class="mr-2 inline-flex size-4 items-center justify-center">
+			<span class="mr-2 inline-flex size-4 items-center justify-center" data-testid="image-update-trigger">
 				{#if canCheckUpdate}
 					<button
 						onclick={checkImageUpdate}

--- a/frontend/src/lib/types/image.type.ts
+++ b/frontend/src/lib/types/image.type.ts
@@ -23,6 +23,12 @@ export interface ImageUsageCounts {
 	totalImageSize: number;
 }
 
+export interface ImageUsedByDto {
+	type: 'project' | 'container';
+	name: string;
+	id?: string;
+}
+
 export interface ImageSummaryDto {
 	id: string;
 	repoTags: string[];
@@ -32,6 +38,7 @@ export interface ImageSummaryDto {
 	virtualSize: number;
 	labels: Record<string, unknown> | null;
 	inUse: boolean;
+	usedBy?: ImageUsedByDto[];
 	repo: string;
 	tag: string;
 	updateInfo?: ImageUpdateInfoDto;

--- a/frontend/src/routes/(app)/images/image-table.svelte
+++ b/frontend/src/routes/(app)/images/image-table.svelte
@@ -15,6 +15,7 @@
 	import ImageUpdateItem from '$lib/components/image-update-item.svelte';
 	import VulnerabilityScanItem from '$lib/components/vulnerability/vulnerability-scan-item.svelte';
 	import UniversalMobileCard from '$lib/components/arcane-table/cards/universal-mobile-card.svelte';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import type { Paginated, SearchPaginationSortRequest } from '$lib/types/pagination.type';
 	import type { ImageSummaryDto, ImageUpdateInfoDto } from '$lib/types/image.type';
 	import type { VulnerabilityScanSummary } from '$lib/types/vulnerability.type';
@@ -23,7 +24,18 @@
 	import { m } from '$lib/paraglide/messages';
 	import { imageService } from '$lib/services/image-service';
 	import { vulnerabilityService } from '$lib/services/vulnerability-service';
-	import { DownloadIcon, TrashIcon, InspectIcon, ImagesIcon, VolumesIcon, ClockIcon, EllipsisIcon, ScanIcon } from '$lib/icons';
+	import {
+		DownloadIcon,
+		TrashIcon,
+		InspectIcon,
+		ImagesIcon,
+		VolumesIcon,
+		ClockIcon,
+		EllipsisIcon,
+		ScanIcon,
+		ProjectsIcon,
+		ContainersIcon
+	} from '$lib/icons';
 
 	let {
 		images = $bindable(),
@@ -300,6 +312,11 @@
 			cell: StatusCell
 		},
 		{
+			id: 'usedBy',
+			title: m.images_used_by(),
+			cell: UsedByCell
+		},
+		{
 			id: 'updates',
 			accessorFn: (row) => {
 				if (row.updateInfo?.hasUpdate) return 'has_update';
@@ -341,6 +358,7 @@
 		{ id: 'id', label: m.common_id(), defaultVisible: false },
 		{ id: 'repoTags', label: m.common_tags(), defaultVisible: true },
 		{ id: 'inUse', label: m.common_status(), defaultVisible: true },
+		{ id: 'usedBy', label: m.images_used_by(), defaultVisible: false },
 		{ id: 'updates', label: m.images_updates(), defaultVisible: false },
 		{ id: 'vulnerabilities', label: m.vuln_title(), defaultVisible: false },
 		{ id: 'size', label: m.common_size(), defaultVisible: true },
@@ -401,6 +419,119 @@
 		<StatusBadge text={m.common_in_use()} variant="green" />
 	{:else}
 		<StatusBadge text={m.common_unused()} variant="amber" />
+	{/if}
+{/snippet}
+
+{#snippet UsedByCell({ item }: { item: ImageSummaryDto })}
+	{#if item.usedBy && item.usedBy.length > 0}
+		{@const maxVisible = 3}
+		{@const hasOverflow = item.usedBy.length > maxVisible}
+		{@const visibleUsage = hasOverflow ? item.usedBy.slice(0, maxVisible) : item.usedBy}
+		{@const overflowUsage = hasOverflow ? item.usedBy.slice(maxVisible) : []}
+		<div class="flex flex-wrap gap-1.5">
+			{#each visibleUsage as usage}
+				{#if usage.type === 'project'}
+					{#if usage.id}
+						<a class="inline-flex" href={`/projects/${encodeURIComponent(usage.id)}`}>
+							<Badge
+								variant="outline"
+								class="hover:bg-accent/40 focus-visible:ring-primary/40 bg-background/80 inline-flex items-center gap-1 rounded-md text-xs transition-colors focus-visible:ring-2"
+							>
+								<ProjectsIcon class="size-3" />
+								<span>{usage.name}</span>
+							</Badge>
+						</a>
+					{:else}
+						<Badge
+							variant="outline"
+							class="hover:bg-accent/40 focus-visible:ring-primary/40 bg-background/80 inline-flex items-center gap-1 rounded-md text-xs transition-colors focus-visible:ring-2"
+						>
+							<ProjectsIcon class="size-3" />
+							<span>{usage.name}</span>
+						</Badge>
+					{/if}
+				{:else if usage.id}
+					<a class="inline-flex" href={`/containers/${encodeURIComponent(usage.id)}`}>
+						<Badge
+							variant="outline"
+							class="hover:bg-accent/40 focus-visible:ring-primary/40 bg-background/80 inline-flex items-center gap-1 rounded-md text-xs transition-colors focus-visible:ring-2"
+						>
+							<ContainersIcon class="size-3" />
+							<span>{usage.name}</span>
+						</Badge>
+					</a>
+				{:else}
+					<Badge
+						variant="outline"
+						class="hover:bg-accent/40 focus-visible:ring-primary/40 bg-background/80 inline-flex items-center gap-1 rounded-md text-xs transition-colors focus-visible:ring-2"
+					>
+						<ContainersIcon class="size-3" />
+						<span>{usage.name}</span>
+					</Badge>
+				{/if}
+			{/each}
+			{#if hasOverflow}
+				<Tooltip.Provider>
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							<Badge
+								variant="outline"
+								class="hover:bg-accent/40 focus-visible:ring-primary/40 bg-background/80 inline-flex items-center rounded-md text-xs transition-colors focus-visible:ring-2"
+							>
+								+{overflowUsage.length}
+							</Badge>
+						</Tooltip.Trigger>
+						<Tooltip.Content class="pointer-events-auto">
+							<div class="flex max-w-xs flex-wrap gap-1.5">
+								{#each overflowUsage as usage}
+									{#if usage.type === 'project'}
+										{#if usage.id}
+											<a class="inline-flex" href={`/projects/${encodeURIComponent(usage.id)}`}>
+												<Badge
+													variant="outline"
+													class="hover:bg-accent/40 focus-visible:ring-primary/40 bg-background/80 inline-flex items-center gap-1 rounded-md text-xs transition-colors focus-visible:ring-2"
+												>
+													<ProjectsIcon class="size-3" />
+													<span>{usage.name}</span>
+												</Badge>
+											</a>
+										{:else}
+											<Badge
+												variant="outline"
+												class="hover:bg-accent/40 focus-visible:ring-primary/40 bg-background/80 inline-flex items-center gap-1 rounded-md text-xs transition-colors focus-visible:ring-2"
+											>
+												<ProjectsIcon class="size-3" />
+												<span>{usage.name}</span>
+											</Badge>
+										{/if}
+									{:else if usage.id}
+										<a class="inline-flex" href={`/containers/${encodeURIComponent(usage.id)}`}>
+											<Badge
+												variant="outline"
+												class="hover:bg-accent/40 focus-visible:ring-primary/40 bg-background/80 inline-flex items-center gap-1 rounded-md text-xs transition-colors focus-visible:ring-2"
+											>
+												<ContainersIcon class="size-3" />
+												<span>{usage.name}</span>
+											</Badge>
+										</a>
+									{:else}
+										<Badge
+											variant="outline"
+											class="hover:bg-accent/40 focus-visible:ring-primary/40 bg-background/80 inline-flex items-center gap-1 rounded-md text-xs transition-colors focus-visible:ring-2"
+										>
+											<ContainersIcon class="size-3" />
+											<span>{usage.name}</span>
+										</Badge>
+									{/if}
+								{/each}
+							</div>
+						</Tooltip.Content>
+					</Tooltip.Root>
+				</Tooltip.Provider>
+			{/if}
+		</div>
+	{:else}
+		<span class="text-muted-foreground">—</span>
 	{/if}
 {/snippet}
 
@@ -481,6 +612,13 @@
 				icon: ImagesIcon,
 				iconVariant: 'purple' as const,
 				show: mobileFieldVisibility.repoTags ?? true
+			},
+			{
+				label: m.images_used_by(),
+				getValue: (item: ImageSummaryDto) => item.usedBy?.map((usage) => usage.name).join(', ') || '—',
+				icon: ImagesIcon,
+				iconVariant: 'purple' as const,
+				show: mobileFieldVisibility.usedBy ?? false
 			}
 		]}
 		footer={(mobileFieldVisibility.created ?? true)

--- a/go.work.sum
+++ b/go.work.sum
@@ -56,6 +56,7 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0/go.mod h1:ZPpqegjbE99EPKsu3iUWV22A04wzGPcAY/ziSIQEEgs=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 h1:Ron4zCA/yk6U7WOBXhTJcDpsUBG9npumK6xw2auFltQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Microsoft/go-winio v0.4.21/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
@@ -129,14 +130,13 @@ github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkN
 github.com/bits-and-blooms/bitset v1.24.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bits-and-blooms/bitset v1.24.3 h1:Bte86SlO3lwPQqww+7BE9ZuUCKIjfqnG5jtEyqA9y9Y=
 github.com/bits-and-blooms/bitset v1.24.3/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bwesterb/go-ristretto v1.2.3 h1:1w53tCkGhCQ5djbat3+MH0BAQ5Kfgbt56UZQ/JMzngw=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
-github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
-github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/x/ansi v0.11.3/go.mod h1:yI7Zslym9tCJcedxz5+WBq+eUGMJT0bM06Fqy1/Y4dI=
 github.com/checkpoint-restore/checkpointctl v1.4.0 h1:3kRns56TArwiyHOMakaumUgSZZlB1hZBkjVgR6IeZ3E=
 github.com/checkpoint-restore/checkpointctl v1.4.0/go.mod h1:ynQ52zQBazgcTZuxpwTFzRinIcAf0haDTC1X1LA/FKA=

--- a/tests/spec/image-updates.spec.ts
+++ b/tests/spec/image-updates.spec.ts
@@ -1,11 +1,11 @@
-import { test, expect, type Page } from '@playwright/test';
-import { fetchImagesWithRetry } from '../utils/fetch.util';
+import { test, expect, type Page } from "@playwright/test";
+import { fetchImagesWithRetry } from "../utils/fetch.util";
 
 const ROUTES = {
-  page: '/images',
-  apiImageUpdatesCheckBatch: '/api/environments/0/image-updates/check-batch',
-  apiImageUpdatesCheckAll: '/api/environments/0/image-updates/check-all',
-  apiImageUpdatesSummary: '/api/environments/0/image-updates/summary',
+  page: "/images",
+  apiImageUpdatesCheckBatch: "/api/environments/0/image-updates/check-batch",
+  apiImageUpdatesCheckAll: "/api/environments/0/image-updates/check-all",
+  apiImageUpdatesSummary: "/api/environments/0/image-updates/summary",
 };
 
 interface BatchUpdateResponse {
@@ -42,7 +42,7 @@ interface UpdateSummary {
 
 async function navigateToImages(page: Page) {
   await page.goto(ROUTES.page);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState("networkidle");
 }
 
 let realImages: any[] = [];
@@ -58,36 +58,36 @@ test.beforeEach(async ({ page }) => {
   }
 });
 
-test.describe('Image Update UI - Check All Updates Button', () => {
-  test('should display the Check Updates button on images page', async ({ page }) => {
+test.describe("Image Update UI - Check All Updates Button", () => {
+  test("should display the Check Updates button on images page", async ({ page }) => {
     await navigateToImages(page);
 
     // Find the Check Updates button - it might be directly visible or in a menu
-    let checkUpdatesButton = page.getByRole('button', { name: 'Check Updates' });
+    let checkUpdatesButton = page.getByRole("button", { name: "Check Updates" });
     const isDirectlyVisible = await checkUpdatesButton.isVisible().catch(() => false);
 
     if (!isDirectlyVisible) {
       // Try to find and click the overflow menu trigger
-      const menuTrigger = page.getByRole('button', { name: 'More actions' });
+      const menuTrigger = page.getByRole("button", { name: "More actions" });
       await menuTrigger.click();
-      checkUpdatesButton = page.getByRole('menuitem', { name: 'Check Updates' });
+      checkUpdatesButton = page.getByRole("menuitem", { name: "Check Updates" });
     }
 
     await expect(checkUpdatesButton).toBeVisible();
   });
 
-  test('should trigger bulk update check when clicking Check Updates button', async ({ page }) => {
+  test("should trigger bulk update check when clicking Check Updates button", async ({ page }) => {
     await navigateToImages(page);
 
     // Find the Check Updates button - it might be directly visible or in a menu
-    let checkUpdatesButton = page.getByRole('button', { name: 'Check Updates' });
+    let checkUpdatesButton = page.getByRole("button", { name: "Check Updates" });
     const isDirectlyVisible = await checkUpdatesButton.isVisible().catch(() => false);
 
     if (!isDirectlyVisible) {
       // Try to find and click the overflow menu trigger
-      const menuTrigger = page.getByRole('button', { name: 'More actions' });
+      const menuTrigger = page.getByRole("button", { name: "More actions" });
       await menuTrigger.click();
-      checkUpdatesButton = page.getByRole('menuitem', { name: 'Check Updates' });
+      checkUpdatesButton = page.getByRole("menuitem", { name: "Check Updates" });
     }
 
     await expect(checkUpdatesButton).toBeVisible();
@@ -100,38 +100,38 @@ test.describe('Image Update UI - Check All Updates Button', () => {
     }
 
     // Eventually a success or completion toast should appear
-    await expect(page.locator('li[data-sonner-toast]')).toBeVisible({ timeout: 60000 });
+    await expect(page.locator("li[data-sonner-toast]")).toBeVisible({ timeout: 60000 });
   });
 });
 
-test.describe('Image Update UI - Individual Image Update Check via Hover Card', () => {
-  test('should display update status icons in the images table', async ({ page }) => {
-    test.skip(!realImages.length, 'No images available');
+test.describe("Image Update UI - Individual Image Update Check via Hover Card", () => {
+  test("should display update status icons in the images table", async ({ page }) => {
+    test.skip(!realImages.length, "No images available");
 
     await navigateToImages(page);
 
     // Wait for the table to load
-    await expect(page.locator('table')).toBeVisible();
+    await expect(page.locator("table")).toBeVisible();
 
     // Check that image rows exist
-    const rows = page.locator('tbody tr');
+    const rows = page.locator("tbody tr");
     await expect(rows.first()).toBeVisible();
   });
 
-  test('should show hover card tooltip when hovering over update status icon', async ({ page }) => {
-    test.skip(!realImages.length, 'No images available');
+  test("should show hover card tooltip when hovering over update status icon", async ({ page }) => {
+    test.skip(!realImages.length, "No images available");
 
     await navigateToImages(page);
 
     // Wait for images table
-    await expect(page.locator('table')).toBeVisible();
+    await expect(page.locator("table")).toBeVisible();
 
     // Find the first row's update status area (the Updates column)
-    const firstRow = page.locator('tbody tr').first();
+    const firstRow = page.locator("tbody tr").first();
     await expect(firstRow).toBeVisible();
 
     // Look for the update status icon trigger element (Tooltip.Trigger wraps a span)
-    const updateStatusTrigger = firstRow.locator('span.inline-flex').first();
+    const updateStatusTrigger = firstRow.locator('[data-testid="image-update-trigger"]').first();
     const hasTrigger = await updateStatusTrigger.isVisible().catch(() => false);
 
     if (hasTrigger) {
@@ -152,35 +152,36 @@ test.describe('Image Update UI - Individual Image Update Check via Hover Card', 
     }
   });
 
-  test('should allow triggering individual image update check from hover card', async ({ page }) => {
-    test.skip(!realImages.length, 'No images available');
+  test("should allow triggering individual image update check from hover card", async ({ page }) => {
+    test.skip(!realImages.length, "No images available");
 
     // Find an image with valid repo/tag for update checking
-    const testImage = realImages.find((img) => img.repo && img.tag && img.repo !== '<none>' && img.tag !== '<none>');
-    test.skip(!testImage, 'No suitable image found for update check');
+    const testImage = realImages.find((img) => img.repo && img.tag && img.repo !== "<none>" && img.tag !== "<none>");
+    test.skip(!testImage, "No suitable image found for update check");
 
     await navigateToImages(page);
-    await expect(page.locator('table')).toBeVisible();
+    await expect(page.locator("table")).toBeVisible();
 
     // Find the row for our test image or the first row with a valid image
-    const rows = page.locator('tbody tr');
+    const rows = page.locator("tbody tr");
     const firstRow = rows.first();
     await expect(firstRow).toBeVisible();
 
     // Look for the update status trigger (could be a button or icon)
-    const updateTrigger = firstRow.locator('span.inline-flex button, span.inline-flex svg').first();
+    const updateTrigger = firstRow.locator('[data-testid="image-update-trigger"]').first();
     const hasUpdateTrigger = await updateTrigger.isVisible().catch(() => false);
 
     if (hasUpdateTrigger) {
       // If it's a clickable button (for unchecked images), click it
-      const isButton = await updateTrigger.evaluate((el) => el.tagName.toLowerCase() === 'button').catch(() => false);
+      const updateButton = updateTrigger.locator("button").first();
+      const hasButton = await updateButton.isVisible().catch(() => false);
 
-      if (isButton) {
-        await updateTrigger.click();
+      if (hasButton) {
+        await updateButton.click();
 
         // Wait for checking to complete (either a toast or state change)
         await expect(async () => {
-          const toast = page.locator('li[data-sonner-toast]');
+          const toast = page.locator("li[data-sonner-toast]");
           const toastVisible = await toast.isVisible().catch(() => false);
           expect(toastVisible).toBeTruthy();
         }).toPass({ timeout: 30000 });
@@ -198,7 +199,7 @@ test.describe('Image Update UI - Individual Image Update Check via Hover Card', 
 
           // Wait for the check to complete
           await expect(async () => {
-            const toast = page.locator('li[data-sonner-toast]');
+            const toast = page.locator("li[data-sonner-toast]");
             const toastVisible = await toast.isVisible().catch(() => false);
             expect(toastVisible).toBeTruthy();
           }).toPass({ timeout: 30000 });
@@ -208,9 +209,9 @@ test.describe('Image Update UI - Individual Image Update Check via Hover Card', 
   });
 });
 
-test.describe('Image Update API Endpoints', () => {
-  test('should check batch image updates via API', async ({ page }) => {
-    const imageRefs = ['nginx:latest', 'alpine:latest'];
+test.describe("Image Update API Endpoints", () => {
+  test("should check batch image updates via API", async ({ page }) => {
+    const imageRefs = ["nginx:latest", "alpine:latest"];
 
     const res = await page.request.post(ROUTES.apiImageUpdatesCheckBatch, {
       data: {
@@ -223,10 +224,10 @@ test.describe('Image Update API Endpoints', () => {
     const json = (await res.json()) as BatchUpdateResponse;
     expect(json.success).toBe(true);
     expect(json.data).toBeDefined();
-    expect(typeof json.data).toBe('object');
+    expect(typeof json.data).toBe("object");
   });
 
-  test('should check all images for updates via API', async ({ page }) => {
+  test("should check all images for updates via API", async ({ page }) => {
     const res = await page.request.post(ROUTES.apiImageUpdatesCheckAll, {
       data: {},
     });
@@ -238,7 +239,7 @@ test.describe('Image Update API Endpoints', () => {
     expect(json.data).toBeDefined();
   });
 
-  test('should get update summary via API', async ({ page }) => {
+  test("should get update summary via API", async ({ page }) => {
     const res = await page.request.get(ROUTES.apiImageUpdatesSummary);
 
     expect(res.status()).toBe(200);
@@ -246,36 +247,36 @@ test.describe('Image Update API Endpoints', () => {
     const json = (await res.json()) as UpdateSummary;
     expect(json.success).toBe(true);
     expect(json.data).toBeDefined();
-    expect(typeof json.data.totalImages).toBe('number');
-    expect(typeof json.data.imagesWithUpdates).toBe('number');
-    expect(typeof json.data.digestUpdates).toBe('number');
-    expect(typeof json.data.errorsCount).toBe('number');
+    expect(typeof json.data.totalImages).toBe("number");
+    expect(typeof json.data.imagesWithUpdates).toBe("number");
+    expect(typeof json.data.digestUpdates).toBe("number");
+    expect(typeof json.data.errorsCount).toBe("number");
   });
 });
 
-test.describe('Image Update UI Integration', () => {
-  test('should display update status icon in images table', async ({ page }) => {
-    test.skip(!realImages.length, 'No images available');
+test.describe("Image Update UI Integration", () => {
+  test("should display update status icon in images table", async ({ page }) => {
+    test.skip(!realImages.length, "No images available");
 
     await navigateToImages(page);
 
     // Wait for the table to load
-    await expect(page.locator('table')).toBeVisible();
+    await expect(page.locator("table")).toBeVisible();
 
     // Check that image rows exist
-    const rows = page.locator('tbody tr');
+    const rows = page.locator("tbody tr");
     await expect(rows.first()).toBeVisible();
   });
 
-  test('should display update information in image detail page', async ({ page }) => {
-    test.skip(!realImages.length, 'No images available');
+  test("should display update information in image detail page", async ({ page }) => {
+    test.skip(!realImages.length, "No images available");
 
-    const testImage = realImages.find((img) => img.repoTags?.[0] && !img.repoTags[0].includes('<none>'));
-    test.skip(!testImage, 'No suitable image found');
+    const testImage = realImages.find((img) => img.repoTags?.[0] && !img.repoTags[0].includes("<none>"));
+    test.skip(!testImage, "No suitable image found");
 
     // Navigate to image detail
     await page.goto(`/images/${encodeURIComponent(testImage.id)}`);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState("networkidle");
 
     // The detail page should load
     await expect(page.locator('h1, h2, [data-testid="image-detail"]').first()).toBeVisible({
@@ -284,8 +285,8 @@ test.describe('Image Update UI Integration', () => {
   });
 });
 
-test.describe('Batch Update Checks', () => {
-  test('should handle empty batch request', async ({ page }) => {
+test.describe("Batch Update Checks", () => {
+  test("should handle empty batch request", async ({ page }) => {
     const res = await page.request.post(ROUTES.apiImageUpdatesCheckBatch, {
       data: {
         imageRefs: [],
@@ -299,8 +300,8 @@ test.describe('Batch Update Checks', () => {
     expect(Object.keys(json.data).length).toBe(0);
   });
 
-  test('should return results for each image in batch', async ({ page }) => {
-    const imageRefs = ['nginx:latest', 'alpine:latest', 'busybox:latest'];
+  test("should return results for each image in batch", async ({ page }) => {
+    const imageRefs = ["nginx:latest", "alpine:latest", "busybox:latest"];
 
     const res = await page.request.post(ROUTES.apiImageUpdatesCheckBatch, {
       data: {
@@ -319,8 +320,8 @@ test.describe('Batch Update Checks', () => {
     }
   });
 
-  test('should handle mixed valid and invalid images in batch', async ({ page }) => {
-    const imageRefs = ['nginx:latest', 'invalid-registry.example.com/nonexistent:latest'];
+  test("should handle mixed valid and invalid images in batch", async ({ page }) => {
+    const imageRefs = ["nginx:latest", "invalid-registry.example.com/nonexistent:latest"];
 
     const res = await page.request.post(ROUTES.apiImageUpdatesCheckBatch, {
       data: {
@@ -334,10 +335,10 @@ test.describe('Batch Update Checks', () => {
     expect(json.success).toBe(true);
 
     // nginx should succeed
-    expect(json.data['nginx:latest']).toBeDefined();
+    expect(json.data["nginx:latest"]).toBeDefined();
 
     // Invalid image should have an error
-    const invalidResult = json.data['invalid-registry.example.com/nonexistent:latest'];
+    const invalidResult = json.data["invalid-registry.example.com/nonexistent:latest"];
     if (invalidResult) {
       expect(invalidResult.error || invalidResult.hasUpdate === false).toBeTruthy();
     }

--- a/types/image/image.go
+++ b/types/image/image.go
@@ -77,6 +77,23 @@ type UpdateInfo struct {
 	UsedCredential bool `json:"usedCredential,omitempty"`
 }
 
+type UsedBy struct {
+	// Type indicates the usage source (e.g., project, container).
+	//
+	// Required: true
+	Type string `json:"type"`
+
+	// Name is the project or container name.
+	//
+	// Required: true
+	Name string `json:"name"`
+
+	// ID is the identifier of the project or container (if available).
+	//
+	// Required: false
+	ID string `json:"id,omitempty"`
+}
+
 type Summary struct {
 	// ID is the unique identifier of the image.
 	//
@@ -117,6 +134,11 @@ type Summary struct {
 	//
 	// Required: true
 	InUse bool `json:"inUse" sortable:"true"`
+
+	// UsedBy lists projects or containers currently using this image.
+	//
+	// Required: false
+	UsedBy []UsedBy `json:"usedBy,omitempty"`
 
 	// Repo is the repository name of the image.
 	//


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1215

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a "Used By" column to the images table that shows which projects or containers are currently using each image. The backend builds usage maps from container labels to identify projects (via `com.docker.compose.project` label) and standalone containers, performing a database lookup to resolve project IDs for linking. The frontend displays this information as clickable badges with icons, showing up to 3 items inline with an overflow tooltip for additional entries.

**Key changes:**
- Backend adds `buildProjectIDMapInternal` and `buildUsageMapInternal` helper functions to track image usage
- New `UsedBy` type in backend and frontend captures type (project/container), name, and optional ID
- Frontend UI renders badges with proper links to project/container detail pages
- Tests updated with `data-testid` attributes for more reliable selectors
- Projects page refresh logic refactored to prevent concurrent refresh operations
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with proper error handling and safe defaults. The backend correctly handles nil checks and database errors. The projects page refactor addresses a previous concern about refresh state tracking. Code duplication in the frontend UsedByCell snippet reduces confidence slightly, but the logic is straightforward and the feature is additive.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/image_service.go | Added `buildProjectIDMapInternal` and `buildUsageMapInternal` to track which projects/containers use each image; replaced simple `inUseMap` with detailed `usageMap` |
| types/image/image.go | Added new `UsedBy` type and `UsedBy` field to `Summary` struct to represent project/container usage |
| frontend/src/routes/(app)/images/image-table.svelte | Added new "Used By" column with `UsedByCell` snippet that displays projects/containers as badges with links and overflow tooltip |
| frontend/src/routes/(app)/projects/+page.svelte | Refactored refresh button logic: replaced `isRefreshing` derived state with `isManualRefreshing` state and `isRefreshBlocked` derived; added guard to prevent concurrent refreshes |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->