### PR TITLE
fix: convert cron expressions from utc into TZ var timezone

### DIFF
--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -133,7 +133,8 @@ func Bootstrap(ctx context.Context) error {
 		}
 	}
 
-	scheduler := scheduler.NewJobScheduler(appCtx)
+	cronLocation := cfg.GetLocation()
+	scheduler := scheduler.NewJobScheduler(appCtx, cronLocation)
 	appServices.JobSchedule.SetScheduler(scheduler)
 	registerJobs(appCtx, scheduler, appServices, cfg)
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/getarcaneapp/arcane/backend/internal/common"
 )
@@ -72,6 +73,10 @@ type Config struct {
 	RegistryTimeout        int    `env:"REGISTRY_TIMEOUT" default:"0"`
 	ProxyRequestTimeout    int    `env:"PROXY_REQUEST_TIMEOUT" default:"0"`
 	BackupVolumeName       string `env:"ARCANE_BACKUP_VOLUME_NAME" default:"arcane-backups"`
+
+	// Timezone for cron job scheduling. Uses IANA timezone names (e.g., "America/New_York", "Europe/London").
+	// "Local" uses the system's local timezone, "UTC" for Coordinated Universal Time.
+	Timezone string `env:"TZ" default:"Local"`
 
 	// BuildablesConfig contains feature-specific configuration that can be conditionally compiled
 	BuildablesConfig
@@ -305,6 +310,24 @@ func (c *Config) ListenAddr() string {
 		return ":" + port
 	}
 	return net.JoinHostPort(host, port)
+}
+
+// GetLocation returns the timezone location for cron scheduling.
+// It parses the Timezone config (TZ env var) into a *time.Location.
+// Returns the system's local timezone if Timezone is "Local".
+// Defaults to UTC if not set or if the timezone cannot be loaded.
+func (c *Config) GetLocation() *time.Location {
+	tz := strings.TrimSpace(c.Timezone)
+	if tz == "" {
+		return time.UTC
+	}
+
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		slog.Warn("Failed to load timezone, falling back to UTC", "timezone", tz, "error", err)
+		return time.UTC
+	}
+	return loc
 }
 
 // GetManagerBaseURL returns the base URL of the manager application.

--- a/docker/examples/compose.basic.yaml
+++ b/docker/examples/compose.basic.yaml
@@ -11,6 +11,9 @@ services:
     environment:
       - ENCRYPTION_KEY=xxxxxxxxxxxxxxxxxxxxxx
       - JWT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxx
+      # Timezone for cron job scheduling (e.g., America/New_York, Europe/London, UTC)
+      # See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+      - TZ=UTC
     # Use host cgroup namespace for better container self-detection
     # This allows Arcane to detect its own container ID more reliably
     cgroup: host


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1771

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements timezone support for cron job scheduling by adding a configurable `TZ` environment variable that allows users to specify their timezone for job schedules. The implementation properly threads the timezone location through the entire system: from config parsing to scheduler initialization to next-run calculations.

**Key changes:**
- Added `TZ` env var with default "Local" in config, with `GetLocation()` helper that falls back to UTC on errors
- Updated `NewJobScheduler` to accept and use `*time.Location` via `cron.WithLocation()`
- Modified `JobService` to store the timezone and apply it in `calculateNextRunInternal()` for accurate next-run display
- Added documentation and example in `compose.basic.yaml`

The implementation correctly handles the scheduler's timezone through the `cron.WithLocation()` option. The `calculateNextRunInternal` method manually sets the location on the parsed schedule, which works with the current cron v3.0.1 library (as noted in the existing comment thread).
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The implementation is clean, follows Go best practices, and properly handles timezone conversion throughout the cron scheduling system. The changes are well-scoped, have good error handling (fallback to UTC), and include helpful documentation. No security concerns, breaking changes, or logical errors were found.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/config/config.go | Added `TZ` environment variable config and `GetLocation()` helper with proper fallback to UTC |
| backend/pkg/scheduler/scheduler.go | Updated `NewJobScheduler` to accept timezone location and pass it to cron via `WithLocation` option |
| backend/internal/bootstrap/bootstrap.go | Retrieves timezone from config and passes it to scheduler constructor |
| backend/internal/services/job_service.go | Stores timezone location and applies it to cron schedule calculations in `calculateNextRunInternal` |
| docker/examples/compose.basic.yaml | Added `TZ` environment variable example with helpful comment and documentation link |

</details>


</details>


<sub>Last reviewed commit: 8ba3455</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->