### PR TITLE
refactor: update pointer calls to use new()

### DIFF
--- a/backend/internal/huma/handlers/environments.go
+++ b/backend/internal/huma/handlers/environments.go
@@ -450,7 +450,7 @@ func (h *EnvironmentHandler) createEnvironmentWithApiKey(ctx context.Context, en
 			Success: true,
 			Data: EnvironmentWithApiKey{
 				Environment: out,
-				ApiKey:      &apiKeyDto.Key,
+				ApiKey:      new(apiKeyDto.Key),
 			},
 		},
 	}, nil
@@ -479,15 +479,13 @@ func (h *EnvironmentHandler) createEnvironmentLegacy(ctx context.Context, env *m
 		go func(envID string, envName string) { //nolint:contextcheck // intentional background context for async task
 			bgCtx := context.Background()
 			if err := h.environmentService.SyncRegistriesToEnvironment(bgCtx, envID); err != nil {
-				slog.WarnContext(bgCtx, "Failed to sync registries to new environment",
-					"environmentID", envID, "environmentName", envName, "error", err.Error())
+				slog.WarnContext(bgCtx, "Failed to sync registries to new environment", "environmentID", envID, "environmentName", envName, "error", err.Error())
 			}
 		}(created.ID, created.Name)
 		go func(envID string, envName string) { //nolint:contextcheck // intentional background context for async task
 			bgCtx := context.Background()
 			if err := h.environmentService.SyncRepositoriesToEnvironment(bgCtx, envID); err != nil {
-				slog.WarnContext(bgCtx, "Failed to sync git repositories to new environment",
-					"environmentID", envID, "environmentName", envName, "error", err.Error())
+				slog.WarnContext(bgCtx, "Failed to sync git repositories to new environment", "environmentID", envID, "environmentName", envName, "error", err.Error())
 			}
 		}(created.ID, created.Name)
 	}
