### PR TITLE
fix(updater): clear update records by image ID and fail closed on used-image discovery errors

### DIFF
--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -1898,10 +1898,7 @@ func buildTrivyCPUSetInternal(nanoCPUs int64, hostCPUs int) string {
 		hostCPUs = 1
 	}
 
-	requestedCPUs := max(int(math.Floor(float64(nanoCPUs)/float64(trivyNanoCPUsPerCore))), 1)
-	if requestedCPUs > hostCPUs {
-		requestedCPUs = hostCPUs
-	}
+	requestedCPUs := min(max(int(math.Floor(float64(nanoCPUs)/float64(trivyNanoCPUsPerCore))), 1), hostCPUs)
 
 	if requestedCPUs == 1 {
 		return "0"


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves error handling in the updater service by implementing fail-closed behavior when discovering actively used images fails. Previously, if `collectUsedImages` failed, the system would continue with an empty image set, potentially leading to unintended behavior. Now it returns early and skips the update run entirely.

Key changes:
- `ApplyPending` now returns early when `collectUsedImages` fails or returns zero images
- `collectUsedImages` tracks errors from both Docker containers and compose projects, returning an error only if all sources fail (fail-closed with partial success tolerance)
- Added comprehensive test coverage for the new error handling paths
- Removed redundant `len(usedImages) > 0` check since the function now guarantees non-empty results on success
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minimal risk
- The changes implement critical safety improvements by switching from fail-open to fail-closed error handling. The logic is well-tested with comprehensive unit tests covering edge cases. The implementation correctly handles partial failures (allowing success if at least one source works) which balances safety with availability.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/updater_service.go | Improved error handling in `collectUsedImages` to fail-closed when discovery fails, preventing unsafe updates. Changed from continuing with empty set to early return. Properly tracks errors from both container and project sources. |
| backend/internal/services/updater_service_test.go | Added comprehensive tests for fail-closed behavior when used-image discovery fails. Tests verify both `collectUsedImages` error handling and `ApplyPending` skip logic. |

</details>


</details>


<sub>Last reviewed commit: 1a87d38</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->