### PR TITLE
fix: silently refresh token on version mismatch instead of forcing logout

### DIFF
--- a/frontend/src/routes/(auth)/login/+page.ts
+++ b/frontend/src/routes/(auth)/login/+page.ts
@@ -3,11 +3,13 @@ import { redirect } from '@sveltejs/kit';
 export const load = async ({ parent, url }) => {
 	const data = await parent();
 
-	if (data.user) {
-		throw redirect(302, '/dashboard');
-	}
+	const rawRedirect = url.searchParams.get('redirect') || '/dashboard';
+	// Guard against open redirects — only allow same-origin relative paths
+	const redirectTo = rawRedirect.startsWith('/') && !rawRedirect.startsWith('//') ? rawRedirect : '/dashboard';
 
-	const redirectTo = url.searchParams.get('redirect') || '/dashboard';
+	if (data.user) {
+		throw redirect(302, redirectTo);
+	}
 
 	const error = url.searchParams.get('error');
 	const errorMessage =

--- a/tests/spec/token-refresh.spec.ts
+++ b/tests/spec/token-refresh.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const REFRESH_TOKEN_KEY = "arcane_refresh_token";
+const TOKEN_EXPIRY_KEY = "arcane_token_expiry";
+
+/**
+ * Register an addInitScript that plants a fake refresh token in sessionStorage
+ * BEFORE any page JavaScript runs on every navigation. Unlike page.evaluate(),
+ * addInitScript survives page.goto() calls made later in the test.
+ */
+async function registerTokenSeeding(page: Page) {
+  await page.addInitScript(
+    ([tokenKey, expiryKey]: [string, string]) => {
+      sessionStorage.setItem(tokenKey, "playwright-test-refresh-token");
+      sessionStorage.setItem(expiryKey, new Date(Date.now() + 3_600_000).toISOString());
+    },
+    [REFRESH_TOKEN_KEY, TOKEN_EXPIRY_KEY],
+  );
+}
+
+/**
+ * Intercept the FIRST request matching urlPattern with a 401 version-mismatch
+ * body. All subsequent requests (e.g. the interceptor's automatic retry) pass
+ * through. Uses a flag rather than unroute() to avoid "Route is already handled".
+ */
+async function injectVersionMismatch401Once(page: Page, urlPattern: string | RegExp) {
+  let fired = false;
+  await page.route(urlPattern, async (route) => {
+    if (!fired) {
+      fired = true;
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          code: "UNAUTHORIZED",
+          message: "Application has been updated. Please log in again.",
+        }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+/**
+ * Intercept every request matching urlPattern with a 401.
+ */
+async function injectExpired401Always(page: Page, urlPattern: string | RegExp) {
+  await page.route(urlPattern, async (route) => {
+    await route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({ code: "UNAUTHORIZED", message: "Invalid or expired token" }),
+    });
+  });
+}
+
+/**
+ * Mock /auth/refresh to return a synthetic 200. Returns a getter to assert
+ * whether the endpoint was called.
+ */
+async function mockRefreshSuccess(page: Page): Promise<() => boolean> {
+  let called = false;
+  await page.route(/\/api\/auth\/refresh$/, async (route) => {
+    called = true;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: {
+          token: "mocked-access-token",
+          refreshToken: "mocked-refresh-token",
+          expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+        },
+      }),
+    });
+  });
+  return () => called;
+}
+
+test.describe("Token refresh behaviour", () => {
+  test("version mismatch 401 on /auth/me during page load is silently recovered", async ({ page }) => {
+    await registerTokenSeeding(page);
+    const wasRefreshCalled = await mockRefreshSuccess(page);
+    await injectVersionMismatch401Once(page, /\/api\/auth\/me$/);
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    expect(wasRefreshCalled()).toBe(true);
+    await expect(page).toHaveURL("/dashboard");
+    await expect(page.getByRole("button", { name: "Sign in to Arcane" })).not.toBeVisible();
+  });
+
+  test("version mismatch 401 on a data endpoint mid-session is silently recovered", async ({ page }) => {
+    await registerTokenSeeding(page);
+    const wasRefreshCalled = await mockRefreshSuccess(page);
+    await injectVersionMismatch401Once(page, /\/api\/environments\/0\/containers/);
+
+    await page.goto("/containers");
+    await page.waitForLoadState("networkidle");
+
+    expect(wasRefreshCalled()).toBe(true);
+    await expect(page).toHaveURL("/containers");
+    await expect(page.getByRole("heading", { name: "Containers", level: 1 })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign in to Arcane" })).not.toBeVisible();
+  });
+
+  test("failed token refresh redirects to /login", async ({ page }) => {
+    await registerTokenSeeding(page);
+
+    await page.route(/\/api\/auth\/refresh$/, async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ code: "UNAUTHORIZED", message: "Invalid or expired refresh token" }),
+      });
+    });
+
+    // Make /auth/me always 401 so the interceptor triggers the refresh flow on load.
+    await injectExpired401Always(page, /\/api\/auth\/me$/);
+
+    await page.goto("/dashboard");
+    await page.waitForURL(/\/login/, { timeout: 10_000 });
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole("button", { name: "Sign in to Arcane", exact: true })).toBeVisible();
+  });
+
+  test("unauthenticated users are redirected to /login", async ({ page }) => {
+    await page.context().clearCookies();
+    await page.goto("/dashboard");
+    await page.waitForURL(/\/login/, { timeout: 10_000 });
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole("button", { name: "Sign in to Arcane", exact: true })).toBeVisible();
+  });
+
+  test("login page honours the redirect param and returns users to their original path", async ({ page }) => {
+    await page.goto("/login?redirect=%2Fcontainers");
+    await page.waitForURL(/\/containers|\/login/, { timeout: 8_000 });
+    const url = page.url();
+    expect(url).toMatch(/\/containers|\/login\?redirect=%2Fcontainers/);
+  });
+});


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes the 401 interceptor to attempt a silent token refresh on version-mismatch errors instead of immediately forcing a logout. Previously, a cookie version mismatch would skip the refresh path entirely and redirect to login. Now the interceptor always tries the refresh handler first, falling back to a login redirect only if the refresh itself fails. Additionally, `refreshAccessToken` now throws on failure instead of returning `null`, which propagates errors to concurrent callers via the subscriber pattern. The login page gains an open redirect guard and now respects the `redirect` query param for already-authenticated users.

