### PR TITLE
fix: hide internal volumes for backups and volume browser

### DIFF
--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -65,6 +65,12 @@ func Bootstrap(ctx context.Context) error {
 		}
 	}(appCtx)
 
+	if appServices.Volume != nil {
+		if err := appServices.Volume.CleanupOrphanedVolumeHelpers(appCtx); err != nil {
+			slog.WarnContext(appCtx, "Failed to cleanup orphaned volume helpers on startup", "error", err)
+		}
+	}
+
 	utils.LoadAgentToken(appCtx, cfg, appServices.Settings.GetStringSetting)
 	utils.EnsureEncryptionKey(appCtx, cfg, appServices.Settings.EnsureEncryptionKey)
 	crypto.InitEncryption(cfg)

--- a/backend/internal/services/volume_service_test.go
+++ b/backend/internal/services/volume_service_test.go
@@ -1,0 +1,57 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsLegacyVolumeHelperContainerInternal(t *testing.T) {
+	tests := []struct {
+		name    string
+		summary container.Summary
+		want    bool
+	}{
+		{
+			name: "legacy helper signature matches",
+			summary: container.Summary{
+				Labels: map[string]string{
+					libarcane.InternalResourceLabel: "true",
+				},
+				Command: "sleep infinity",
+				Mounts: []container.MountPoint{
+					{Destination: "/volume"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "internal trivy-like helper is not treated as legacy volume helper",
+			summary: container.Summary{
+				Labels: map[string]string{
+					libarcane.InternalResourceLabel: "true",
+				},
+				Command: "trivy image --quiet alpine:latest",
+				Mounts: []container.MountPoint{
+					{Destination: "/var/run/docker.sock"},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isLegacyVolumeHelperContainerInternal(tt.summary))
+		})
+	}
+}
+
+func TestBuildVolumeHelperLabelsInternal(t *testing.T) {
+	labels := buildVolumeHelperLabelsInternal()
+
+	require.Equal(t, "true", labels[libarcane.InternalResourceLabel])
+	require.Len(t, labels, 1)
+}

--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -870,7 +870,7 @@ func (s *VulnerabilityService) createBatchTrivyContainer(ctx context.Context, tr
 		Image:      trivyImage,
 		Entrypoint: []string{"sh", "-c", "trap 'exit 0' TERM; while :; do sleep 1; done"},
 		Labels: map[string]string{
-			libarcane.InternalContainerLabel: "true",
+			libarcane.InternalResourceLabel: "true",
 		},
 	}
 
@@ -1073,7 +1073,7 @@ func (s *VulnerabilityService) GetTrivyVersion(ctx context.Context) string {
 		Image: trivyImage,
 		Cmd:   []string{"--version"},
 		Labels: map[string]string{
-			libarcane.InternalContainerLabel: "true",
+			libarcane.InternalResourceLabel: "true",
 		},
 	}
 
@@ -1223,7 +1223,7 @@ func (s *VulnerabilityService) ensureTrivyCacheVolumeInternal(ctx context.Contex
 	_, err = dockerClient.VolumeCreate(ctx, volumetypes.CreateOptions{
 		Name: trivyCacheVolumeName,
 		Labels: map[string]string{
-			libarcane.InternalContainerLabel: "true",
+			libarcane.InternalResourceLabel: "true",
 		},
 	})
 	if err != nil {
@@ -1320,7 +1320,7 @@ func buildTrivyContainerConfig(trivyImage string, cmdArgs []string) *containerty
 		Image: trivyImage,
 		Cmd:   cmdArgs,
 		Labels: map[string]string{
-			libarcane.InternalContainerLabel: "true",
+			libarcane.InternalResourceLabel: "true",
 		},
 	}
 }

--- a/backend/pkg/libarcane/internal_resource.go
+++ b/backend/pkg/libarcane/internal_resource.go
@@ -3,14 +3,18 @@ package libarcane
 import "strings"
 
 // Internal containers indicate containers used for arcanes utilties, ie: temp containers used for viewing files for volumes etc
-const InternalContainerLabel = "com.getarcaneapp.internal.container"
+const (
+	InternalResourceLabel = "com.getarcaneapp.internal.resource"
+	// Deprecated - Legacy label. Use InternalResourceLabel instead.
+	legacyInternalContainerLabel = "com.getarcaneapp.internal.container"
+)
 
 func IsInternalContainer(labels map[string]string) bool {
 	if labels == nil {
 		return false
 	}
 	for k, v := range labels {
-		if strings.EqualFold(k, InternalContainerLabel) {
+		if strings.EqualFold(k, InternalResourceLabel) || strings.EqualFold(k, legacyInternalContainerLabel) {
 			switch strings.TrimSpace(strings.ToLower(v)) {
 			case "true", "1", "yes", "on":
 				return true

--- a/frontend/src/lib/components/arcane-table/arcane-table-toolbar.svelte
+++ b/frontend/src/lib/components/arcane-table/arcane-table-toolbar.svelte
@@ -216,10 +216,6 @@
 			{@render customToolbarActions()}
 		{/if}
 
-		{#if customToolbarActions}
-			{@render customToolbarActions()}
-		{/if}
-
 		<div class="hidden md:block">
 			<DataTableViewOptions {table} {customViewOptions} />
 		</div>


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1641

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements functionality to hide internal volumes (like `arcane-backups`) from the volumes list and browser by default, with a UI toggle to show them when needed. The changes include:

- Renamed `InternalContainerLabel` to `InternalResourceLabel` to support labeling both containers and volumes as internal resources, maintaining backward compatibility
- Refactored helper container strategy to prefer `busybox:stable-musl` over Arcane image, with fallback logic
- Added `CleanupOrphanedVolumeHelpers` function called on startup to prevent resource leaks from previous Arcane runs
- Added `includeInternal` query parameter to volume list/count endpoints
- Implemented frontend toggle "Show Internal Volumes" in the volumes table view options
- Fixed bug in `GetVolumeUsageCounts` where `dockerService` was incorrectly used instead of `volumeService`
- Added unit tests for helper container identification logic

The implementation properly filters internal volumes by checking both the internal resource label and the backup volume name.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is generally safe to merge with appropriate testing
- The PR implements a significant refactor to hide internal volumes and improve helper container management. The changes are well-tested with new unit tests, maintain backward compatibility, and fix existing bugs. However, the volume_service.go changes are substantial and affect core backup/restore operations, warranting thorough testing before merging.
- Pay close attention to `backend/internal/services/volume_service.go` due to the extensive changes to helper container management and image resolution strategy
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/pkg/libarcane/internal_resource.go | Renamed label constant from `InternalContainerLabel` to `InternalResourceLabel` to support both containers and volumes, maintains backward compatibility with legacy label |
| backend/internal/huma/handlers/volumes.go | Added `includeInternal` query param to list and count endpoints, fixed bug where `dockerService` was used instead of `volumeService` in counts endpoint |
| backend/internal/services/volume_service.go | Major refactor: switched to busybox helper image, added internal volume filtering, cleanup logic for orphaned helpers, and improved helper image resolution strategy with arcane fallback |
| frontend/src/routes/(app)/volumes/volume-table.svelte | Added UI toggle to show/hide internal volumes with persistence via customSettings |

</details>


</details>


<sub>Last reviewed commit: 7e30147</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->