### PR TITLE
fix: git test connection not using default branch

### DIFF
--- a/backend/internal/huma/handlers/git_repositories.go
+++ b/backend/internal/huma/handlers/git_repositories.go
@@ -75,7 +75,7 @@ type DeleteGitRepositoryOutput struct {
 
 type TestGitRepositoryInput struct {
 	ID     string `path:"id" doc:"Repository ID"`
-	Branch string `query:"branch" doc:"Branch to test (optional, defaults to main)"`
+	Branch string `query:"branch" doc:"Branch to test (optional, uses repository default branch when omitted)"`
 }
 
 type TestGitRepositoryOutput struct {

--- a/backend/internal/services/git_repository_service.go
+++ b/backend/internal/services/git_repository_service.go
@@ -265,10 +265,6 @@ func (s *GitRepositoryService) TestConnection(ctx context.Context, id string, br
 		return err
 	}
 
-	if branch == "" {
-		branch = "main"
-	}
-
 	err = s.gitClient.TestConnection(ctx, repository.URL, branch, authConfig)
 	if err != nil {
 		// Log error event


### PR DESCRIPTION
## What This PR Implements

Test connection for git syncs will now use the default branch and no ref.

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1754

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes git test connection to use the repository's actual default branch instead of hardcoding a fallback to `"main"`. Previously, when no branch was specified, `TestConnection` would default to `"main"`, which would fail for repositories with a different default branch (e.g., `master`, `develop`). Now, an empty branch is passed through to the git client's `Clone` method, which correctly uses go-git's default behavior of cloning whatever HEAD points to on the remote.

- Removed the `if branch == "" { branch = "main" }` fallback in `GitRepositoryService.TestConnection`
- Updated the API doc string on `TestGitRepositoryInput.Branch` to accurately describe the new behavior
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — it's a minimal, correct fix that removes a hardcoded assumption.
- The change is small (4 lines removed, 1 doc string updated), well-scoped, and the downstream git client already handles empty branch strings correctly by defaulting to the remote's HEAD. No new code paths or edge cases are introduced.
- No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/huma/handlers/git_repositories.go | Documentation-only change: updated the `Branch` query parameter doc string from "defaults to main" to "uses repository default branch when omitted" to accurately reflect the new behavior. |
| backend/internal/services/git_repository_service.go | Removed hardcoded fallback to "main" branch in `TestConnection`. When branch is empty, the downstream `Clone` method in the git client correctly omits `ReferenceName` and `SingleBranch`, causing go-git to use the remote's default branch (HEAD). |

</details>


</details>


<sub>Last reviewed commit: 81ee844</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->