- The core interceptor change in `api-service.ts` removes the `!isVersionMismatch` guard so refresh is attempted even on version-tagged 401s, with a clean fallback path when refresh fails
- `/auth/me` removed from `skipAuthPaths`, allowing the interceptor to attempt token refresh on session-check 401s — this enables silent re-auth after app updates
- `refreshAccessToken` in `auth-service.ts` now throws errors instead of returning `null`, and the subscriber queue properly propagates errors to concurrent callers
- Login page adds an open redirect guard (`startsWith('/')` and `!startsWith('//')`) and moves redirect resolution before the auth check
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge — the logic changes are well-reasoned and edge cases are handled.
- The changes address a real UX issue (forced logout on version mismatch) with a sensible approach: try silent refresh first, fall back to login redirect. Error propagation to concurrent callers is properly fixed. The open redirect guard is a good security improvement. The PR description is sparse (no issue linked, no testing checklist completed), which is the main reason for not scoring 5.
- `frontend/src/lib/services/api-service.ts` — the interceptor flow is the most critical change and should be tested with both valid and expired refresh tokens during a version mismatch.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/services/api-service.ts | Interceptor now tries token refresh on version mismatch 401s before redirecting, removes `/auth/me` from skip list, and adds structured fallback when no refresh handler is available. Logic is sound. |
| frontend/src/lib/services/auth-service.ts | Changed `refreshAccessToken` to throw on failure instead of returning null. Concurrent subscriber pattern now properly propagates errors. All callers handle the throws. |
| frontend/src/routes/(auth)/login/+page.ts | Added open redirect protection for the `redirect` query parameter and moved redirect resolution before the auth check so already-logged-in users are redirected to the intended page instead of always going to `/dashboard`. |

</details>


</details>


<sub>Last reviewed commit: 6ab4d32</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=2e3f3c6f-4c88-4dcf-b9fa-85cac1da67f7))

<!-- /greptile_comment -->