### PR TITLE
fix: unable to create trivy conatiner due to nano cpu error

### DIFF
--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -894,7 +894,7 @@ func (s *VulnerabilityService) createBatchTrivyContainer(ctx context.Context, tr
 		},
 	}
 
-	resp, err := dockerClient.ContainerCreate(ctx, config, hostConfig, nil, nil, "")
+	resp, err := s.createTrivyContainerWithFallback(ctx, dockerClient, config, hostConfig)
 	if err != nil {
 		return "", fmt.Errorf("failed to create container: %w", err)
 	}
@@ -1510,6 +1510,57 @@ func logTrivyScanFailureDiagnosticsInternal(ctx context.Context, imageName, imag
 	)
 }
 
+func isNanoCPUsUnsupportedErrorInternal(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errMsg := strings.ToLower(err.Error())
+
+	return strings.Contains(errMsg, "nanocpus can not be set") ||
+		strings.Contains(errMsg, "nanocpus cannot be set") ||
+		strings.Contains(errMsg, "cpu cfs scheduler") ||
+		strings.Contains(errMsg, "cpu cfs quota") ||
+		strings.Contains(errMsg, "cpu cfs period")
+}
+
+func cloneHostConfigWithoutNanoCPUsInternal(hostConfig *containertypes.HostConfig) *containertypes.HostConfig {
+	if hostConfig == nil {
+		return nil
+	}
+
+	cloned := *hostConfig
+	cloned.NanoCPUs = 0
+
+	return &cloned
+}
+
+func (s *VulnerabilityService) createTrivyContainerWithFallback(
+	ctx context.Context,
+	dockerClient *client.Client,
+	config *containertypes.Config,
+	hostConfig *containertypes.HostConfig,
+) (containertypes.CreateResponse, error) {
+	resp, err := dockerClient.ContainerCreate(ctx, config, hostConfig, nil, nil, "")
+	if err == nil {
+		return resp, nil
+	}
+
+	if !isNanoCPUsUnsupportedErrorInternal(err) || hostConfig == nil || hostConfig.NanoCPUs <= 0 {
+		return containertypes.CreateResponse{}, err
+	}
+
+	fallbackHostConfig := cloneHostConfigWithoutNanoCPUsInternal(hostConfig)
+	slog.WarnContext(ctx, "docker daemon does not support NanoCPUs; retrying trivy container without cpu limit", "error", err)
+
+	resp, retryErr := dockerClient.ContainerCreate(ctx, config, fallbackHostConfig, nil, nil, "")
+	if retryErr != nil {
+		return containertypes.CreateResponse{}, retryErr
+	}
+
+	return resp, nil
+}
+
 func (s *VulnerabilityService) runTrivyContainer(
 	ctx context.Context,
 	dockerClient *client.Client,
@@ -1534,7 +1585,7 @@ func (s *VulnerabilityService) runTrivyContainer(
 		}
 	}()
 
-	resp, err := dockerClient.ContainerCreate(ctx, config, hostConfig, nil, nil, "")
+	resp, err := s.createTrivyContainerWithFallback(ctx, dockerClient, config, hostConfig)
 	if err != nil {
 		return nil, nil, 0, 0, fmt.Errorf("failed to create trivy container: %w", err)
 	}

--- a/backend/internal/services/vulnerability_service_test.go
+++ b/backend/internal/services/vulnerability_service_test.go
@@ -10,7 +10,10 @@ import (
 	"os"
 	"testing"
 
+	containertypes "github.com/docker/docker/api/types/container"
+	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/getarcaneapp/arcane/types/vulnerability"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -107,4 +110,79 @@ func TestCleanupTrivyLogTempFilesInternal_RemovesFiles(t *testing.T) {
 	_, err = os.Stat(stderrPath)
 	require.Error(t, err)
 	require.True(t, os.IsNotExist(err))
+}
+
+func TestIsNanoCPUsUnsupportedErrorInternal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "matches issue error message",
+			err:  errors.New("Error response from daemon: NanoCPUs can not be set, as your kernel does not support CPU CFS scheduler or the cgroup is not mounted"),
+			want: true,
+		},
+		{
+			name: "matches cannot variant",
+			err:  errors.New("NanoCPUs cannot be set on this daemon"),
+			want: true,
+		},
+		{
+			name: "matches cfs quota warning",
+			err:  errors.New("failed to create container: no cpu cfs quota support"),
+			want: true,
+		},
+		{
+			name: "ignores unrelated errors",
+			err:  errors.New("failed to create container: image not found"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, isNanoCPUsUnsupportedErrorInternal(tc.err))
+		})
+	}
+}
+
+func TestCloneHostConfigWithoutNanoCPUsInternal(t *testing.T) {
+	t.Parallel()
+
+	original := &containertypes.HostConfig{
+		AutoRemove: true,
+		Mounts: []mounttypes.Mount{
+			{
+				Type:   mounttypes.TypeBind,
+				Source: "/var/run/docker.sock",
+				Target: "/var/run/docker.sock",
+			},
+		},
+		Resources: containertypes.Resources{
+			NanoCPUs:   trivyMaxCPUNano,
+			Memory:     trivyMaxMemoryBytes,
+			MemorySwap: trivyMaxMemoryBytes,
+		},
+	}
+
+	cloned := cloneHostConfigWithoutNanoCPUsInternal(original)
+	require.NotNil(t, cloned)
+
+	assert.Zero(t, cloned.NanoCPUs)
+	assert.Equal(t, trivyMaxMemoryBytes, cloned.Memory)
+	assert.Equal(t, trivyMaxMemoryBytes, cloned.MemorySwap)
+	assert.Equal(t, original.AutoRemove, cloned.AutoRemove)
+	assert.Equal(t, original.Mounts, cloned.Mounts)
+
+	// Ensure original is unchanged
+	assert.Equal(t, trivyMaxCPUNano, original.NanoCPUs)
 }


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Trivy container creation failures on Docker hosts that don't support CPU CFS scheduling (e.g., certain kernel configurations or cgroup setups) by adding a fallback that retries without the `NanoCPUs` resource limit.

- Adds `isNanoCPUsUnsupportedErrorInternal` to detect Docker daemon errors related to NanoCPU/CFS unsupported configurations
- Adds `cloneHostConfigWithoutNanoCPUsInternal` to create a copy of the host config with `NanoCPUs` zeroed out
- Introduces `createTrivyContainerWithFallback` which first attempts container creation normally, then retries without CPU limits if a NanoCPU error is detected
- Applies the fallback to both `createBatchTrivyContainer` and `runTrivyContainer`
- Includes table-driven unit tests for the error detection and config cloning functions
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge — it adds a well-scoped fallback mechanism with appropriate logging and tests.
- The changes are focused and defensive: the fallback only activates on specific Docker daemon errors, logs a warning when triggered, and includes unit tests. The shallow copy in the clone function is safe given the usage pattern. Minor concern about broad error string matching, but low practical risk.
- No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/vulnerability_service.go | Adds NanoCPU fallback logic for Trivy container creation. Three new functions: error detection, host config cloning, and a retry wrapper. Applied to both `createBatchTrivyContainer` and `runTrivyContainer`. |
| backend/internal/services/vulnerability_service_test.go | Adds well-structured table-driven tests for the new `isNanoCPUsUnsupportedErrorInternal` and `cloneHostConfigWithoutNanoCPUsInternal` functions. Tests cover nil, positive, and negative cases and verify the original config is not mutated. |

</details>


</details>


<sub>Last reviewed commit: 1d63e51</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->