### PR TITLE
perf(image-service): fetch vulnerability summaries only for paginated image results

### DIFF
--- a/backend/internal/services/image_service_test.go
+++ b/backend/internal/services/image_service_test.go
@@ -1,0 +1,41 @@
+package services
+
+import (
+	"testing"
+
+	imagetypes "github.com/getarcaneapp/arcane/types/image"
+	"github.com/getarcaneapp/arcane/types/vulnerability"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetImageIDsFromSummariesInternal(t *testing.T) {
+	items := []imagetypes.Summary{
+		{ID: "img1"},
+		{ID: "img2"},
+		{ID: "img1"},
+		{ID: ""},
+	}
+
+	got := getImageIDsFromSummariesInternal(items)
+	assert.Equal(t, []string{"img1", "img2"}, got)
+}
+
+func TestApplyVulnerabilitySummariesToItemsInternal(t *testing.T) {
+	items := []imagetypes.Summary{
+		{ID: "img1"},
+		{ID: "img2"},
+	}
+
+	summary := &vulnerability.ScanSummary{
+		ImageID: "img1",
+		Status:  vulnerability.ScanStatusCompleted,
+	}
+	vulnerabilityMap := map[string]*vulnerability.ScanSummary{
+		"img1": summary,
+	}
+
+	applyVulnerabilitySummariesToItemsInternal(items, vulnerabilityMap)
+
+	assert.Equal(t, summary, items[0].VulnerabilityScan)
+	assert.Nil(t, items[1].VulnerabilityScan)
+}


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR optimizes the `ListImagesPaginated` function by deferring vulnerability summary fetching until after pagination, search, and filtering. Previously, vulnerability data was fetched for all images before pagination, which was wasteful when only a subset of images would be returned to the user. Now, vulnerability summaries are only fetched for the images that appear in the final paginated result.

**Key changes:**
- Removed vulnerability map fetching from the pre-pagination phase
- Pass `nil` for vulnerability map to `mapDockerImagesToDTOs` initially
- After pagination, extract image IDs from the result set using new helper `getImageIDsFromSummariesInternal` (with deduplication)
- Fetch vulnerability summaries only for those paginated image IDs
- Apply summaries to the result items using new helper `applyVulnerabilitySummariesToItemsInternal`
- Added unit tests for both new helper functions

The implementation correctly handles edge cases (empty results, duplicate IDs, empty image IDs) and maintains the same functional behavior while significantly reducing database/service calls for large image sets.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The change is a clean performance optimization with proper error handling, unit tests covering the new functions, and no breaking changes to the API contract. The logic correctly handles edge cases (empty results, nil checks) and maintains functional equivalence to the previous implementation.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/image_service.go | Optimized vulnerability summary fetching to only query the paginated subset of images instead of all images, improving performance for large image lists |
| backend/internal/services/image_service_test.go | Added unit tests for the new helper functions that extract image IDs and apply vulnerability summaries to paginated results |

</details>


</details>


<sub>Last reviewed commit: dcc2a42</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->