### PR TITLE
feat: move port mappings to networks tab for container details

### DIFF
--- a/frontend/src/routes/(app)/containers/components/ContainerNetwork.svelte
+++ b/frontend/src/routes/(app)/containers/components/ContainerNetwork.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
+	import { PortBadge } from '$lib/components/badges';
 	import { m } from '$lib/paraglide/messages';
 	import type { ContainerDetailsDto } from '$lib/types/container.type';
 	import { NetworksIcon } from '$lib/icons';
@@ -22,6 +23,27 @@
 </script>
 
 <div class="space-y-6">
+	<Card.Root id="container-port-mappings">
+		<Card.Header icon={NetworksIcon}>
+			<div class="flex flex-col space-y-1.5">
+				<Card.Title>
+					<h2>
+						{m.common_port_mappings()}
+					</h2>
+				</Card.Title>
+			</div>
+		</Card.Header>
+		<Card.Content class="p-4">
+			{#if container.ports && container.ports.length > 0}
+				<PortBadge ports={container.ports} />
+			{:else}
+				<div class="text-muted-foreground rounded-lg border border-dashed py-12 text-center">
+					<div class="text-sm">{m.containers_no_ports()}</div>
+				</div>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
 	<Card.Root>
 		<Card.Header icon={NetworksIcon}>
 			<div class="flex flex-col space-y-1.5">
@@ -141,7 +163,7 @@
 													{m.containers_aliases()}
 												</div>
 												<div class="text-foreground space-y-1 text-sm font-medium">
-													{#each rawNetworkConfig.aliases as alias}
+													{#each rawNetworkConfig.aliases as alias, index (index)}
 														<div class="cursor-pointer font-mono break-all select-all" title="Click to select">
 															{alias}
 														</div>

--- a/frontend/src/routes/(app)/containers/components/ContainerOverview.svelte
+++ b/frontend/src/routes/(app)/containers/components/ContainerOverview.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
 	import StatusBadge from '$lib/components/badges/status-badge.svelte';
-	import { PortBadge } from '$lib/components/badges';
 	import { m } from '$lib/paraglide/messages';
 	import type { ContainerDetailsDto } from '$lib/types/container.type';
 	import { format, formatDistanceToNow } from 'date-fns';
@@ -10,9 +9,10 @@
 	interface Props {
 		container: ContainerDetailsDto;
 		primaryIpAddress: string;
+		onViewPortMappings?: () => void;
 	}
 
-	let { container, primaryIpAddress }: Props = $props();
+	let { container, primaryIpAddress, onViewPortMappings }: Props = $props();
 
 	function parseDockerDate(input: string | Date | undefined | null): Date | null {
 		if (!input) return null;
@@ -256,6 +256,11 @@
 							{m.containers_ports_exposed({ exposed: uniquePorts.exposed })}
 						{/if}
 					</div>
+					{#if onViewPortMappings && uniquePorts.total > 0}
+						<button type="button" class="text-primary w-fit text-xs font-medium hover:underline" onclick={onViewPortMappings}>
+							{m.common_view_details()} → {m.containers_nav_networks()}
+						</button>
+					{/if}
 				</Card.Content>
 			</Card.Root>
 
@@ -345,14 +350,5 @@
 				</Card.Root>
 			{/if}
 		</div>
-
-		{#if container.ports && container.ports.length > 0}
-			<div class="mt-6">
-				<div class="text-muted-foreground mb-3 text-xs font-semibold tracking-wide uppercase">
-					{m.common_port_mappings()}
-				</div>
-				<PortBadge ports={container.ports} />
-			</div>
-		{/if}
 	</Card.Content>
 </Card.Root>


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1379

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reorganizes the container details UI by moving port mappings from the Overview tab to the Networks tab. The implementation adds smooth navigation from the overview to the network tab when users click "View Details" on the ports card. The code follows Svelte 5 best practices by using `$derived` for reactive values and properly handling async navigation with `tick()` and `requestAnimationFrame()`.

**Key changes:**
- Port mappings now display in a dedicated card on the Networks tab
- Added conditional "View Details" link in Overview tab that navigates to Network tab and scrolls to port mappings
- Network tab now shows when container has either networks or ports (previously only networks)
- Fixed keyed each loop in aliases rendering for better performance
- All state management uses proper Svelte 5 patterns (`$derived` instead of `$effect` for computed values)
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no issues found
- The code follows Svelte 5 best practices using `$derived` for reactive computations instead of updating state in `$effect` blocks. The navigation logic properly uses `tick()` to wait for DOM updates and `requestAnimationFrame()` for smooth scrolling. The keyed each loop improvement prevents potential rendering issues. All changes are UI reorganization with no breaking changes to functionality.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/routes/(app)/containers/[containerId]/+page.svelte | Added navigation logic to network tab with port mappings scroll behavior, using proper Svelte 5 patterns with `$derived` and async handling |
| frontend/src/routes/(app)/containers/components/ContainerNetwork.svelte | Moved port mappings display to network tab with proper card structure and keyed each loop |
| frontend/src/routes/(app)/containers/components/ContainerOverview.svelte | Removed port mappings display and added navigation link to view details in network tab |

</details>


</details>


<sub>Last reviewed commit: 4546a57</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->