### PR TITLE
fix: change notification logs to TEXT instead of VARCHAR(255)

### DIFF
--- a/backend/internal/models/notification.go
+++ b/backend/internal/models/notification.go
@@ -70,7 +70,7 @@ func (NotificationSettings) TableName() string {
 type NotificationLog struct {
 	ID        uint                 `json:"id" gorm:"primaryKey"`
 	Provider  NotificationProvider `json:"provider" gorm:"not null;index;type:varchar(50)"`
-	ImageRef  string               `json:"imageRef" gorm:"not null"`
+	ImageRef  string               `json:"imageRef" gorm:"not null;type:text"`
 	Status    string               `json:"status" gorm:"not null"`
 	Error     *string              `json:"error,omitempty"`
 	Metadata  JSON                 `json:"metadata" gorm:"type:jsonb"`

--- a/backend/resources/migrations/postgres/036_notification_log_image_ref_text.down.sql
+++ b/backend/resources/migrations/postgres/036_notification_log_image_ref_text.down.sql
@@ -1,0 +1,2 @@
+-- Revert image_ref back to VARCHAR(255)
+ALTER TABLE notification_logs ALTER COLUMN image_ref TYPE VARCHAR(255);

--- a/backend/resources/migrations/postgres/036_notification_log_image_ref_text.up.sql
+++ b/backend/resources/migrations/postgres/036_notification_log_image_ref_text.up.sql
@@ -1,0 +1,2 @@
+-- Change image_ref from VARCHAR(255) to TEXT to support batch notifications with multiple image refs
+ALTER TABLE notification_logs ALTER COLUMN image_ref TYPE TEXT;

--- a/backend/resources/migrations/sqlite/036_notification_log_image_ref_text.down.sql
+++ b/backend/resources/migrations/sqlite/036_notification_log_image_ref_text.down.sql
@@ -1,0 +1,1 @@
+-- No-op: SQLite doesn't enforce VARCHAR length constraints

--- a/backend/resources/migrations/sqlite/036_notification_log_image_ref_text.up.sql
+++ b/backend/resources/migrations/sqlite/036_notification_log_image_ref_text.up.sql
@@ -1,0 +1,3 @@
+-- SQLite doesn't enforce VARCHAR length, but we recreate the table for consistency
+-- SQLite treats VARCHAR(255) and TEXT the same, so this is a no-op for existing data
+-- but documents the intended schema change


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

Changed the `image_ref` column in `notification_logs` table from VARCHAR(255) to TEXT to support batch notifications. This fixes a data truncation issue where multiple image references joined with `", "` (seen at `notification_service.go:1222`) could exceed the 255-character limit.

- Updated GORM model to specify `type:text` for the `ImageRef` field
- Added PostgreSQL migration 036 to ALTER the column type from VARCHAR(255) to TEXT
- Added SQLite migration 036 as documentation (no-op since SQLite doesn't enforce VARCHAR length)
- Both up and down migrations are present for proper rollback support
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The change is straightforward and addresses a legitimate data storage limitation. The migration syntax is correct for both PostgreSQL and SQLite, includes proper rollback migrations, and follows the existing migration numbering scheme. The GORM model change correctly specifies the text type, and this aligns with how the field is used in the codebase (storing comma-separated lists of image references in batch notifications).
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/models/notification.go | Updated `ImageRef` field gorm tag to specify `type:text` for unbounded string storage |
| backend/resources/migrations/postgres/036_notification_log_image_ref_text.up.sql | Alters `image_ref` column from VARCHAR(255) to TEXT to support batch notifications with multiple image references |
| backend/resources/migrations/postgres/036_notification_log_image_ref_text.down.sql | Reverts `image_ref` column back to VARCHAR(255) |

</details>


</details>


<sub>Last reviewed commit: 8ea14f0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->