### PR TITLE
fix: allow custom ssl certificate mappings

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	OidcProviderLogoUrl        string `env:"OIDC_PROVIDER_LOGO_URL" default:""`
 
 	DockerHost              string `env:"DOCKER_HOST" default:"unix:///var/run/docker.sock"`
+	CustomCertsDir          string `env:"CUSTOM_CERTS" default:""`
 	ProjectsDirectory       string `env:"PROJECTS_DIRECTORY" default:"/app/data/projects"`
 	LogJson                 bool   `env:"LOG_JSON" default:"false"`
 	LogLevel                string `env:"LOG_LEVEL" default:"info" options:"toLower"`

--- a/backend/internal/huma/handlers/container_registries.go
+++ b/backend/internal/huma/handlers/container_registries.go
@@ -417,7 +417,7 @@ func (h *ContainerRegistryHandler) performRegistryTest(ctx context.Context, regi
 		}
 	}
 
-	testResult, err := registry.TestRegistryConnection(ctx, registryModel.URL, creds)
+	testResult, err := registry.TestRegistryConnection(ctx, registryModel.URL, creds, h.registryService.GetCertPool(), registryModel.Insecure)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/utils/certs/certs.go
+++ b/backend/internal/utils/certs/certs.go
@@ -1,0 +1,71 @@
+package certs
+
+import (
+	"crypto/x509"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func LoadCustomCertPool(certsDir string) (*x509.CertPool, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("load system cert pool: %w", err)
+	}
+	if pool == nil {
+		pool = x509.NewCertPool()
+	}
+
+	certsDir = strings.TrimSpace(certsDir)
+	if certsDir == "" {
+		return pool, nil
+	}
+
+	stat, err := os.Stat(certsDir)
+	if err != nil {
+		return nil, fmt.Errorf("stat custom certs directory %q: %w", certsDir, err)
+	}
+	if !stat.IsDir() {
+		return nil, fmt.Errorf("custom certs path %q is not a directory", certsDir)
+	}
+
+	loaded := 0
+	scanned := 0
+
+	err = filepath.WalkDir(certsDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		ext := strings.ToLower(filepath.Ext(d.Name()))
+		if ext != ".pem" && ext != ".crt" && ext != ".cert" {
+			return nil
+		}
+
+		scanned++
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read custom cert file %q: %w", path, err)
+		}
+
+		if ok := pool.AppendCertsFromPEM(content); !ok {
+			return fmt.Errorf("no valid PEM certificate found in %q", path)
+		}
+
+		loaded++
+		slog.Info("Loaded custom CA certificate", "path", path)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("load custom certs from %q: %w", certsDir, err)
+	}
+
+	slog.Info("Custom certificate loading complete", "directory", certsDir, "scanned_files", scanned, "loaded_files", loaded)
+	return pool, nil
+}

--- a/backend/internal/utils/http/client.go
+++ b/backend/internal/utils/http/client.go
@@ -1,32 +1,36 @@
 package http
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"net/http"
 	"time"
 )
 
