### PR TITLE
fix: image counts are incorrectly calculated

### DIFF
--- a/backend/internal/services/docker_client_service_test.go
+++ b/backend/internal/services/docker_client_service_test.go
@@ -1,0 +1,38 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCountImageUsage_UsesContainerImageIDs(t *testing.T) {
+	images := []image.Summary{
+		{ID: "sha256:image-a", Containers: -1},
+		{ID: "sha256:image-b", Containers: 0},
+		{ID: "sha256:image-c", Containers: 99},
+	}
+
+	containers := []container.Summary{
+		{ImageID: "sha256:image-a"},
+		{ImageID: "sha256:image-c"},
+		{ImageID: "sha256:image-a"}, // duplicate container ref should not affect counts
+		{ImageID: ""},
+	}
+
+	inuse, unused, total := countImageUsageInternal(images, containers)
+
+	assert.Equal(t, 2, inuse)
+	assert.Equal(t, 1, unused)
+	assert.Equal(t, 3, total)
+}
+
+func TestCountImageUsage_NoImages(t *testing.T) {
+	inuse, unused, total := countImageUsageInternal(nil, []container.Summary{{ImageID: "sha256:image-a"}})
+
+	assert.Equal(t, 0, inuse)
+	assert.Equal(t, 0, unused)
+	assert.Equal(t, 0, total)
+}

--- a/types/imageupdate/image_update.go
+++ b/types/imageupdate/image_update.go
@@ -74,7 +74,7 @@ type Response struct {
 }
 
 type Summary struct {
-	// TotalImages is the total number of images checked.
+	// TotalImages is the total number of current Docker images considered.
 	//
 	// Required: true
 	TotalImages int `json:"totalImages"`


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1712

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

Fixed incorrect image count calculations by replacing unreliable `image.Containers` field with proper container-to-image ID matching. The PR addresses two key issues:

- **Image usage tracking**: Now fetches all containers and builds a map of in-use image IDs, then checks each image against this map. Previously relied on `image.Containers` field which was producing incorrect counts (showing -1, 0, or 99 values).
- **Update summary accuracy**: `GetUpdateSummary` now filters counts to only live Docker images, preventing stale database records from inflating statistics.

The changes include comprehensive test coverage verifying the fixes work correctly, and integration tests to ensure the API counts align with the actual image data.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no identified risks
- The changes are well-architected with proper error handling, comprehensive unit tests demonstrating the fix works correctly, and integration tests validating end-to-end behavior. The root cause is clearly addressed by replacing unreliable data with proper container-to-image ID matching
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/docker_client_service.go | Fixed image usage counting by checking container ImageIDs instead of unreliable image.Containers field |
| backend/internal/services/image_service.go | Refactored prune cleanup logic into smaller functions and added orphaned record cleanup |
| backend/internal/services/image_update_service.go | Fixed GetUpdateSummary to only count live Docker images, preventing stale data from inflating counts |

</details>


</details>


<sub>Last reviewed commit: 19c5c57</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->