### PR TITLE
perf: improve performance of image update, prune, and vuln actions

### DIFF
--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -36,6 +36,14 @@ type ImageParts struct {
 	Tag        string
 }
 
+type localImageSnapshot struct {
+	ImageID       string
+	Repository    string
+	Tag           string
+	PrimaryDigest string
+	AllDigests    []string
+}
+
 func NewImageUpdateService(db *database.DB, settingsService *SettingsService, registryService *ContainerRegistryService, dockerService *DockerClientService, eventService *EventService, notificationService *NotificationService) *ImageUpdateService {
 	return &ImageUpdateService{
 		db:                  db,
@@ -61,7 +69,7 @@ func (s *ImageUpdateService) CheckImageUpdate(ctx context.Context, imageRef stri
 
 	registries := s.getRegistriesForImage(ctx, parts.Registry)
 
-	digestResult, err := s.checkDigestUpdate(ctx, parts, registries)
+	digestResult, snapshot, err := s.checkDigestUpdateWithSnapshotInternal(ctx, parts, registries)
 	if err != nil {
 		result := &imageupdate.Response{
 			Error:          err.Error(),
@@ -77,7 +85,7 @@ func (s *ImageUpdateService) CheckImageUpdate(ctx context.Context, imageRef stri
 		if logErr := s.eventService.LogImageEvent(ctx, models.EventTypeImageScan, "", imageRef, systemUser.ID, systemUser.Username, "0", metadata); logErr != nil {
 			slog.WarnContext(ctx, "Failed to log image update check error event", "imageRef", imageRef, "error", logErr.Error())
 		}
-		if saveErr := s.saveUpdateResult(ctx, imageRef, result); saveErr != nil {
+		if saveErr := s.saveUpdateResultWithSnapshotInternal(ctx, imageRef, result, snapshot); saveErr != nil {
 			slog.WarnContext(ctx, "Failed to save update result", "imageRef", imageRef, "error", saveErr.Error())
 		}
 		return result, err
@@ -96,7 +104,7 @@ func (s *ImageUpdateService) CheckImageUpdate(ctx context.Context, imageRef stri
 	if logErr := s.eventService.LogImageEvent(ctx, models.EventTypeImageScan, "", imageRef, systemUser.ID, systemUser.Username, "0", metadata); logErr != nil {
 		slog.WarnContext(ctx, "Failed to log image update check event", "imageRef", imageRef, "error", logErr.Error())
 	}
-	if saveErr := s.saveUpdateResult(ctx, imageRef, digestResult); saveErr != nil {
+	if saveErr := s.saveUpdateResultWithSnapshotInternal(ctx, imageRef, digestResult, snapshot); saveErr != nil {
 		slog.WarnContext(ctx, "Failed to save update result", "imageRef", imageRef, "error", saveErr.Error())
 	}
 
@@ -169,12 +177,12 @@ func (s *ImageUpdateService) getRegistryToken(ctx context.Context, regHost, repo
 	return "", nil, fmt.Errorf("failed to get registry token")
 }
 
-func (s *ImageUpdateService) checkDigestUpdate(ctx context.Context, parts *ImageParts, registries []models.ContainerRegistry) (*imageupdate.Response, error) {
+func (s *ImageUpdateService) checkDigestUpdateWithSnapshotInternal(ctx context.Context, parts *ImageParts, registries []models.ContainerRegistry) (*imageupdate.Response, *localImageSnapshot, error) {
 	rc := registry.NewClient()
 
 	token, auth, err := s.getRegistryToken(ctx, parts.Registry, parts.Repository, registries)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get registry token: %w", err)
+		return nil, nil, fmt.Errorf("failed to get registry token: %w", err)
 	}
 
 	normalizedRepo := s.normalizeRepository(parts.Registry, parts.Repository)
@@ -191,17 +199,17 @@ func (s *ImageUpdateService) checkDigestUpdate(ctx context.Context, parts *Image
 	}
 	elapsed := time.Since(start)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get remote digest: %w", err)
+		return nil, nil, fmt.Errorf("failed to get remote digest: %w", err)
 	}
 
-	// Get local image and all its digests
-	localDigest, allLocalDigests, err := s.getLocalImageDigestWithAll(ctx, fmt.Sprintf("%s/%s:%s", parts.Registry, parts.Repository, parts.Tag))
+	snapshot, err := s.inspectLocalImageSnapshotInternal(ctx, fmt.Sprintf("%s/%s:%s", parts.Registry, parts.Repository, parts.Tag))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get local digest: %w", err)
+		return nil, nil, fmt.Errorf("failed to get local digest: %w", err)
 	}
 
+	localDigest := snapshot.PrimaryDigest
 	hasUpdate := true
-	for _, localDig := range allLocalDigests {
+	for _, localDig := range snapshot.AllDigests {
 		if localDig == remoteDigest {
 			localDigest = localDig
 			hasUpdate = false
@@ -212,7 +220,7 @@ func (s *ImageUpdateService) checkDigestUpdate(ctx context.Context, parts *Image
 	slog.DebugContext(ctx, "digest comparison",
 		"imageRef", fmt.Sprintf("%s/%s:%s", parts.Registry, parts.Repository, parts.Tag),
 		"primaryLocalDigest", localDigest,
-		"allLocalDigests", allLocalDigests,
+		"allLocalDigests", snapshot.AllDigests,
 		"remoteDigest", remoteDigest,
 		"hasUpdate", hasUpdate)
 
@@ -227,7 +235,7 @@ func (s *ImageUpdateService) checkDigestUpdate(ctx context.Context, parts *Image
 		AuthUsername:   auth.Username,
 		AuthRegistry:   auth.Registry,
 		UsedCredential: auth.Method == "credential",
-	}, nil
+	}, snapshot, nil
 }
 
 func (s *ImageUpdateService) parseImageReference(imageRef string) *ImageParts {
@@ -351,7 +359,7 @@ func (s *ImageUpdateService) getImageRefByID(ctx context.Context, imageID string
 	return "", fmt.Errorf("no valid repository tags or digests found for image")
 }
 
-func (s *ImageUpdateService) getAllImageRefs(ctx context.Context, limit int) ([]string, error) {
+func (s *ImageUpdateService) getAllImageRefsInternal(ctx context.Context, limit int) ([]string, error) {
 	dockerClient, err := s.dockerService.GetClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Docker: %w", err)
@@ -362,32 +370,38 @@ func (s *ImageUpdateService) getAllImageRefs(ctx context.Context, limit int) ([]
 		return nil, fmt.Errorf("failed to list Docker images: %w", err)
 	}
 
+	return dedupeImageRefsFromSummariesInternal(images, limit), nil
+}
+
+func dedupeImageRefsFromSummariesInternal(images []image.Summary, limit int) []string {
+	seen := make(map[string]struct{})
 	var imageRefs []string
 	for _, img := range images {
 		for _, tag := range img.RepoTags {
 			if tag != "<none>:<none>" {
+				if _, exists := seen[tag]; exists {
+					continue
+				}
+				seen[tag] = struct{}{}
 				imageRefs = append(imageRefs, tag)
 			}
-		}
-		if limit > 0 && len(imageRefs) >= limit {
-			break
+			if limit > 0 && len(imageRefs) >= limit {
+				return imageRefs[:limit]
+			}
 		}
 	}
-	if limit > 0 && len(imageRefs) > limit {
-		imageRefs = imageRefs[:limit]
-	}
-	return imageRefs, nil
+	return imageRefs
 }
 
-func (s *ImageUpdateService) getLocalImageDigestWithAll(ctx context.Context, imageRef string) (string, []string, error) {
+func (s *ImageUpdateService) inspectLocalImageSnapshotInternal(ctx context.Context, imageRef string) (*localImageSnapshot, error) {
 	dockerClient, err := s.dockerService.GetClient()
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to connect to Docker: %w", err)
+		return nil, fmt.Errorf("failed to connect to Docker: %w", err)
 	}
 
 	inspectResponse, err := dockerClient.ImageInspect(ctx, imageRef)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to inspect image: %w", err)
+		return nil, fmt.Errorf("failed to inspect image: %w", err)
 	}
 
 	var allDigests []string
@@ -416,7 +430,15 @@ func (s *ImageUpdateService) getLocalImageDigestWithAll(ctx context.Context, ima
 		allDigests = []string{primaryDigest}
 	}
 
-	return primaryDigest, allDigests, nil
+	repo, tag := extractRepoAndTagFromImage(inspectResponse)
+
+	return &localImageSnapshot{
+		ImageID:       inspectResponse.ID,
+		Repository:    repo,
+		Tag:           tag,
+		PrimaryDigest: primaryDigest,
+		AllDigests:    allDigests,
+	}, nil
 }
 
 // Returns all enabled credentials whose URL matches the image registry domain (normalized)
@@ -492,13 +514,17 @@ func (s *ImageUpdateService) CheckImageUpdateByID(ctx context.Context, imageID s
 	if err != nil {
 		return nil, err
 	}
-	if saveErr := s.saveUpdateResultByID(ctx, imageID, result); saveErr != nil {
+	if saveErr := s.saveUpdateResultByIDInternal(ctx, imageID, result); saveErr != nil {
 		slog.WarnContext(ctx, "Failed to save update result by ID", "imageID", imageID, "error", saveErr.Error())
 	}
 	return result, nil
 }
 
-func (s *ImageUpdateService) saveUpdateResult(ctx context.Context, imageRef string, result *imageupdate.Response) error {
+func (s *ImageUpdateService) saveUpdateResultWithSnapshotInternal(ctx context.Context, imageRef string, result *imageupdate.Response, snapshot *localImageSnapshot) error {
+	if snapshot != nil && snapshot.ImageID != "" {
+		return s.savePreparedUpdateResultInternal(ctx, snapshot.ImageID, snapshot.Repository, snapshot.Tag, result)
+	}
+
 	parts := s.parseImageReference(imageRef)
 	if parts == nil {
 		return fmt.Errorf("invalid image reference")
@@ -507,7 +533,7 @@ func (s *ImageUpdateService) saveUpdateResult(ctx context.Context, imageRef stri
 	if err != nil {
 		return fmt.Errorf("failed to get image ID: %w", err)
 	}
-	return s.saveUpdateResultByID(ctx, imageID, result)
+	return s.saveUpdateResultByIDInternal(ctx, imageID, result)
 }
 
 func extractRepoAndTagFromImage(dockerImage image.InspectResponse) (repo, tag string) {
@@ -589,19 +615,23 @@ func buildImageUpdateRecord(imageID, repo, tag string, result *imageupdate.Respo
 	}
 }
 
-func (s *ImageUpdateService) saveUpdateResultByID(ctx context.Context, imageID string, result *imageupdate.Response) error {
+func (s *ImageUpdateService) saveUpdateResultByIDInternal(ctx context.Context, imageID string, result *imageupdate.Response) error {
+	dockerClient, err := s.dockerService.GetClient()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Docker: %w", err)
+	}
+
+	dockerImage, err := dockerClient.ImageInspect(ctx, imageID)
+	if err != nil {
+		return fmt.Errorf("failed to inspect image: %w", err)
+	}
+
+	repo, tag := extractRepoAndTagFromImage(dockerImage)
+	return s.savePreparedUpdateResultInternal(ctx, imageID, repo, tag, result)
+}
+
+func (s *ImageUpdateService) savePreparedUpdateResultInternal(ctx context.Context, imageID, repo, tag string, result *imageupdate.Response) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		dockerClient, err := s.dockerService.GetClient()
-		if err != nil {
-			return fmt.Errorf("failed to connect to Docker: %w", err)
-		}
-
-		dockerImage, err := dockerClient.ImageInspect(ctx, imageID)
-		if err != nil {
-			return fmt.Errorf("failed to inspect image: %w", err)
-		}
-
-		repo, tag := extractRepoAndTagFromImage(dockerImage)
 		updateRecord := buildImageUpdateRecord(imageID, repo, tag, result)
 
 		// Check if there's an existing record to compare state changes
@@ -680,14 +710,16 @@ type regAuth struct {
 }
 
 type batchImage struct {
-	ref   string
-	parts *ImageParts
+	refs         []string
+	canonicalRef string
+	parts        *ImageParts
 }
 
-func (s *ImageUpdateService) parseAndGroupImages(imageRefs []string) (map[string]map[string]struct{}, map[string]*imageupdate.Response, []batchImage) {
+func (s *ImageUpdateService) parseAndGroupImagesInternal(imageRefs []string) (map[string]map[string]struct{}, map[string]*imageupdate.Response, []batchImage) {
 	regRepos := make(map[string]map[string]struct{})
 	results := make(map[string]*imageupdate.Response)
 	var images []batchImage
+	indexByNormalizedRef := make(map[string]int)
 
 	for _, ref := range imageRefs {
 		parts := s.parseImageReference(ref)
@@ -703,7 +735,18 @@ func (s *ImageUpdateService) parseAndGroupImages(imageRefs []string) (map[string
 			regRepos[parts.Registry] = make(map[string]struct{})
 		}
 		regRepos[parts.Registry][s.normalizeRepository(parts.Registry, parts.Repository)] = struct{}{}
-		images = append(images, batchImage{ref: ref, parts: parts})
+		normalizedRef := strings.ToLower(fmt.Sprintf("%s/%s:%s", parts.Registry, s.normalizeRepository(parts.Registry, parts.Repository), parts.Tag))
+		if idx, exists := indexByNormalizedRef[normalizedRef]; exists {
+			images[idx].refs = append(images[idx].refs, ref)
+			continue
+		}
+
+		indexByNormalizedRef[normalizedRef] = len(images)
+		images = append(images, batchImage{
+			refs:         []string{ref},
+			canonicalRef: ref,
+			parts:        parts,
+		})
 	}
 	return regRepos, results, images
 }
@@ -859,13 +902,13 @@ func (s *ImageUpdateService) buildRegistryAuthMap(ctx context.Context, rc *regis
 	return regAuthMap
 }
 
-func (s *ImageUpdateService) checkSingleImageInBatch(
+func (s *ImageUpdateService) checkSingleImageInBatchInternal(
 	ctx context.Context,
 	rc *registry.Client,
 	authMap map[string]regAuth,
 	enabledRegs []models.ContainerRegistry,
 	parts *ImageParts,
-) *imageupdate.Response {
+) (*imageupdate.Response, *localImageSnapshot) {
 
 	start := time.Now()
 	authInfo := authMap[parts.Registry]
@@ -892,10 +935,10 @@ func (s *ImageUpdateService) checkSingleImageInBatch(
 			AuthUsername:   auth.Username,
 			AuthRegistry:   auth.Registry,
 			UsedCredential: auth.Method == "credential",
-		}
+		}, nil
 	}
 
-	localDigest, allLocalDigests, ldErr := s.getLocalImageDigestWithAll(ctx, fmt.Sprintf("%s/%s:%s", parts.Registry, parts.Repository, parts.Tag))
+	snapshot, ldErr := s.inspectLocalImageSnapshotInternal(ctx, fmt.Sprintf("%s/%s:%s", parts.Registry, parts.Repository, parts.Tag))
 	if ldErr != nil {
 		return &imageupdate.Response{
 			Error:          ldErr.Error(),
@@ -905,11 +948,12 @@ func (s *ImageUpdateService) checkSingleImageInBatch(
 			AuthUsername:   auth.Username,
 			AuthRegistry:   auth.Registry,
 			UsedCredential: auth.Method == "credential",
-		}
+		}, nil
 	}
 
+	localDigest := snapshot.PrimaryDigest
 	hasDigestUpdate := true
-	for _, localDig := range allLocalDigests {
+	for _, localDig := range snapshot.AllDigests {
 		if localDig == remoteDigest {
 			localDigest = localDig
 			hasDigestUpdate = false
@@ -928,7 +972,7 @@ func (s *ImageUpdateService) checkSingleImageInBatch(
 		AuthUsername:   auth.Username,
 		AuthRegistry:   auth.Registry,
 		UsedCredential: auth.Method == "credential",
-	}
+	}, snapshot
 }
 
 func (s *ImageUpdateService) CheckMultipleImages(ctx context.Context, imageRefs []string, externalCreds []containerregistry.Credential) (map[string]*imageupdate.Response, error) {
@@ -942,7 +986,7 @@ func (s *ImageUpdateService) CheckMultipleImages(ctx context.Context, imageRefs 
 
 	rc := registry.NewClient()
 
-	regRepos, initialResults, images := s.parseAndGroupImages(imageRefs)
+	regRepos, initialResults, images := s.parseAndGroupImagesInternal(imageRefs)
 	maps.Copy(results, initialResults)
 
 	credMap, enabledRegs := s.buildCredentialMap(ctx, externalCreds)
@@ -957,14 +1001,16 @@ func (s *ImageUpdateService) CheckMultipleImages(ctx context.Context, imageRefs 
 
 	for _, img := range images {
 		g.Go(func() error {
-			res := s.checkSingleImageInBatch(groupCtx, rc, regAuthMap, enabledRegs, img.parts)
+			res, snapshot := s.checkSingleImageInBatchInternal(groupCtx, rc, regAuthMap, enabledRegs, img.parts)
 
 			mu.Lock()
-			results[img.ref] = res
+			for _, ref := range img.refs {
+				results[ref] = res
+			}
 			mu.Unlock()
 
-			if err := s.saveUpdateResult(groupCtx, img.ref, res); err != nil {
-				slog.WarnContext(groupCtx, "Failed to save update result", "imageRef", img.ref, "error", err.Error())
+			if err := s.saveUpdateResultWithSnapshotInternal(groupCtx, img.canonicalRef, res, snapshot); err != nil {
+				slog.WarnContext(groupCtx, "Failed to save update result", "imageRef", img.canonicalRef, "error", err.Error())
 			}
 			return nil
 		})
@@ -1034,7 +1080,7 @@ func (s *ImageUpdateService) CheckMultipleImages(ctx context.Context, imageRefs 
 }
 
 func (s *ImageUpdateService) CheckAllImages(ctx context.Context, limit int, externalCreds []containerregistry.Credential) (map[string]*imageupdate.Response, error) {
-	imageRefs, err := s.getAllImageRefs(ctx, limit)
+	imageRefs, err := s.getAllImageRefsInternal(ctx, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image references: %w", err)
 	}
@@ -1071,34 +1117,27 @@ func (s *ImageUpdateService) CleanupOrphanedRecords(ctx context.Context) error {
 		return fmt.Errorf("failed to list Docker images: %w", err)
 	}
 
-	dockerImageIDs := make(map[string]bool)
+	dockerImageIDs := make([]string, 0, len(dockerImages))
 	for _, img := range dockerImages {
-		dockerImageIDs[img.ID] = true
+		dockerImageIDs = append(dockerImageIDs, img.ID)
 	}
 
-	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var updateRecords []models.ImageUpdateRecord
-		if err := tx.Find(&updateRecords).Error; err != nil {
-			return fmt.Errorf("failed to query update records: %w", err)
-		}
+	var result *gorm.DB
+	if len(dockerImageIDs) == 0 {
+		result = s.db.WithContext(ctx).Where("1 = 1").Delete(&models.ImageUpdateRecord{})
+	} else {
+		result = s.db.WithContext(ctx).Where("id NOT IN ?", dockerImageIDs).Delete(&models.ImageUpdateRecord{})
+	}
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete orphaned records: %w", result.Error)
+	}
 
-		var idsToDelete []string
-		for _, record := range updateRecords {
-			if !dockerImageIDs[record.ID] {
-				idsToDelete = append(idsToDelete, record.ID)
-			}
-		}
-
-		if len(idsToDelete) > 0 {
-			if err := tx.Delete(&models.ImageUpdateRecord{}, "id IN ?", idsToDelete).Error; err != nil {
-				return fmt.Errorf("failed to delete orphaned records: %w", err)
-			}
-			slog.InfoContext(ctx, "Cleaned up orphaned image update records", "deletedCount", len(idsToDelete))
-		} else {
-			slog.InfoContext(ctx, "No orphaned image update records found")
-		}
-		return nil
-	})
+	if result.RowsAffected > 0 {
+		slog.InfoContext(ctx, "Cleaned up orphaned image update records", "deletedCount", result.RowsAffected)
+	} else {
+		slog.InfoContext(ctx, "No orphaned image update records found")
+	}
+	return nil
 }
 
 func (s *ImageUpdateService) GetUpdateSummary(ctx context.Context) (*imageupdate.Summary, error) {
@@ -1129,40 +1168,26 @@ func (s *ImageUpdateService) getUpdateSummaryForImageIDsInternal(ctx context.Con
 		return summary, nil
 	}
 
-	var (
-		imagesWithUpdates int64
-		digestUpdates     int64
-		errorsCount       int64
-	)
-
-	g, groupCtx := errgroup.WithContext(ctx)
-
-	g.Go(func() error {
-		return s.db.WithContext(groupCtx).
-			Model(&models.ImageUpdateRecord{}).
-			Where("id IN ? AND has_update = ?", imageIDs, true).
-			Count(&imagesWithUpdates).Error
-	})
-	g.Go(func() error {
-		return s.db.WithContext(groupCtx).
-			Model(&models.ImageUpdateRecord{}).
-			Where("id IN ? AND has_update = ? AND update_type = ?", imageIDs, true, "digest").
-			Count(&digestUpdates).Error
-	})
-	g.Go(func() error {
-		return s.db.WithContext(groupCtx).
-			Model(&models.ImageUpdateRecord{}).
-			Where("id IN ? AND last_error IS NOT NULL AND last_error != ''", imageIDs).
-			Count(&errorsCount).Error
-	})
-
-	if err := g.Wait(); err != nil {
+	var aggregate struct {
+		ImagesWithUpdates int64 `gorm:"column:images_with_updates"`
+		DigestUpdates     int64 `gorm:"column:digest_updates"`
+		ErrorsCount       int64 `gorm:"column:errors_count"`
+	}
+	if err := s.db.WithContext(ctx).
+		Model(&models.ImageUpdateRecord{}).
+		Select(`
+			COALESCE(SUM(CASE WHEN has_update THEN 1 ELSE 0 END), 0) AS images_with_updates,
+			COALESCE(SUM(CASE WHEN has_update AND update_type = ? THEN 1 ELSE 0 END), 0) AS digest_updates,
+			COALESCE(SUM(CASE WHEN last_error IS NOT NULL AND last_error != '' THEN 1 ELSE 0 END), 0) AS errors_count
+		`, "digest").
+		Where("id IN ?", imageIDs).
+		Scan(&aggregate).Error; err != nil {
 		return nil, err
 	}
 
-	summary.ImagesWithUpdates = int(imagesWithUpdates)
-	summary.DigestUpdates = int(digestUpdates)
-	summary.ErrorsCount = int(errorsCount)
+	summary.ImagesWithUpdates = int(aggregate.ImagesWithUpdates)
+	summary.DigestUpdates = int(aggregate.DigestUpdates)
+	summary.ErrorsCount = int(aggregate.ErrorsCount)
 
 	return summary, nil
 }

--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -182,7 +182,7 @@ func (s *VulnerabilityService) getTrivyScanSlotChannelInternal(limit int) chan i
 
 	createSlots := func(size int) chan int {
 		slots := make(chan int, size)
-		for i := 0; i < size; i++ {
+		for i := range size {
 			slots <- i
 		}
 		return slots
@@ -1217,6 +1217,15 @@ func (s *VulnerabilityService) DeleteScanResult(ctx context.Context, imageID str
 	return s.db.WithContext(ctx).Where("id = ?", imageID).Delete(&models.VulnerabilityScanRecord{}).Error
 }
 
+// DeleteScanResultsByImageIDs deletes scan results for multiple images in one query.
+func (s *VulnerabilityService) DeleteScanResultsByImageIDs(ctx context.Context, imageIDs []string) error {
+	if s.db == nil || len(imageIDs) == 0 {
+		return nil
+	}
+
+	return s.db.WithContext(ctx).Where("id IN ?", imageIDs).Delete(&models.VulnerabilityScanRecord{}).Error
+}
+
 // CleanupOrphanedScanRecords removes vulnerability scan records for images that
 // no longer exist in Docker. This keeps "images scanned" counts in sync (e.g.
 // avoids "5/3" when images were deleted after being scanned). Safe to call
@@ -1889,10 +1898,7 @@ func buildTrivyCPUSetInternal(nanoCPUs int64, hostCPUs int) string {
 		hostCPUs = 1
 	}
 
-	requestedCPUs := int(math.Floor(float64(nanoCPUs) / float64(trivyNanoCPUsPerCore)))
-	if requestedCPUs < 1 {
-		requestedCPUs = 1
-	}
+	requestedCPUs := max(int(math.Floor(float64(nanoCPUs)/float64(trivyNanoCPUsPerCore))), 1)
 	if requestedCPUs > hostCPUs {
 		requestedCPUs = hostCPUs
 	}
@@ -2658,10 +2664,7 @@ func (s *VulnerabilityService) saveScanResultWithRetryInternal(
 			}
 
 			if retryDelay > 0 {
-				delay := retryDelay * time.Duration(1<<(attempt-1))
-				if delay > defaultScanSaveRetryMaxDelay {
-					delay = defaultScanSaveRetryMaxDelay
-				}
+				delay := min(retryDelay*time.Duration(1<<(attempt-1)), defaultScanSaveRetryMaxDelay)
 
 				timer := time.NewTimer(delay)
 				select {

--- a/backend/internal/services/vulnerability_service_test.go
+++ b/backend/internal/services/vulnerability_service_test.go
@@ -14,10 +14,13 @@ import (
 
 	containertypes "github.com/docker/docker/api/types/container"
 	mounttypes "github.com/docker/docker/api/types/mount"
+	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/timeouts"
 	"github.com/getarcaneapp/arcane/types/vulnerability"
+	glsqlite "github.com/glebarez/sqlite"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestIsExpectedDockerStreamEndErrorInternal(t *testing.T) {
@@ -368,7 +371,7 @@ func TestGetTrivyScanSlotChannelInternal_PrefillsSlots(t *testing.T) {
 	require.Equal(t, 3, len(slotCh))
 
 	seen := map[int]bool{}
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		slotID := <-slotCh
 		seen[slotID] = true
 	}
@@ -482,4 +485,44 @@ func TestAwaitContainerWaitResponseInternal_NoStatus(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ended without status")
 	require.Equal(t, int64(0), status)
+}
+
+func setupVulnerabilityScanTestDB(t *testing.T) *database.DB {
+	t.Helper()
+	dsn := fmt.Sprintf("file:vulnerability-scan-test-%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := gorm.Open(glsqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.VulnerabilityScanRecord{}))
+	return &database.DB{DB: db}
+}
+
+func TestVulnerabilityService_DeleteScanResultsByImageIDs(t *testing.T) {
+	ctx := context.Background()
+	db := setupVulnerabilityScanTestDB(t)
+	svc := &VulnerabilityService{db: db}
+
+	records := []models.VulnerabilityScanRecord{
+		{ID: "sha256:img1", ImageName: "nginx:latest", Status: models.ScanStatusCompleted, ScanTime: time.Now()},
+		{ID: "sha256:img2", ImageName: "redis:7", Status: models.ScanStatusCompleted, ScanTime: time.Now()},
+		{ID: "sha256:img3", ImageName: "postgres:16", Status: models.ScanStatusCompleted, ScanTime: time.Now()},
+	}
+	for i := range records {
+		require.NoError(t, db.Create(&records[i]).Error)
+	}
+
+	require.NoError(t, svc.DeleteScanResultsByImageIDs(ctx, []string{"sha256:img1", "sha256:img3"}))
+
+	var remaining []models.VulnerabilityScanRecord
+	require.NoError(t, db.Find(&remaining).Error)
+	require.Len(t, remaining, 1)
+	require.Equal(t, "sha256:img2", remaining[0].ID)
+}
+
+func TestVulnerabilityService_DeleteScanResultsByImageIDs_EmptyInput(t *testing.T) {
+	ctx := context.Background()
+	db := setupVulnerabilityScanTestDB(t)
+	svc := &VulnerabilityService{db: db}
+
+	require.NoError(t, svc.DeleteScanResultsByImageIDs(ctx, nil))
+	require.NoError(t, svc.DeleteScanResultsByImageIDs(ctx, []string{}))
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -73,6 +73,7 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8V
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
+github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/v10 v10.0.1 h1:n9dERvixoC/1JjDmBcs9FPaEryoANa2sCgVFo6ez9cI=
@@ -240,11 +241,10 @@ github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJn
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
 github.com/fsouza/fake-gcs-server v1.17.0 h1:OeH75kBZcZa3ZE+zz/mFdJ2btt9FgqfjI7gIh9+5fvk=
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
-github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
-github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/getarcaneapp/arcane/types v0.0.0-20251219045603-8a9960a2bf04/go.mod h1:7Wj+0JnpYq4RQS+otyM6e4zkyJKDC01wxkWPyFCHwZA=
 github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
 github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-co-op/gocron/v2 v2.18.2/go.mod h1:Zii6he+Zfgy5W9B+JKk/KwejFOW0kZTFvHtwIpR4aBI=
 github.com/go-jose/go-jose/v3 v3.0.0 h1:s6rrhirfEP/CGIoc6p+PZAeogN2SxKav6Wp7+dyMWVo=
 github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
@@ -270,6 +270,7 @@ github.com/gofiber/fiber/v2 v2.52.7 h1:6xJpE4sSqErvMiEZo9ZpJLRSVcpkNBvioeqAHKwhT
 github.com/gofiber/fiber/v2 v2.52.7/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
 github.com/gofiber/fiber/v2 v2.52.9 h1:YjKl5DOiyP3j0mO61u3NTmK7or8GzzWzCFzkboyP5cw=
 github.com/gofiber/fiber/v2 v2.52.9/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
+github.com/gofiber/fiber/v2 v2.52.11/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
@@ -384,6 +385,7 @@ github.com/ktrysmt/go-bitbucket v0.6.4 h1:C8dUGp0qkwncKtAnozHCbbqhptefzEd1I0sfnu
 github.com/ktrysmt/go-bitbucket v0.6.4/go.mod h1:9u0v3hsd2rqCHRIpbir1oP7F58uo5dq19sBYvuMoyQ4=
 github.com/labstack/echo/v4 v4.13.3 h1:pwhpCPrTl5qry5HRdM5FwdXnhXSLSY+WE+YQSeCaafY=
 github.com/labstack/echo/v4 v4.13.3/go.mod h1:o90YNEeQWjDozo584l7AwhJMHN0bOC4tAfg+Xox9q5g=
+github.com/labstack/echo/v4 v4.15.0/go.mod h1:xmw1clThob0BSVRX1CRQkGQ/vjwcpOMjQZSZa9fKA/c=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=
 github.com/labstack/gommon v0.4.2/go.mod h1:QlUFxVM+SNXhDL/Z7YhocGIBYOiwB0mXm1+1bAPHPyU=
 github.com/letsencrypt/boulder v0.0.0-20240620165639-de9c06129bec h1:2tTW6cDth2TSgRbAhD7yjZzTQmcN25sDRPEeinR51yQ=
@@ -510,11 +512,8 @@ github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xI
 github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6 h1:pnnLyeX7o/5aX8qUQ69P/mLojDqwda8hFOCBTmP/6hw=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6/go.mod h1:39R/xuhNgVhi+K0/zst4TLrJrVmbm6LVgl4A0+ZFS5M=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/sylabs/sif/v2 v2.22.0 h1:Y+xXufp4RdgZe02SR3nWEg7S6q4tPWN237WHYzkDSKA=
 github.com/sylabs/sif/v2 v2.22.0/go.mod h1:W1XhWTmG1KcG7j5a3KSYdMcUIFvbs240w/MMVW627hs=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
@@ -545,6 +544,7 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.62.0 h1:8dKRBX/y2rCzyc6903Zu1+3qN0H/d2MsxPPmVNamiH0=
 github.com/valyala/fasthttp v1.62.0/go.mod h1:FCINgr4GKdKqV8Q0xv8b+UxPV+H/O5nNFo3D+r54Htg=
+github.com/valyala/fasthttp v1.69.0/go.mod h1:4wA4PfAraPlAsJ5jMSqCE2ug5tqUPwKXxVj8oNECGcw=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vbauerster/mpb/v8 v8.10.2 h1:2uBykSHAYHekE11YvJhKxYmLATKHAGorZwFlyNw4hHM=
@@ -553,8 +553,6 @@ github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW
 github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
-github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
-github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/go-gitlab v0.15.0 h1:rWtwKTgEnXyNUGrOArN7yyc3THRkpYcKXIXia9abywQ=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
@@ -565,6 +563,7 @@ github.com/xdg-go/stringprep v1.0.3 h1:kdwGpVNwPFtjs98xCGkHjQtGKh86rDcRZN17QEMCO
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
+github.com/xyproto/randomstring v1.2.0/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d h1:splanxYIlg+5LfHAM6xpdFEAYOk8iySO56hMFq6uLyA=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.2.1 h1:ruQGxdhGHe7FWOJPT0mKs5+pD2Xs1Bm/kdGlHO04FmM=


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements several significant performance optimizations for image update, prune, and vulnerability operations:

- **Batch database operations**: Replaced multiple individual DELETE queries with single batch operations using `IN` clauses (`DeleteScanResultsByImageIDs`, orphaned record cleanup)
- **Query optimization**: Combined three separate COUNT queries into a single aggregated query in `getUpdateSummaryForImageIDsInternal`, reducing database round-trips
- **Image deduplication**: Added `parseAndGroupImagesInternal` to deduplicate normalized image references (e.g., `nginx:latest` and `docker.io/library/nginx:latest`), preventing redundant registry checks
- **Snapshot caching**: Introduced `localImageSnapshot` struct to cache Docker inspect results, avoiding repeated API calls during batch operations
- **In-use set optimization**: Created `buildRunningImageIDSetInternal` to build a reusable set of running container image IDs once, eliminating N container inspections during prune operations
- **Fast-path container checks**: Added `isImageIDLikeReferenceInternal` to skip container inspect calls when `c.Image` is already a usable tag reference
- **Modern Go syntax**: Leveraged Go 1.26 features like `range` over integers and built-in `min`/`max` functions
- **Transaction removal**: Removed unnecessary transaction wrapper in `CleanupOrphanedRecords` since it's a single DELETE operation

All optimizations have corresponding test coverage and maintain backward compatibility.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- All changes are well-tested performance optimizations with clear intent. The refactoring follows Go best practices, reduces database and API calls, and includes comprehensive test coverage. No breaking changes or security concerns identified.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/image_service.go | Optimized vulnerability cleanup to use batch delete and simplified update record fetching with filtered query |
| backend/internal/services/image_update_service.go | Major refactoring: added image snapshot caching, deduplication of normalized refs, single SQL aggregation for summaries, and removed unnecessary transaction |
| backend/internal/services/updater_service.go | Added fast path for container image checks by building in-use set once and reusing it, avoiding redundant container inspections |
| backend/internal/services/vulnerability_service.go | Added batch delete method, replaced conditional logic with built-in `max`/`min` functions, and used range-over-integer syntax |

</details>


</details>


<sub>Last reviewed commit: df658c2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->