-func NewHTTPClient() *http.Client {
-	transport := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   5 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
-	return &http.Client{
-		Transport: transport,
-		Timeout:   10 * time.Second,
-	}
+func NewHTTPClientWithCertPool(certPool *x509.CertPool) *http.Client {
+	return newHTTPClientInternal(10*time.Second, 5*time.Second, certPool)
 }
 
-func NewHTTPClientWithTimeout(timeout time.Duration) *http.Client {
+func NewHTTPClientWithTimeoutAndCertPool(timeout time.Duration, certPool *x509.CertPool) *http.Client {
+	return newHTTPClientInternal(timeout, 10*time.Second, certPool)
+}
+
+func newHTTPClientInternal(timeout, tlsHandshakeTimeout time.Duration, certPool *x509.CertPool) *http.Client {
 	transport := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
+		TLSHandshakeTimeout:   tlsHandshakeTimeout,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
+
+	if certPool != nil {
+		transport.TLSClientConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			RootCAs:    certPool,
+		}
+	}
+
 	return &http.Client{
 		Transport: transport,
 		Timeout:   timeout,

--- a/backend/internal/utils/registry/client.go
+++ b/backend/internal/utils/registry/client.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"net/http"
 )
 
@@ -9,9 +11,38 @@ type Client struct {
 	http *http.Client
 }
 
-func NewClient() *Client {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+func NewClient(certPool *x509.CertPool) *Client {
+	return NewClientWithInsecure(certPool, false)
+}
+
+func NewClientWithInsecure(certPool *x509.CertPool, insecure bool) *Client {
+	transport := cloneTransportInternal(nil)
 	transport.Proxy = http.ProxyFromEnvironment
 
+	if certPool != nil || insecure {
+		tlsCfg := &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: insecure, // #nosec G402 - this is optional and controlled by explicit insecure-registry setting
+		}
+		if certPool != nil {
+			tlsCfg.RootCAs = certPool
+		}
+		transport.TLSClientConfig = tlsCfg
+	}
+
 	return &Client{http: &http.Client{Transport: transport}}
+}
+
+func cloneTransportInternal(rt http.RoundTripper) *http.Transport {
+	if rt != nil {
+		if transport, ok := rt.(*http.Transport); ok {
+			return transport.Clone()
+		}
+	}
+
+	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+		return defaultTransport.Clone()
+	}
+
+	return &http.Transport{}
 }

--- a/backend/internal/utils/registry/registry_test.go
+++ b/backend/internal/utils/registry/registry_test.go
@@ -24,7 +24,7 @@ func TestCheckAuthParsesRealmAndService(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient()
+	c := NewClient(nil)
 	got, err := c.CheckAuth(context.Background(), srv.URL)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -50,7 +50,7 @@ func TestGetTokenMultiScopes(t *testing.T) {
 	u, _ := url.Parse(srv.URL)
 	authURL := fmt.Sprintf("%s/auth?service=test.local", u.String())
 
-	c := NewClient()
+	c := NewClient(nil)
 	tok, err := c.GetTokenMulti(context.Background(), authURL, []string{"library/a", "library/b"}, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -77,7 +77,7 @@ func TestGetLatestDigestLowerCaseHeader(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient()
+	c := NewClient(nil)
 	d, err := c.GetLatestDigest(context.Background(), srv.URL, "org/repo", "latest", "")
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/backend/internal/utils/registry/test_connection.go
+++ b/backend/internal/utils/registry/test_connection.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -24,8 +25,8 @@ type TestResult struct {
 	Errors         []string  `json:"errors"`
 }
 
-func TestRegistryConnection(ctx context.Context, registryURL string, creds *Credentials) (*TestResult, error) {
-	c := NewClient()
+func TestRegistryConnection(ctx context.Context, registryURL string, creds *Credentials, certPool *x509.CertPool, insecure bool) (*TestResult, error) {
+	c := NewClientWithInsecure(certPool, insecure)
 	res := &TestResult{
 		URL:       registryURL,
 		Domain:    registryURL,

--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -48,6 +48,8 @@ services:
       - ${HOST_PROJECT_ROOT:-..}/backend:/app/backend:cached
       - ${HOST_PROJECT_ROOT:-..}/backend/.air.toml:/app/backend/.air.toml:ro
       - /var/run/docker.sock:/var/run/docker.sock
+      # Optional: mount custom CA certs for self-signed registries
+      # - ${HOST_PROJECT_ROOT:-..}/certs:/app/certs:ro
       - arcane-dev-data:/app/backend/data
       - go-build-cache:/go/cache
       - go-mod-cache:/go/pkg/mod
@@ -63,6 +65,8 @@ services:
       - ENCRYPTION_KEY=dev-encryption-key-replace-in-production-must-be-32-chars
       - JWT_SECRET=dev-jwt-secret-replace-in-production-must-be-long-enough
       - DATABASE_URL=file:data/arcane.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(2500)&_txlock=immediate
+      # Optional: load custom CA certs from mounted directory
+      # - ARCANE_CUSTOM_CERTS=/app/certs
     working_dir: /app/backend
     networks:
       - arcane-dev


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables support for custom SSL certificates for container registries by introducing a new certificate loading system. The implementation adds a `CUSTOM_CERTS` environment variable to specify a directory containing custom CA certificates (.pem, .crt, .cert files), which are loaded at startup and merged with the system cert pool.

**Key changes:**
- Created new `backend/internal/utils/certs` package to load custom certificates from a directory
- Certificate pool is initialized early in bootstrap and passed through HTTP clients, registry clients, and all services that interact with external registries
- All registry operations now properly use the custom cert pool
- Added graceful fallback: if custom cert directory doesn't exist, logs warning and continues with system cert pool
- Properly handles the `Insecure` registry flag by creating per-request clients with `InsecureSkipVerify` when needed
- Comprehensive test coverage for certificate loading edge cases

The implementation is well-structured and follows Go best practices for TLS configuration.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minor considerations around certificate validation behavior.
- The implementation is clean, well-tested, and follows proper TLS security practices. The certificate loading logic has appropriate error handling and fallback mechanisms. However, score is 4 instead of 5 due to one consideration: the interaction between custom certificates and the insecure flag could benefit from documentation clarifying that when a registry is marked insecure, it bypasses both system and custom certificates.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/utils/certs/certs.go | New package that loads custom CA certificates from a directory. Scans for .pem, .crt, and .cert files, appends them to the system cert pool. |
| backend/internal/utils/bootstrap_util.go | Added `InitializeCustomCertPool` with fallback logic: if custom cert directory doesn't exist, logs a warning and returns system cert pool. |
| backend/internal/utils/registry/client.go | Registry client now accepts `certPool` and `insecure` parameters. Creates TLS config with custom certs and optional insecure skip verify. |
| backend/internal/services/container_registry_service.go | Service now stores `certPool`, passes it through registry operations. Creates per-request insecure clients when needed. Fixed credential/insecure flag matching logic. |
| backend/internal/services/image_update_service.go | Stores `certPool`, creates registry clients per-operation with appropriate insecure settings based on registry configuration. |

</details>


</details>


<sub>Last reviewed commit: 899b1d2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->