@@ -552,8 +550,8 @@ func (h *EnvironmentHandler) UpdateEnvironment(ctx context.Context, input *Updat
 	user, _ := humamw.GetCurrentUserFromContext(ctx)
 	var userID, username *string
 	if user != nil {
-		userID = &user.ID
-		username = &user.Username
+		userID = new(user.ID)
+		username = new(user.Username)
 	}
 	updated, updateErr := h.environmentService.UpdateEnvironment(ctx, input.ID, updates, userID, username)
 	if updateErr != nil {
@@ -608,7 +606,7 @@ func (h *EnvironmentHandler) UpdateEnvironment(ctx context.Context, input *Updat
 			return nil, huma.Error500InternalServerError((&common.EnvironmentMappingError{Err: mapErr}).Error())
 		}
 
-		newApiKey = &apiKeyDto.Key
+		newApiKey = new(apiKeyDto.Key)
 	}
 
 	// Set the API key on the response if regenerated
@@ -639,8 +637,8 @@ func (h *EnvironmentHandler) DeleteEnvironment(ctx context.Context, input *Delet
 	user, _ := humamw.GetCurrentUserFromContext(ctx)
 	var userID, username *string
 	if user != nil {
-		userID = &user.ID
-		username = &user.Username
+		userID = new(user.ID)
+		username = new(user.Username)
 	}
 	if err := h.environmentService.DeleteEnvironment(ctx, input.ID, userID, username); err != nil {
 		return nil, huma.Error500InternalServerError((&common.EnvironmentDeletionError{Err: err}).Error())

--- a/backend/internal/huma/middleware/auth.go
+++ b/backend/internal/huma/middleware/auth.go
@@ -140,7 +140,7 @@ func createAgentSudoUser() *models.User {
 	email := "agent@getarcane.app"
 	return &models.User{
 		BaseModel: models.BaseModel{ID: "agent"},
-		Email:     &email,
+		Email:     new(email),
 		Roles:     []string{"admin"},
 	}
 }

--- a/backend/internal/services/api_key_service.go
+++ b/backend/internal/services/api_key_service.go
@@ -122,11 +122,11 @@ func (s *ApiKeyService) CreateEnvironmentApiKey(ctx context.Context, environment
 
 	ak := &models.ApiKey{
 		Name:          name,
-		Description:   &description,
+		Description:   new(description),
 		KeyHash:       keyHash,
 		KeyPrefix:     keyPrefix,
 		UserID:        userID,
-		EnvironmentID: &environmentID,
+		EnvironmentID: new(environmentID),
 	}
 
 	if err := s.db.WithContext(ctx).Create(ak).Error; err != nil {

--- a/backend/internal/services/event_service.go
+++ b/backend/internal/services/event_service.go
@@ -200,18 +200,17 @@ func (s *EventService) LogContainerEvent(ctx context.Context, eventType models.E
 	description := s.generateEventDescription(eventType, "container", containerName)
 	severity := s.getEventSeverity(eventType)
 
-	resourceType := "container"
 	_, err := s.CreateEvent(ctx, CreateEventRequest{
 		Type:          eventType,
 		Severity:      severity,
 		Title:         title,
 		Description:   description,
-		ResourceType:  &resourceType,
-		ResourceID:    &containerID,
-		ResourceName:  &containerName,
-		UserID:        &userID,
-		Username:      &username,
-		EnvironmentID: &environmentID,
+		ResourceType:  new("container"),
+		ResourceID:    new(containerID),
+		ResourceName:  new(containerName),
+		UserID:        new(userID),
+		Username:      new(username),
+		EnvironmentID: new(environmentID),
 		Metadata:      metadata,
 	})
 	return err
@@ -222,18 +221,17 @@ func (s *EventService) LogImageEvent(ctx context.Context, eventType models.Event
 	description := s.generateEventDescription(eventType, "image", imageName)
 	severity := s.getEventSeverity(eventType)
 
-	resourceType := "image"
 	_, err := s.CreateEvent(ctx, CreateEventRequest{
 		Type:          eventType,
 		Severity:      severity,
 		Title:         title,
 		Description:   description,
-		ResourceType:  &resourceType,
-		ResourceID:    &imageID,
-		ResourceName:  &imageName,
-		UserID:        &userID,
-		Username:      &username,
-		EnvironmentID: &environmentID,
+		ResourceType:  new("image"),
+		ResourceID:    new(imageID),
+		ResourceName:  new(imageName),
+		UserID:        new(userID),
+		Username:      new(username),
+		EnvironmentID: new(environmentID),
 		Metadata:      metadata,
 	})
 	return err
@@ -244,18 +242,17 @@ func (s *EventService) LogProjectEvent(ctx context.Context, eventType models.Eve
 	description := s.generateEventDescription(eventType, "project", projectName)
 	severity := s.getEventSeverity(eventType)
 
-	resourceType := "project"
 	_, err := s.CreateEvent(ctx, CreateEventRequest{
 		Type:          eventType,
 		Severity:      severity,
 		Title:         title,
 		Description:   description,
-		ResourceType:  &resourceType,
-		ResourceID:    &projectID,
-		ResourceName:  &projectName,
-		UserID:        &userID,
-		Username:      &username,
-		EnvironmentID: &environmentID,
+		ResourceType:  new("project"),
+		ResourceID:    new(projectID),
+		ResourceName:  new(projectName),
+		UserID:        new(userID),
+		Username:      new(username),
+		EnvironmentID: new(environmentID),
 		Metadata:      metadata,
 	})
 	return err
@@ -271,8 +268,8 @@ func (s *EventService) LogUserEvent(ctx context.Context, eventType models.EventT
 		Severity:    severity,
 		Title:       title,
 		Description: description,
-		UserID:      &userID,
-		Username:    &username,
+		UserID:      new(userID),
+		Username:    new(username),
 		Metadata:    metadata,
 	})
 	return err
@@ -283,18 +280,17 @@ func (s *EventService) LogVolumeEvent(ctx context.Context, eventType models.Even
 	description := s.generateEventDescription(eventType, "volume", volumeName)
 	severity := s.getEventSeverity(eventType)
 
-	resourceType := "volume"
 	_, err := s.CreateEvent(ctx, CreateEventRequest{
 		Type:          eventType,
 		Severity:      severity,
 		Title:         title,
 		Description:   description,
-		ResourceType:  &resourceType,
-		ResourceID:    &volumeID,
-		ResourceName:  &volumeName,
-		UserID:        &userID,
-		Username:      &username,
-		EnvironmentID: &environmentID,
+		ResourceType:  new("volume"),
+		ResourceID:    new(volumeID),
+		ResourceName:  new(volumeName),
+		UserID:        new(userID),
+		Username:      new(username),
+		EnvironmentID: new(environmentID),
 		Metadata:      metadata,
 	})
 	return err
@@ -305,18 +301,17 @@ func (s *EventService) LogNetworkEvent(ctx context.Context, eventType models.Eve
 	description := s.generateEventDescription(eventType, "network", networkName)
 	severity := s.getEventSeverity(eventType)
 
-	resourceType := "network"
 	_, err := s.CreateEvent(ctx, CreateEventRequest{
 		Type:          eventType,
 		Severity:      severity,
 		Title:         title,
 		Description:   description,
-		ResourceType:  &resourceType,
-		ResourceID:    &networkID,
-		ResourceName:  &networkName,
-		UserID:        &userID,
-		Username:      &username,
-		EnvironmentID: &environmentID,
+		ResourceType:  new("network"),
+		ResourceID:    new(networkID),
+		ResourceName:  new(networkName),
+		UserID:        new(userID),
+		Username:      new(username),
+		EnvironmentID: new(environmentID),
 		Metadata:      metadata,
 	})
 	return err
@@ -353,12 +348,12 @@ func (s *EventService) LogErrorEvent(ctx context.Context, eventType models.Event
 			Severity:      models.EventSeverityError,
 			Title:         title,
 			Description:   description,
-			ResourceType:  &resourceType,
-			ResourceID:    &resourceID,
-			ResourceName:  &resourceName,
-			UserID:        &userID,
-			Username:      &username,
-			EnvironmentID: &environmentID,
+			ResourceType:  new(resourceType),
+			ResourceID:    new(resourceID),
+			ResourceName:  new(resourceName),
+			UserID:        new(userID),
+			Username:      new(username),
+			EnvironmentID: new(environmentID),
 			Metadata:      metadata,
 		})
 		if logErr != nil {

--- a/backend/internal/services/event_service_test.go
+++ b/backend/internal/services/event_service_test.go
@@ -1,0 +1,112 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/getarcaneapp/arcane/backend/internal/database"
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	glsqlite "github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupEventServiceTestDB(t *testing.T) *database.DB {
+	t.Helper()
+	db, err := gorm.Open(glsqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Event{}))
+	return &database.DB{DB: db}
+}
+
+func TestCreateEventRequestJSONOmitempty(t *testing.T) {
+	t.Run("includes optional fields when set", func(t *testing.T) {
+		payload, err := json.Marshal(CreateEventRequest{
+			Type:         models.EventTypeContainerStart,
+			Title:        "Container started",
+			Description:  "Container 'web' has been started",
+			ResourceType: new("container"),
+			ResourceID:   new("container-1"),
+			ResourceName: new("web"),
+			UserID:       new("user-1"),
+			Username:     new("arcane"),
+		})
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(payload, &decoded))
+
+		require.Equal(t, "container", decoded["resourceType"])
+		require.Equal(t, "container-1", decoded["resourceId"])
+		require.Equal(t, "web", decoded["resourceName"])
+		require.Equal(t, "user-1", decoded["userId"])
+		require.Equal(t, "arcane", decoded["username"])
+	})
+
+	t.Run("omits optional fields when nil", func(t *testing.T) {
+		payload, err := json.Marshal(CreateEventRequest{
+			Type:  models.EventTypeUserLogin,
+			Title: "User logged in",
+		})
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(payload, &decoded))
+
+		_, hasResourceType := decoded["resourceType"]
+		_, hasResourceID := decoded["resourceId"]
+		_, hasResourceName := decoded["resourceName"]
+		_, hasUserID := decoded["userId"]
+		_, hasUsername := decoded["username"]
+
+		require.False(t, hasResourceType)
+		require.False(t, hasResourceID)
+		require.False(t, hasResourceName)
+		require.False(t, hasUserID)
+		require.False(t, hasUsername)
+	})
+}
+
+func TestEventService_LogEventsPersistOptionalPointers(t *testing.T) {
+	ctx := context.Background()
+	db := setupEventServiceTestDB(t)
+	svc := NewEventService(db)
+
+	metadata := models.JSON{"source": "test"}
+	err := svc.LogContainerEvent(ctx, models.EventTypeContainerStart, "container-1", "web", "user-1", "arcane", "0", metadata)
+	require.NoError(t, err)
+
+	var containerEvent models.Event
+	err = db.WithContext(ctx).Where("type = ?", models.EventTypeContainerStart).First(&containerEvent).Error
+	require.NoError(t, err)
+
+	require.NotNil(t, containerEvent.ResourceType)
+	require.Equal(t, "container", *containerEvent.ResourceType)
+	require.NotNil(t, containerEvent.ResourceID)
+	require.Equal(t, "container-1", *containerEvent.ResourceID)
+	require.NotNil(t, containerEvent.ResourceName)
+	require.Equal(t, "web", *containerEvent.ResourceName)
+	require.NotNil(t, containerEvent.UserID)
+	require.Equal(t, "user-1", *containerEvent.UserID)
+	require.NotNil(t, containerEvent.Username)
+	require.Equal(t, "arcane", *containerEvent.Username)
+	require.NotNil(t, containerEvent.EnvironmentID)
+	require.Equal(t, "0", *containerEvent.EnvironmentID)
+	require.Equal(t, "test", containerEvent.Metadata["source"])
+
+	err = svc.LogUserEvent(ctx, models.EventTypeUserLogin, "user-2", "arcane-user", nil)
+	require.NoError(t, err)
+
+	var userEvent models.Event
+	err = db.WithContext(ctx).Where("type = ?", models.EventTypeUserLogin).First(&userEvent).Error
+	require.NoError(t, err)
+
+	require.Nil(t, userEvent.ResourceType)
+	require.Nil(t, userEvent.ResourceID)
+	require.Nil(t, userEvent.ResourceName)
+	require.NotNil(t, userEvent.UserID)
+	require.Equal(t, "user-2", *userEvent.UserID)
+	require.NotNil(t, userEvent.Username)
+	require.Equal(t, "arcane-user", *userEvent.Username)
+}

--- a/backend/internal/services/git_repository_service.go
+++ b/backend/internal/services/git_repository_service.go
@@ -126,15 +126,14 @@ func (s *GitRepositoryService) CreateRepository(ctx context.Context, req models.
 	}
 
 	// Log event
-	resourceType := "git_repository"
 	_, _ = s.eventService.CreateEvent(ctx, CreateEventRequest{
 		Type:         models.EventTypeGitRepositoryCreate,
 		Severity:     models.EventSeveritySuccess,
 		Title:        "Git repository created",
 		Description:  fmt.Sprintf("Created git repository '%s' (%s)", repository.Name, repository.URL),
-		ResourceType: &resourceType,
-		ResourceID:   &repository.ID,
-		ResourceName: &repository.Name,
+		ResourceType: new("git_repository"),
+		ResourceID:   new(repository.ID),
+		ResourceName: new(repository.Name),
 	})
 
 	return &repository, nil
@@ -200,15 +199,14 @@ func (s *GitRepositoryService) UpdateRepository(ctx context.Context, id string, 
 		}
 
 		// Log event
-		resourceType := "git_repository"
 		_, _ = s.eventService.CreateEvent(ctx, CreateEventRequest{
 			Type:         models.EventTypeGitRepositoryUpdate,
 			Severity:     models.EventSeveritySuccess,
 			Title:        "Git repository updated",
 			Description:  fmt.Sprintf("Updated git repository '%s'", repository.Name),
-			ResourceType: &resourceType,
-			ResourceID:   &repository.ID,
-			ResourceName: &repository.Name,
+			ResourceType: new("git_repository"),
+			ResourceID:   new(repository.ID),
+			ResourceName: new(repository.Name),
 		})
 	}
 
@@ -237,15 +235,14 @@ func (s *GitRepositoryService) DeleteRepository(ctx context.Context, id string) 
 	}
 
 	// Log event
-	resourceType := "git_repository"
 	_, _ = s.eventService.CreateEvent(ctx, CreateEventRequest{
 		Type:         models.EventTypeGitRepositoryDelete,
 		Severity:     models.EventSeverityInfo,
 		Title:        "Git repository deleted",
 		Description:  fmt.Sprintf("Deleted git repository '%s'", repository.Name),
-		ResourceType: &resourceType,
-		ResourceID:   &repository.ID,
-		ResourceName: &repository.Name,
+		ResourceType: new("git_repository"),
+		ResourceID:   new(repository.ID),
+		ResourceName: new(repository.Name),
 	})
 
 	return nil
@@ -268,29 +265,27 @@ func (s *GitRepositoryService) TestConnection(ctx context.Context, id string, br
 	err = s.gitClient.TestConnection(ctx, repository.URL, branch, authConfig)
 	if err != nil {
 		// Log error event
-		resourceType := "git_repository"
 		_, _ = s.eventService.CreateEvent(ctx, CreateEventRequest{
 			Type:         models.EventTypeGitRepositoryError,
 			Severity:     models.EventSeverityError,
 			Title:        "Git repository connection test failed",
 			Description:  fmt.Sprintf("Failed to connect to repository '%s': %s", repository.Name, err.Error()),
-			ResourceType: &resourceType,
-			ResourceID:   &repository.ID,
-			ResourceName: &repository.Name,
+			ResourceType: new("git_repository"),
+			ResourceID:   new(repository.ID),
+			ResourceName: new(repository.Name),
 		})
 		return err
 	}
 
 	// Log success event
-	resourceType := "git_repository"
 	_, _ = s.eventService.CreateEvent(ctx, CreateEventRequest{
 		Type:         models.EventTypeGitRepositoryTest,
 		Severity:     models.EventSeveritySuccess,
 		Title:        "Git repository connection successful",
 		Description:  fmt.Sprintf("Successfully connected to repository '%s'", repository.Name),
-		ResourceType: &resourceType,
-		ResourceID:   &repository.ID,
-		ResourceName: &repository.Name,
+		ResourceType: new("git_repository"),
+		ResourceID:   new(repository.ID),
+		ResourceName: new(repository.Name),
 	})
 
 	return nil

--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -191,17 +191,16 @@ func (s *GitOpsSyncService) CreateSync(ctx context.Context, environmentID string
 	slog.InfoContext(ctx, "GitOps sync created successfully", "syncID", sync.ID, "name", sync.Name)
 
 	// Log event
-	resourceType := "git_sync"
 	_, _ = s.eventService.CreateEvent(ctx, CreateEventRequest{
 		Type:         models.EventTypeGitSyncCreate,
 		Severity:     models.EventSeveritySuccess,
 		Title:        "Git sync created",
 		Description:  fmt.Sprintf("Created git sync configuration '%s'", sync.Name),
-		ResourceType: &resourceType,
-		ResourceID:   &sync.ID,
-		ResourceName: &sync.Name,
-		UserID:       &systemUser.ID,
-		Username:     &systemUser.Username,
+		ResourceType: new("git_sync"),
+		ResourceID:   new(sync.ID),
+		ResourceName: new(sync.Name),
+		UserID:       new(systemUser.ID),
+		Username:     new(systemUser.Username),
 	})
 
 	if _, err := s.PerformSync(ctx, sync.EnvironmentID, sync.ID); err != nil {
@@ -253,15 +252,14 @@ func (s *GitOpsSyncService) UpdateSync(ctx context.Context, environmentID, id st
 		}
 
 		// Log event
-		resourceType := "git_sync"
 		_, _ = s.eventService.CreateEvent(ctx, CreateEventRequest{
 			Type:         models.EventTypeGitSyncUpdate,
 			Severity:     models.EventSeveritySuccess,
 			Title:        "Git sync updated",
 			Description:  fmt.Sprintf("Updated git sync configuration '%s'", sync.Name),
-			ResourceType: &resourceType,
-			ResourceID:   &sync.ID,
-			ResourceName: &sync.Name,
+			ResourceType: new("git_sync"),
+			ResourceID:   new(sync.ID),
+			ResourceName: new(sync.Name),
 		})
 	}
 
@@ -294,16 +292,17 @@ func (s *GitOpsSyncService) DeleteSync(ctx context.Context, environmentID, id st
 	}
 
 	// Log event
-	resourceType := "git_sync"
 	_, _ = s.eventService.CreateEvent(ctx, CreateEventRequest{
 		Type:         models.EventTypeGitSyncDelete,
 		Severity:     models.EventSeverityInfo,
 		Title:        "Git sync deleted",
 		Description:  fmt.Sprintf("Deleted git sync configuration '%s'", sync.Name),
-		ResourceType: &resourceType,
-		ResourceID:   &sync.ID,
-		ResourceName: &sync.Name, UserID: &systemUser.ID,
-		Username: &systemUser.Username})
+		ResourceType: new("git_sync"),
+		ResourceID:   new(sync.ID),
+		ResourceName: new(sync.Name),
+		UserID:       new(systemUser.ID),
+		Username:     new(systemUser.Username),
+	})
 
 	return nil
 }
@@ -388,17 +387,16 @@ func (s *GitOpsSyncService) PerformSync(ctx context.Context, environmentID, id s
 	result.Message = fmt.Sprintf("Successfully synced compose file from %s to project %s", sync.ComposePath, project.Name)
 
 	// Log success event
-	resourceType := "git_sync"
 	_, _ = s.eventService.CreateEvent(syncCtx, CreateEventRequest{
 		Type:         models.EventTypeGitSyncRun,
 		Severity:     models.EventSeveritySuccess,
 		Title:        "Git sync completed",
 		Description:  fmt.Sprintf("Successfully synced '%s' to project '%s'", sync.Name, project.Name),
-		ResourceType: &resourceType,
-		ResourceID:   &sync.ID,
-		ResourceName: &sync.Name,
-		UserID:       &systemUser.ID,
-		Username:     &systemUser.Username,
+		ResourceType: new("git_sync"),
+		ResourceID:   new(sync.ID),
+		ResourceName: new(sync.Name),
+		UserID:       new(systemUser.ID),
+		Username:     new(systemUser.Username),
 	})
 
 	slog.InfoContext(syncCtx, "GitOps sync completed", "syncId", id, "project", project.Name)
@@ -445,8 +443,7 @@ func (s *GitOpsSyncService) GetSyncStatus(ctx context.Context, environmentID, id
 
 	// Calculate next sync time
 	if sync.AutoSync && sync.LastSyncAt != nil {
-		nextSync := sync.LastSyncAt.Add(time.Duration(sync.SyncInterval) * time.Minute)
-		status.NextSyncAt = &nextSync
+		status.NextSyncAt = new(sync.LastSyncAt.Add(time.Duration(sync.SyncInterval) * time.Minute))
 	}
 
 	return status, nil
@@ -551,8 +548,8 @@ func (s *GitOpsSyncService) ImportSyncs(ctx context.Context, environmentID strin
 			Branch:       importItem.Branch,
 			ComposePath:  importItem.DockerComposePath,
 			ProjectName:  importItem.SyncName,
-			AutoSync:     &importItem.AutoSync,
-			SyncInterval: &importItem.SyncInterval,
+			AutoSync:     new(importItem.AutoSync),
+			SyncInterval: new(importItem.SyncInterval),
 		}
 
 		_, err = s.CreateSync(ctx, environmentID, createReq)
@@ -568,21 +565,22 @@ func (s *GitOpsSyncService) ImportSyncs(ctx context.Context, environmentID strin
 }
 
 func (s *GitOpsSyncService) logSyncError(ctx context.Context, sync *models.GitOpsSync, errorMsg string) {
-	resourceType := "git_sync"
 	_, _ = s.eventService.CreateEvent(ctx, CreateEventRequest{
 		Type:         models.EventTypeGitSyncError,
 		Severity:     models.EventSeverityError,
 		Title:        "Git sync failed",
 		Description:  fmt.Sprintf("Failed to sync '%s': %s", sync.Name, errorMsg),
-		ResourceType: &resourceType,
-		ResourceID:   &sync.ID,
-		ResourceName: &sync.Name, UserID: &systemUser.ID,
-		Username: &systemUser.Username})
+		ResourceType: new("git_sync"),
+		ResourceID:   new(sync.ID),
+		ResourceName: new(sync.Name),
+		UserID:       new(systemUser.ID),
+		Username:     new(systemUser.Username),
+	})
 }
 
 func (s *GitOpsSyncService) failSync(ctx context.Context, id string, result *gitops.SyncResult, sync *models.GitOpsSync, message, errMsg string) error {
 	result.Message = message
-	result.Error = &errMsg
+	result.Error = new(errMsg)
 	s.updateSyncStatus(ctx, id, "failed", errMsg, "")
 	s.logSyncError(ctx, sync, errMsg)
 	return fmt.Errorf("%s", errMsg)

--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -552,7 +552,7 @@ func stringToPtr(s string) *string {
 	if s == "" {
 		return nil
 	}
-	return &s
+	return new(s)
 }
 
 func stringPtrToString(s *string) string {

--- a/backend/internal/services/notification_service.go
+++ b/backend/internal/services/notification_service.go
@@ -174,7 +174,7 @@ func (s *NotificationService) SendImageUpdateNotification(ctx context.Context, i
 		if sendErr != nil {
 			status = "failed"
 			msg := sendErr.Error()
-			errMsg = &msg
+			errMsg = new(msg)
 			errors = append(errors, fmt.Sprintf("%s: %s", setting.Provider, msg))
 		}
 
@@ -273,7 +273,7 @@ func (s *NotificationService) SendContainerUpdateNotification(ctx context.Contex
 		if sendErr != nil {
 			status = "failed"
 			msg := sendErr.Error()
-			errMsg = &msg
+			errMsg = new(msg)
 			errors = append(errors, fmt.Sprintf("%s: %s", setting.Provider, msg))
 		}
 
@@ -442,7 +442,7 @@ func (s *NotificationService) SendVulnerabilityNotification(ctx context.Context,
 		if sendErr != nil {
 			status = "failed"
 			msg := sendErr.Error()
-			errMsg = &msg
+			errMsg = new(msg)
 			errors = append(errors, fmt.Sprintf("%s: %s", setting.Provider, msg))
 		}
 
@@ -1210,7 +1210,7 @@ func (s *NotificationService) SendBatchImageUpdateNotification(ctx context.Conte
 		if sendErr != nil {
 			status = "failed"
 			msg := sendErr.Error()
-			errMsg = &msg
+			errMsg = new(msg)
 			errors = append(errors, fmt.Sprintf("%s: %s", setting.Provider, msg))
 		}
 
@@ -2866,7 +2866,7 @@ func (s *NotificationService) SendPruneReportNotification(ctx context.Context, r
 		if sendErr != nil {
 			status = "failed"
 			msg := sendErr.Error()
-			errMsg = &msg
+			errMsg = new(msg)
 			errors = append(errors, fmt.Sprintf("%s: %s", setting.Provider, msg))
 		}
 

--- a/backend/internal/services/playwright_service.go
+++ b/backend/internal/services/playwright_service.go
@@ -36,7 +36,7 @@ func (ps *PlaywrightService) CreateTestApiKeys(ctx context.Context, count int) (
 	for i := 0; i < count; i++ {
 		req := apikey.CreateApiKey{
 			Name:        fmt.Sprintf("test-api-key-%d", i+1),
-			Description: stringPtr(fmt.Sprintf("Test API key %d for Playwright tests", i+1)),
+			Description: new(fmt.Sprintf("Test API key %d for Playwright tests", i+1)),
 		}
 
 		apiKey, err := ps.apiKeyService.CreateApiKey(ctx, user.ID, req)
@@ -78,8 +78,4 @@ func (ps *PlaywrightService) DeleteAllTestApiKeys(ctx context.Context) error {
 
 	slog.Info("Playwright: Test API keys deleted", "count", len(apiKeys))
 	return nil
-}
-
-func stringPtr(s string) *string {
-	return &s
 }

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -238,7 +238,7 @@ func (s *ProjectService) GetProjectServices(ctx context.Context, projectID strin
 	for _, c := range containers {
 		var health *string
 		if c.Health != "" {
-			health = &c.Health
+			health = new(c.Health)
 		}
 
 		var svcConfig *composetypes.ServiceConfig
@@ -262,14 +262,13 @@ func (s *ProjectService) GetProjectServices(ctx context.Context, projectID strin
 
 	for _, svc := range project.Services {
 		if !have[svc.Name] {
-			svcCopy := svc
 			services = append(services, ProjectServiceInfo{
 				Name:          svc.Name,
 				Image:         svc.Image,
 				Status:        "stopped",
 				Ports:         []string{},
 				IconURL:       meta.ServiceIcons[svc.Name],
-				ServiceConfig: &svcCopy,
+				ServiceConfig: new(svc),
 			})
 		}
 	}
@@ -457,10 +456,10 @@ func (s *ProjectService) upsertProjectForDir(ctx context.Context, dirName, dirPa
 		reason := "Project discovered from filesystem, status pending Docker service query"
 		proj := &models.Project{
 			Name:         dirName,
-			DirName:      &dirName,
+			DirName:      new(dirName),
 			Path:         dirPath,
 			Status:       models.ProjectStatusUnknown,
-			StatusReason: &reason,
+			StatusReason: new(reason),
 			ServiceCount: 0,
 			RunningCount: 0,
 		}
@@ -1455,14 +1454,11 @@ func (s *ProjectService) mapProjectToDto(ctx context.Context, p models.Project, 
 		statusLower := strings.ToLower(c.Status)
 		switch {
 		case strings.Contains(statusLower, "(healthy)"):
-			h := "healthy"
-			health = &h
+			health = new("healthy")
 		case strings.Contains(statusLower, "(unhealthy)"):
-			h := "unhealthy"
-			health = &h
+			health = new("unhealthy")
 		case strings.Contains(statusLower, "(starting)"):
-			h := "starting"
-			health = &h
+			health = new("starting")
 		}
 
 		containerName := ""

--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -385,12 +385,12 @@ func (s *SettingsService) MigrateOidcConfigToFields(ctx context.Context) error {
 	}
 
 	_, err = s.UpdateSettings(ctx, settings.Update{
-		OidcClientId:     &oidcConfig.ClientID,
-		OidcClientSecret: &oidcConfig.ClientSecret,
-		OidcIssuerUrl:    &oidcConfig.IssuerURL,
-		OidcScopes:       &scopes,
-		OidcAdminClaim:   &oidcConfig.AdminClaim,
-		OidcAdminValue:   &oidcConfig.AdminValue,
+		OidcClientId:     new(oidcConfig.ClientID),
+		OidcClientSecret: new(oidcConfig.ClientSecret),
+		OidcIssuerUrl:    new(oidcConfig.IssuerURL),
+		OidcScopes:       new(scopes),
+		OidcAdminClaim:   new(oidcConfig.AdminClaim),
+		OidcAdminValue:   new(oidcConfig.AdminValue),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to migrate OIDC config: %w", err)

--- a/backend/internal/services/template_service.go
+++ b/backend/internal/services/template_service.go
@@ -629,15 +629,15 @@ func (s *TemplateService) convertRemoteToLocal(remote tmpl.RemoteTemplate, regis
 		EnvContent:  nil,
 		IsCustom:    false,
 		IsRemote:    true,
-		RegistryID:  &registry.ID,
+		RegistryID:  new(registry.ID),
 		Registry:    registry,
 		Metadata: &models.ComposeTemplateMetadata{
-			Version:          &remote.Version,
-			Author:           &remote.Author,
+			Version:          new(remote.Version),
+			Author:           new(remote.Author),
 			Tags:             remote.Tags,
-			RemoteURL:        &remote.ComposeURL,
-			EnvURL:           &remote.EnvURL,
-			DocumentationURL: &remote.DocumentationURL,
+			RemoteURL:        new(remote.ComposeURL),
+			EnvURL:           new(remote.EnvURL),
+			DocumentationURL: new(remote.DocumentationURL),
 		},
 	}
 }

--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -1253,17 +1253,13 @@ func (s *UpdaterService) logAutoUpdate(ctx context.Context, sev models.EventSeve
 		title = "Auto-update run completed"
 	}
 
-	resourceType := "system"
-	resourceName := "auto_updater"
-	environmentID := "0"
-
 	_, _ = s.eventService.CreateEvent(ctx, CreateEventRequest{
 		Type:          models.EventTypeSystemAutoUpdate,
 		Severity:      sev,
 		Title:         title,
-		ResourceType:  &resourceType,
-		ResourceName:  &resourceName,
-		EnvironmentID: &environmentID,
+		ResourceType:  new("system"),
+		ResourceName:  new("auto_updater"),
+		EnvironmentID: new("0"),
 		Metadata:      metadata,
 	})
 }

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -227,7 +227,7 @@ func (s *UserService) AttachOidcSubjectTransactional(ctx context.Context, userID
 		}
 
 		// Link subject
-		u.OidcSubjectId = &subject
+		u.OidcSubjectId = new(subject)
 
 		if updateFn != nil {
 			updateFn(&u)
@@ -271,8 +271,8 @@ func (s *UserService) CreateDefaultAdmin(ctx context.Context) error {
 		displayName := "Arcane Admin"
 		userModel := &models.User{
 			Username:               "arcane",
-			Email:                  &email,
-			DisplayName:            &displayName,
+			Email:                  new(email),
+			DisplayName:            new(displayName),
 			PasswordHash:           hashedPassword,
 			Roles:                  models.StringSlice{"admin"},
 			RequiresPasswordChange: true,

--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -1100,7 +1100,11 @@ func (s *VulnerabilityService) GetTrivyVersion(ctx context.Context) string {
 		_ = dockerClient.ContainerRemove(ctx, resp.ID, containertypes.RemoveOptions{Force: true})
 		return ""
 	}
-	defer logs.Close()
+	defer func() {
+		if closeErr := logs.Close(); closeErr != nil {
+			slog.WarnContext(ctx, "failed to close trivy version logs stream", "error", closeErr)
+		}
+	}()
 
 	stdoutFile, err := createTrivyLogTempFileInternal("trivy-version-stdout-*")
 	if err != nil {
@@ -1255,7 +1259,7 @@ func (s *VulnerabilityService) createTrivyConfigTempFile(ctx context.Context, co
 	}
 	if _, err := configFile.WriteString(content); err != nil {
 		slog.WarnContext(ctx, "failed to write trivy config", "error", err)
-		configFile.Close()
+		_ = configFile.Close()
 		_ = os.Remove(configFile.Name())
 		return "", false
 	}
@@ -1271,7 +1275,7 @@ func (s *VulnerabilityService) createTrivyIgnoreTempFile(ctx context.Context, co
 	}
 	if _, err := ignoreFile.WriteString(content); err != nil {
 		slog.WarnContext(ctx, "failed to write trivy ignore", "error", err)
-		ignoreFile.Close()
+		_ = ignoreFile.Close()
 		_ = os.Remove(ignoreFile.Name())
 		return "", false
 	}
@@ -1549,7 +1553,11 @@ func (s *VulnerabilityService) runTrivyContainer(
 		_ = dockerClient.ContainerRemove(ctx, resp.ID, containertypes.RemoveOptions{Force: true})
 		return nil, nil, 0, 0, fmt.Errorf("failed to stream trivy logs: %w", err)
 	}
-	defer logs.Close()
+	defer func() {
+		if closeErr := logs.Close(); closeErr != nil {
+			slog.WarnContext(ctx, "failed to close trivy scan logs stream", "error", closeErr)
+		}
+	}()
 
 	logDone := startDockerLogCopyInternal(logs, stdoutFile, stderrFile)
 

--- a/backend/internal/utils/ptr_util.go
+++ b/backend/internal/utils/ptr_util.go
@@ -1,9 +1,5 @@
 package utils
 
-func Ptr[T any](v T) *T {
-	return &v
-}
-
 func DerefString(p *string) string {
 	if p == nil {
 		return ""


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR modernizes pointer creation throughout the backend codebase by adopting Go 1.26's enhanced `new()` function, which now accepts expressions as arguments.

**Key changes:**
- Removed the custom `utils.Ptr` helper function (no longer needed with Go 1.26)
- Replaced patterns like `temp := value; ptr := &temp` with cleaner `new(value)` syntax
- Updated pointer creation for string literals: `new("literal")` instead of creating temporary variables
- Simplified pointer creation for function calls: `new(time.Now())` instead of `now := time.Now(); ptr := &now`
- Added comprehensive test coverage in `event_service_test.go` to verify correct behavior

**Impact:**
- Reduces code verbosity and eliminates unnecessary temporary variables
- Improves code readability by making pointer creation more concise
- Aligns with Go 1.26 best practices per custom rule 4da04955-3abb-4e9c-ae2f-26c1a1adeb57
- No functional changes - purely a refactoring for code clarity
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no risk - it's a clean refactoring with comprehensive test coverage
- This is a straightforward refactoring that leverages Go 1.26's built-in `new()` enhancement. The changes are mechanical, consistent throughout the codebase, and the new test file validates correctness. No logic changes were made.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/utils/ptr_util.go | Removed obsolete `Ptr` helper function now that Go 1.26 provides `new()` with expression support |
| backend/internal/services/auth_service.go | Replaced pointer creation patterns with `new()` for cleaner code; removed utils import |
| backend/internal/services/event_service.go | Replaced temporary variables with `new()` for pointer creation to string literals and variables |
| backend/internal/services/event_service_test.go | Added comprehensive tests verifying `new()` correctly creates pointers to values and handles JSON serialization |
| backend/internal/services/gitops_sync_service.go | Refactored event logging to use `new()` with expressions, removing local variable declarations |
| backend/internal/services/git_repository_service.go | Consistently applied `new()` pattern to event logging throughout repository operations |

</details>


</details>


<sub>Last reviewed commit: 06f5c7d</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - What: Use the new built-in `new` function to initialize variables with expressions for better clarit... ([source](https://app.greptile.com/review/custom-context?memory=4da04955-3abb-4e9c-ae2f-26c1a1adeb57))

<!-- /greptile_comment -->