### PR TITLE
fix(scheduler): bound environment health sync concurrency and prevent overlapping runs

### DIFF
--- a/backend/pkg/scheduler/environment_health_job_test.go
+++ b/backend/pkg/scheduler/environment_health_job_test.go
@@ -1,0 +1,25 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEnvironmentHealthJob_Defaults(t *testing.T) {
+	job := NewEnvironmentHealthJob(nil, nil)
+
+	require.Equal(t, defaultEnvironmentSyncConcurrency, job.syncConcurrency)
+	require.Equal(t, defaultEnvironmentSyncTimeout, job.syncTimeout)
+	require.False(t, job.running.Load())
+}
+
+func TestEnvironmentHealthJob_RunGuardAtomic(t *testing.T) {
+	job := &EnvironmentHealthJob{}
+
+	require.True(t, job.running.CompareAndSwap(false, true))
+	require.False(t, job.running.CompareAndSwap(false, true))
+
+	job.running.Store(false)
+	require.True(t, job.running.CompareAndSwap(false, true))
+}


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the environment health job to prevent overlapping runs and bound concurrency during the sync phase. The implementation uses an `atomic.Bool` guard to skip execution if a previous run is still in progress, and replaces unbounded goroutine creation with `errgroup` limited to 4 concurrent operations with a 90-second timeout.

**Key changes:**
- Extracted inline struct definition into named `healthEnvironment` type for better code clarity
- Added atomic run guard to prevent concurrent health check executions
- Replaced fire-and-forget goroutines with bounded `errgroup` (max 4 concurrent) and 90s timeout
- Collected online remote environments first, then batch-synced them in controlled fashion
- Added basic unit tests for initialization defaults and atomic guard behavior

**Note:** One comment was left about loop variable capture, but this is actually safe in Go 1.22+ (this codebase uses Go 1.26) due to per-iteration loop variable semantics. The code is correct as written.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minimal risk, though one incorrect review comment should be disregarded
- The implementation correctly addresses concurrency control and prevents resource exhaustion. The atomic guard prevents overlapping runs, and the bounded errgroup with timeout prevents unbounded goroutine creation. Code follows Go idioms for Go 1.22+. Minor deduction because the PR description template wasn't filled out, making it harder to verify the intended behavior against requirements.
- No files require special attention - the loop variable capture comment should be disregarded as Go 1.22+ uses per-iteration loop variables
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/pkg/scheduler/environment_health_job.go | added concurrency control with atomic guard, errgroup-based bounded sync, and timeout handling for environment health checks |
| backend/pkg/scheduler/environment_health_job_test.go | new test file validates default configuration values and atomic run guard behavior |

</details>


</details>


<sub>Last reviewed commit: fb5c671</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->