### PR TITLE
fix: image size mismatch on details page

### DIFF
--- a/backend/internal/huma/handlers/images.go
+++ b/backend/internal/huma/handlers/images.go
@@ -289,17 +289,15 @@ func (h *ImageHandler) GetImage(ctx context.Context, input *GetImageInput) (*Get
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	img, err := h.imageService.GetImageByID(ctx, input.ImageID)
+	out, err := h.imageService.GetImageDetail(ctx, input.ImageID)
 	if err != nil {
 		return nil, huma.Error404NotFound((&common.ImageNotFoundError{Err: err}).Error())
 	}
 
-	out := image.NewDetailSummary(img)
-
 	return &GetImageOutput{
 		Body: base.ApiResponse[image.DetailSummary]{
 			Success: true,
-			Data:    out,
+			Data:    *out,
 		},
 	}, nil
 }

--- a/frontend/src/routes/(app)/images/[imageId]/+page.svelte
+++ b/frontend/src/routes/(app)/images/[imageId]/+page.svelte
@@ -140,7 +140,7 @@
 		}
 	});
 
-	const imageSize = $derived.by(() => bytes.format(image?.size || 0) || '0 B');
+	const imageSize = $derived.by(() => bytes.format(Number(image?.size ?? 0)) || '0 B');
 	const architecture = $derived.by(() => image?.architecture || m.common_na());
 	const osName = $derived.by(() => image?.os || m.common_na());
 	const repoTags = $derived.by(() => image?.repoTags ?? []);


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

Added new `GetImageDetail` method to fetch image details with correct size values by querying both `ImageInspect` and `ImageList` concurrently, addressing a size mismatch between the details page and list view.

**Critical Issue Found:**
- Line 93 in `backend/internal/services/image_service.go` uses `new(inspect)` which creates a zero-valued struct instead of `&inspect`, causing all image details (tags, digests, architecture, config, etc.) to be lost

**Other Changes:**
- Updated handler to call new `GetImageDetail` method
- Fixed frontend type handling for image size field
</details>


<details open><summary><h3>Confidence Score: 0/5</h3></summary>

- This PR contains a critical bug that will break the image details page by returning empty data
- Line 93 passes a zero-valued struct to `NewDetailSummary` instead of the populated `inspect` variable, causing complete data loss. This will result in the image details page showing no tags, digests, configuration, or metadata - only the ID and size will be populated. This is a blocking issue that must be fixed before merge.
- backend/internal/services/image_service.go requires immediate attention - line 93 must be changed from `new(inspect)` to `&inspect`
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/image_service.go | Added `GetImageDetail` with concurrent fetching, but critical bug: passes zero-valued struct instead of populated `inspect` variable to `NewDetailSummary` |
| backend/internal/huma/handlers/images.go | Correctly updated to call new `GetImageDetail` method and dereference the pointer result |
| frontend/src/routes/(app)/images/[imageId]/+page.svelte | Fixed type handling for image size by wrapping in `Number()` and using nullish coalescing |

</details>


</details>


<sub>Last reviewed commit: c2b937c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->