### PR TITLE
perf(volume-service): replace nested usage enrichment loop with map lookup

### DIFF
--- a/backend/internal/services/volume_service_test.go
+++ b/backend/internal/services/volume_service_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/volume"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
 	"github.com/stretchr/testify/require"
 )
@@ -54,4 +55,60 @@ func TestBuildVolumeHelperLabelsInternal(t *testing.T) {
 
 	require.Equal(t, "true", labels[libarcane.InternalResourceLabel])
 	require.Len(t, labels, 1)
+}
+
+func TestEnrichVolumesWithUsageDataInternal(t *testing.T) {
+	svc := &VolumeService{}
+
+	tests := []struct {
+		name         string
+		volumes      []*volume.Volume
+		usageVolumes []volume.Volume
+		wantLen      int
+		assertions   func(t *testing.T, got []volume.Volume)
+	}{
+		{
+			name: "attaches usage by name and skips nil volumes",
+			volumes: []*volume.Volume{
+				{Name: "vol-a"},
+				nil,
+				{Name: "vol-b"},
+			},
+			usageVolumes: []volume.Volume{
+				{Name: "vol-a", UsageData: &volume.UsageData{Size: 100, RefCount: 2}},
+				{Name: "vol-c", UsageData: &volume.UsageData{Size: 50, RefCount: 1}},
+			},
+			wantLen: 2,
+			assertions: func(t *testing.T, got []volume.Volume) {
+				require.NotNil(t, got[0].UsageData)
+				require.EqualValues(t, 100, got[0].UsageData.Size)
+				require.EqualValues(t, 2, got[0].UsageData.RefCount)
+				require.Nil(t, got[1].UsageData)
+			},
+		},
+		{
+			name: "keeps first usage entry when duplicate usage names exist",
+			volumes: []*volume.Volume{
+				{Name: "vol-dup"},
+			},
+			usageVolumes: []volume.Volume{
+				{Name: "vol-dup", UsageData: &volume.UsageData{Size: 10, RefCount: 1}},
+				{Name: "vol-dup", UsageData: &volume.UsageData{Size: 20, RefCount: 3}},
+			},
+			wantLen: 1,
+			assertions: func(t *testing.T, got []volume.Volume) {
+				require.NotNil(t, got[0].UsageData)
+				require.EqualValues(t, 10, got[0].UsageData.Size)
+				require.EqualValues(t, 1, got[0].UsageData.RefCount)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := svc.enrichVolumesWithUsageDataInternal(tt.volumes, tt.usageVolumes)
+			require.Len(t, got, tt.wantLen)
+			tt.assertions(t, got)
+		})
+	}
 }


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

Replaces O(n*m) nested loop with O(n+m) map-based lookup in `enrichVolumesWithUsageDataInternal`. The optimization builds a map of usage data by volume name, then performs constant-time lookups instead of scanning the entire usage array for each volume.

- Builds `usageByName` map from `usageVolumes` array to enable O(1) lookups
- Preserves original "first-seen" behavior when duplicate volume names exist in usage data
- Includes comprehensive test coverage for the optimization
- No functional changes, purely a performance improvement
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge with no risk
- The change is a straightforward performance optimization that replaces a nested loop with a map lookup. The logic is correct, behavior is preserved (including the first-seen duplicate handling), and comprehensive tests verify the implementation.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/volume_service.go | Replaced nested loop (O(n*m)) with map lookup (O(n+m)) in enrichVolumesWithUsageDataInternal, significantly improving performance for large datasets |
| backend/internal/services/volume_service_test.go | Added comprehensive test coverage for enrichVolumesWithUsageDataInternal including nil handling and duplicate behavior validation |

</details>


</details>


<sub>Last reviewed commit: 8551561</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->