### PR TITLE
fix: table sorting not persisting across reloads

### DIFF
--- a/frontend/src/lib/components/arcane-table/arcane-table.types.svelte.ts
+++ b/frontend/src/lib/components/arcane-table/arcane-table.types.svelte.ts
@@ -8,6 +8,9 @@ export type FieldSpec = {
 };
 
 export type MobileFieldVisibility = Record<string, boolean>;
+export type SortDirection = 'asc' | 'desc';
+export type SortPreference = [string, SortDirection];
+export type SortState = { column: string; direction: SortDirection };
 
 export type ColumnWidth = 'auto' | 'min' | 'max' | number;
 export type ColumnAlign = 'left' | 'center' | 'right';
@@ -36,6 +39,8 @@ export type CompactTablePrefs = {
 	f?: [string, unknown][];
 	// g: global filter string
 	g?: string;
+	// s: sort as [column, direction]
+	s?: SortPreference;
 	// l: page size (limit)
 	l?: number;
 	// m: list of hidden mobile field ids
@@ -65,6 +70,19 @@ export function encodeFilters(filters: ColumnFiltersState): [string, unknown][] 
 export function decodeFilters(pairs?: [string, unknown][]): ColumnFiltersState {
 	if (!pairs?.length) return [];
 	return pairs.map(([id, value]) => ({ id, value }));
+}
+
+export function encodeSort(sort?: SortState): SortPreference | undefined {
+	if (!sort?.column) return undefined;
+	return [sort.column, sort.direction];
+}
+
+export function decodeSort(value: unknown): SortState | undefined {
+	if (!Array.isArray(value) || value.length !== 2) return undefined;
+	const [column, direction] = value;
+	if (typeof column !== 'string') return undefined;
+	if (direction !== 'asc' && direction !== 'desc') return undefined;
+	return { column, direction };
 }
 
 export function encodeMobileVisibility(visibility: Record<string, boolean>): string[] {

--- a/frontend/src/lib/components/arcane-table/arcane-table.utils.ts
+++ b/frontend/src/lib/components/arcane-table/arcane-table.utils.ts
@@ -1,13 +1,14 @@
 import type { ColumnFiltersState } from '@tanstack/table-core';
 import type { FilterMap } from '$lib/types/pagination.type';
 import type { CompactTablePrefs } from './arcane-table.types.svelte';
-import { decodeFilters } from './arcane-table.types.svelte';
+import { decodeFilters, decodeSort } from './arcane-table.types.svelte';
 
 export type PersistedPreferencesSnapshot = {
 	hiddenColumns: string[];
 	restoredFilters: ColumnFiltersState;
 	filtersMap: FilterMap;
 	search: string;
+	sort?: { column: string; direction: 'asc' | 'desc' };
 	limit: number;
 	mobileVisibility?: string[];
 	customSettings?: Record<string, unknown>;
@@ -65,6 +66,7 @@ export function extractPersistedPreferences(
 	const restoredFilters = decodeFilters(prefs.f);
 	const filtersMap = toFilterMap(restoredFilters);
 	const search = (prefs.g ?? '').trim();
+	const sort = decodeSort(prefs.s);
 	const limit = prefs.l ?? fallbackLimit;
 
 	return {
@@ -72,6 +74,7 @@ export function extractPersistedPreferences(
 		restoredFilters,
 		filtersMap,
 		search,
+		sort,
 		limit,
 		mobileVisibility: prefs.m,
 		customSettings: prefs.c

--- a/frontend/src/lib/utils/table-persistence.util.ts
+++ b/frontend/src/lib/utils/table-persistence.util.ts
@@ -1,6 +1,6 @@
 import { browser } from '$app/environment';
 import { PersistedState } from 'runed';
-import type { CompactTablePrefs } from '$lib/components/arcane-table/arcane-table.types.svelte';
+import { decodeSort, type CompactTablePrefs } from '$lib/components/arcane-table/arcane-table.types.svelte';
 import type { FilterMap, FilterValue, SearchPaginationSortRequest } from '$lib/types/pagination.type';
 
 const DEFAULT_LIMIT = 20;
@@ -102,6 +102,11 @@ export function resolveInitialTableRequest(
 		const limit = normalizeLimit(current.l);
 		if (limit !== undefined && base.pagination?.limit !== limit) {
 			base.pagination = { page: 1, limit };
+		}
+
+		const sort = decodeSort(current.s);
+		if (sort) {
+			base.sort = sort;
 		}
 	} catch (error) {
 		return base;


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1029

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

Added sort state persistence to `arcane-table` component to fix table sorting not persisting across page reloads. The implementation follows the existing pattern used for filters, search, and pagination persistence.

**Key changes:**
- Added `SortState`, `SortDirection`, and `SortPreference` types to represent sort state
- Implemented `encodeSort()` and `decodeSort()` functions for serialization
- Extended `CompactTablePrefs` to include `s` field for sort preference
- Modified `onSortingChange` handler to persist sort state when user changes sorting
- Added logic in `onMount` to restore persisted sort state on component initialization
- Updated `resolveInitialTableRequest()` to apply persisted sort on first load

The implementation correctly handles edge cases like missing sort state and maintains consistency with other persistence features.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase for persistence, has clean type definitions, and properly handles edge cases. The code is well-structured with no obvious bugs or security issues.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/components/arcane-table/arcane-table.types.svelte.ts | Added type definitions and encode/decode functions for sort persistence - clean implementation |
| frontend/src/lib/components/arcane-table/arcane-table.utils.ts | Added sort field to snapshot type and extraction logic - straightforward change |
| frontend/src/lib/utils/table-persistence.util.ts | Added sort restoration in initial table request resolver - simple addition |
| frontend/src/lib/components/arcane-table/arcane-table.svelte | Integrated sort persistence throughout component lifecycle - main logic looks correct |

</details>


</details>


<sub>Last reviewed commit: 4ce0c4f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->