### PR TITLE
perf(vulnerability-service): prefilter list-all scans and inline ignored vuln filtering

### DIFF
--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -622,16 +622,33 @@ func (s *VulnerabilityService) ListAllVulnerabilities(ctx context.Context, envID
 		}, nil
 	}
 
-	var records []models.VulnerabilityScanRecord
-	if err := s.db.WithContext(ctx).
-		Select("id", "image_name", "vulnerabilities", "status", "total_count").
+	recordsQuery := s.db.WithContext(ctx).
+		Select("id", "image_name", "vulnerabilities", "total_count").
 		Where("status = ?", models.ScanStatusCompleted).
-		Where("total_count > 0").
-		Find(&records).Error; err != nil {
+		Where("total_count > 0")
+	var hasPossibleMatches bool
+	recordsQuery, hasPossibleMatches = applyListAllVulnerabilityRecordPrefiltersInternal(recordsQuery, params.Filters)
+	if !hasPossibleMatches {
+		filtered := pagination.FilterResult[vulnerability.VulnerabilityWithImage]{
+			Items:          []vulnerability.VulnerabilityWithImage{},
+			TotalCount:     0,
+			TotalAvailable: 0,
+		}
+		response := pagination.BuildResponseFromFilterResult(filtered, params)
+		return filtered.Items, response, nil
+	}
+
+	var records []models.VulnerabilityScanRecord
+	if err := recordsQuery.Find(&records).Error; err != nil {
 		return nil, pagination.Response{}, fmt.Errorf("failed to list vulnerability scans: %w", err)
 	}
 
-	items := make([]vulnerability.VulnerabilityWithImage, 0)
+	ignoredKeys, err := s.getIgnoredVulnerabilityKeySetByEnvironmentInternal(ctx, envID)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to filter ignored vulnerabilities", "error", err)
+	}
+
+	items := make([]vulnerability.VulnerabilityWithImage, 0, estimatedVulnerabilityRecordCountInternal(records))
 	for _, record := range records {
 		if len(record.Vulnerabilities) == 0 || record.Vulnerabilities[0] == "" {
 			continue
@@ -644,18 +661,19 @@ func (s *VulnerabilityService) ListAllVulnerabilities(ctx context.Context, envID
 		}
 
 		for _, vuln := range vulns {
+			if len(ignoredKeys) > 0 {
+				key := vulnerabilityIgnoreKeyInternal(record.ID, vuln.VulnerabilityID, vuln.PkgName, vuln.InstalledVersion)
+				if _, isIgnored := ignoredKeys[key]; isIgnored {
+					continue
+				}
+			}
+
 			items = append(items, vulnerability.VulnerabilityWithImage{
 				Vulnerability: vuln,
 				ImageID:       record.ID,
 				ImageName:     record.ImageName,
 			})
 		}
-	}
-
-	// Filter out ignored vulnerabilities
-	items, err := s.filterIgnoredVulnerabilities(ctx, envID, items)
-	if err != nil {
-		slog.WarnContext(ctx, "failed to filter ignored vulnerabilities", "error", err)
 	}
 
 	config := pagination.Config[vulnerability.VulnerabilityWithImage]{
@@ -728,6 +746,139 @@ func (s *VulnerabilityService) ListAllVulnerabilities(ctx context.Context, envID
 	response := pagination.BuildResponseFromFilterResult(filtered, params)
 
 	return filtered.Items, response, nil
+}
+
+func applyListAllVulnerabilityRecordPrefiltersInternal(query *gorm.DB, filters map[string]string) (*gorm.DB, bool) {
+	if query == nil || len(filters) == 0 {
+		return query, true
+	}
+
+	if severityFilter, ok := filters["severity"]; ok {
+		severityColumns := severityCountColumnsForFilterInternal(severityFilter)
+		if len(severityColumns) == 0 {
+			return query, false
+		}
+
+		parts := make([]string, 0, len(severityColumns))
+		args := make([]any, 0, len(severityColumns))
+		for _, col := range severityColumns {
+			parts = append(parts, col+" > ?")
+			args = append(args, 0)
+		}
+		query = query.Where("("+strings.Join(parts, " OR ")+")", args...)
+	}
+
+	if imageNameFilter, ok := filters["imageName"]; ok {
+		imageNameParts := splitNonEmptyCSVInternal(imageNameFilter)
+		if len(imageNameParts) == 0 {
+			return query, false
+		}
+
+		clauses := make([]string, 0, len(imageNameParts))
+		args := make([]any, 0, len(imageNameParts))
+		for _, part := range imageNameParts {
+			clauses = append(clauses, "LOWER(image_name) LIKE ?")
+			args = append(args, "%"+strings.ToLower(part)+"%")
+		}
+		query = query.Where("("+strings.Join(clauses, " OR ")+")", args...)
+	}
+
+	return query, true
+}
+
+func severityCountColumnsForFilterInternal(value string) []string {
+	parts := splitNonEmptyCSVInternal(value)
+	if len(parts) == 0 {
+		return nil
+	}
+
+	columns := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		var col string
+		switch {
+		case strings.EqualFold(part, string(vulnerability.SeverityCritical)):
+			col = "critical_count"
+		case strings.EqualFold(part, string(vulnerability.SeverityHigh)):
+			col = "high_count"
+		case strings.EqualFold(part, string(vulnerability.SeverityMedium)):
+			col = "medium_count"
+		case strings.EqualFold(part, string(vulnerability.SeverityLow)):
+			col = "low_count"
+		case strings.EqualFold(part, string(vulnerability.SeverityUnknown)):
+			col = "unknown_count"
+		default:
+			continue
+		}
+
+		if _, exists := seen[col]; exists {
+			continue
+		}
+
+		seen[col] = struct{}{}
+		columns = append(columns, col)
+	}
+
+	return columns
+}
+
+func splitNonEmptyCSVInternal(value string) []string {
+	parts := make([]string, 0)
+	for part := range strings.SplitSeq(value, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		parts = append(parts, part)
+	}
+	return parts
+}
+
+func estimatedVulnerabilityRecordCountInternal(records []models.VulnerabilityScanRecord) int {
+	if len(records) == 0 {
+		return 0
+	}
+
+	total := 0
+	for i := range records {
+		if records[i].TotalCount <= 0 {
+			continue
+		}
+
+		if total > math.MaxInt-records[i].TotalCount {
+			return math.MaxInt
+		}
+		total += records[i].TotalCount
+	}
+
+	return total
+}
+
+func vulnerabilityIgnoreKeyInternal(imageID, vulnerabilityID, pkgName, installedVersion string) string {
+	return imageID + ":" + vulnerabilityID + ":" + pkgName + ":" + installedVersion
+}
+
+func (s *VulnerabilityService) getIgnoredVulnerabilityKeySetByEnvironmentInternal(ctx context.Context, envID string) (map[string]struct{}, error) {
+	if s.db == nil {
+		return nil, nil
+	}
+
+	var ignores []models.VulnerabilityIgnore
+	if err := s.db.WithContext(ctx).Where("environment_id = ?", envID).Find(&ignores).Error; err != nil {
+		return nil, fmt.Errorf("failed to get ignore records: %w", err)
+	}
+
+	if len(ignores) == 0 {
+		return nil, nil
+	}
+
+	ignoredKeys := make(map[string]struct{}, len(ignores))
+	for _, ignore := range ignores {
+		key := vulnerabilityIgnoreKeyInternal(ignore.ImageID, ignore.VulnerabilityID, ignore.PkgName, ignore.InstalledVersion)
+		ignoredKeys[key] = struct{}{}
+	}
+
+	return ignoredKeys, nil
 }
 
 func severityRankInternal(severity vulnerability.Severity) int {
@@ -2854,13 +3005,13 @@ func (s *VulnerabilityService) filterIgnoredVulnerabilitiesForImage(
 
 	ignoredKeys := make(map[string]struct{}, len(ignores))
 	for _, ignore := range ignores {
-		key := fmt.Sprintf("%s:%s:%s:%s", ignore.ImageID, ignore.VulnerabilityID, ignore.PkgName, ignore.InstalledVersion)
+		key := vulnerabilityIgnoreKeyInternal(ignore.ImageID, ignore.VulnerabilityID, ignore.PkgName, ignore.InstalledVersion)
 		ignoredKeys[key] = struct{}{}
 	}
 
 	filtered := make([]vulnerability.Vulnerability, 0, len(vulns))
 	for _, vuln := range vulns {
-		key := fmt.Sprintf("%s:%s:%s:%s", imageID, vuln.VulnerabilityID, vuln.PkgName, vuln.InstalledVersion)
+		key := vulnerabilityIgnoreKeyInternal(imageID, vuln.VulnerabilityID, vuln.PkgName, vuln.InstalledVersion)
 		if _, isIgnored := ignoredKeys[key]; isIgnored {
 			continue
 		}
@@ -3185,39 +3336,4 @@ func (s *VulnerabilityService) GetIgnoreRecordsForImage(ctx context.Context, env
 	}
 
 	return ignores, nil
-}
-
-// filterIgnoredVulnerabilities removes ignored vulnerabilities from the list
-func (s *VulnerabilityService) filterIgnoredVulnerabilities(ctx context.Context, envID string, vulns []vulnerability.VulnerabilityWithImage) ([]vulnerability.VulnerabilityWithImage, error) {
-	if s.db == nil || len(vulns) == 0 {
-		return vulns, nil
-	}
-
-	// Get all ignore records for this environment
-	var ignores []models.VulnerabilityIgnore
-	if err := s.db.WithContext(ctx).Where("environment_id = ?", envID).Find(&ignores).Error; err != nil {
-		return nil, fmt.Errorf("failed to get ignore records: %w", err)
-	}
-
-	if len(ignores) == 0 {
-		return vulns, nil
-	}
-
-	// Build a set of ignored vulnerability keys
-	ignoredKeys := make(map[string]struct{}, len(ignores))
-	for _, ignore := range ignores {
-		key := fmt.Sprintf("%s:%s:%s:%s", ignore.ImageID, ignore.VulnerabilityID, ignore.PkgName, ignore.InstalledVersion)
-		ignoredKeys[key] = struct{}{}
-	}
-
-	// Filter out ignored vulnerabilities
-	filtered := make([]vulnerability.VulnerabilityWithImage, 0, len(vulns))
-	for _, vuln := range vulns {
-		key := fmt.Sprintf("%s:%s:%s:%s", vuln.ImageID, vuln.VulnerabilityID, vuln.PkgName, vuln.InstalledVersion)
-		if _, isIgnored := ignoredKeys[key]; !isIgnored {
-			filtered = append(filtered, vuln)
-		}
-	}
-
-	return filtered, nil
 }

--- a/backend/internal/services/vulnerability_service_test.go
+++ b/backend/internal/services/vulnerability_service_test.go
@@ -16,6 +16,7 @@ import (
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/internal/utils/pagination"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/timeouts"
 	"github.com/getarcaneapp/arcane/types/vulnerability"
 	glsqlite "github.com/glebarez/sqlite"
@@ -492,7 +493,7 @@ func setupVulnerabilityScanTestDB(t *testing.T) *database.DB {
 	dsn := fmt.Sprintf("file:vulnerability-scan-test-%d?mode=memory&cache=shared", time.Now().UnixNano())
 	db, err := gorm.Open(glsqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.VulnerabilityScanRecord{}))
+	require.NoError(t, db.AutoMigrate(&models.VulnerabilityScanRecord{}, &models.VulnerabilityIgnore{}))
 	return &database.DB{DB: db}
 }
 
@@ -525,4 +526,121 @@ func TestVulnerabilityService_DeleteScanResultsByImageIDs_EmptyInput(t *testing.
 
 	require.NoError(t, svc.DeleteScanResultsByImageIDs(ctx, nil))
 	require.NoError(t, svc.DeleteScanResultsByImageIDs(ctx, []string{}))
+}
+
+func TestSeverityCountColumnsForFilterInternal(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    []string
+		wantNil bool
+	}{
+		{
+			name:  "single severity",
+			value: "critical",
+			want:  []string{"critical_count"},
+		},
+		{
+			name:  "multiple severities and duplicates",
+			value: "high,critical,high,UNKNOWN",
+			want:  []string{"high_count", "critical_count", "unknown_count"},
+		},
+		{
+			name:  "invalid severities only",
+			value: "foo,bar",
+			want:  []string{},
+		},
+		{
+			name:    "empty value",
+			value:   " , , ",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := severityCountColumnsForFilterInternal(tt.value)
+			if tt.wantNil {
+				require.Nil(t, got)
+				return
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestApplyListAllVulnerabilityRecordPrefiltersInternal_NoPossibleMatches(t *testing.T) {
+	db := setupVulnerabilityScanTestDB(t)
+	base := db.WithContext(context.Background()).Model(&models.VulnerabilityScanRecord{})
+
+	_, ok := applyListAllVulnerabilityRecordPrefiltersInternal(base, map[string]string{"severity": "not-a-severity"})
+	require.False(t, ok)
+
+	_, ok = applyListAllVulnerabilityRecordPrefiltersInternal(base, map[string]string{"imageName": "  ,  "})
+	require.False(t, ok)
+
+	_, ok = applyListAllVulnerabilityRecordPrefiltersInternal(base, map[string]string{
+		"severity":  "high,bad",
+		"imageName": "nginx",
+	})
+	require.True(t, ok)
+}
+
+func TestEstimatedVulnerabilityRecordCountInternal(t *testing.T) {
+	records := []models.VulnerabilityScanRecord{
+		{TotalCount: 5},
+		{TotalCount: 0},
+		{TotalCount: -3},
+		{TotalCount: 12},
+	}
+
+	require.Equal(t, 17, estimatedVulnerabilityRecordCountInternal(records))
+}
+
+func TestVulnerabilityService_ListAllVulnerabilities_FiltersIgnoredInline(t *testing.T) {
+	ctx := context.Background()
+	db := setupVulnerabilityScanTestDB(t)
+	svc := &VulnerabilityService{db: db}
+
+	vulns := []vulnerability.Vulnerability{
+		{
+			VulnerabilityID:  "CVE-2026-0001",
+			PkgName:          "openssl",
+			InstalledVersion: "1.0.0",
+			Severity:         vulnerability.SeverityHigh,
+		},
+	}
+	rawVulns, err := json.Marshal(vulns)
+	require.NoError(t, err)
+
+	scan := models.VulnerabilityScanRecord{
+		ID:              "sha256:list-all-1",
+		ImageName:       "nginx:latest",
+		Status:          models.ScanStatusCompleted,
+		ScanTime:        time.Now(),
+		HighCount:       1,
+		TotalCount:      1,
+		Vulnerabilities: models.StringSlice{string(rawVulns)},
+	}
+	require.NoError(t, db.Create(&scan).Error)
+
+	reason := "accepted risk"
+	ignore := models.VulnerabilityIgnore{
+		EnvironmentID:    "env-1",
+		ImageID:          scan.ID,
+		VulnerabilityID:  "CVE-2026-0001",
+		PkgName:          "openssl",
+		InstalledVersion: "1.0.0",
+		Reason:           &reason,
+		CreatedBy:        "tester",
+	}
+	require.NoError(t, db.Create(&ignore).Error)
+
+	items, page, err := svc.ListAllVulnerabilities(ctx, "env-1", pagination.QueryParams{
+		PaginationParams: pagination.PaginationParams{Start: 0, Limit: 20},
+	})
+	require.NoError(t, err)
+	require.Empty(t, items)
+	require.Equal(t, int64(0), page.TotalItems)
+	require.Equal(t, int64(0), page.GrandTotalItems)
 }


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR optimizes the `ListAllVulnerabilities` function by introducing query-level prefiltering to reduce unnecessary database fetches and replacing a post-processing filter with inline ignored vulnerability filtering.

Key changes:
- Added `applyListAllVulnerabilityRecordPrefiltersInternal` to filter scans at the database query level using severity counts and image name patterns, preventing unnecessary record fetches when filters cannot match
- Replaced the `filterIgnoredVulnerabilities` post-processing function with inline filtering during vulnerability iteration using `getIgnoredVulnerabilityKeySetByEnvironmentInternal` for better performance
- Extracted and consolidated the vulnerability ignore key generation logic into `vulnerabilityIgnoreKeyInternal` helper, eliminating `fmt.Sprintf` duplication
- Added `splitNonEmptyCSVInternal` and `estimatedVulnerabilityRecordCountInternal` helpers following the "Internal" suffix convention
- All new internal helper functions properly follow the codebase naming convention requiring "Internal" suffix for unexported functions
- Comprehensive test coverage added for all new helper functions including edge cases
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no identified issues
- The changes are well-implemented performance optimizations with proper validation, comprehensive test coverage, and adherence to codebase conventions. The prefiltering logic safely validates all column names against hardcoded constants before SQL concatenation, preventing injection. The inline filtering optimization maintains correctness while improving performance. All new functions follow the Internal suffix naming convention and include appropriate tests for edge cases.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/vulnerability_service.go | Added prefiltering logic to reduce database load by filtering at query time, inlined ignored vulnerability filtering for better performance, and extracted helper functions following naming conventions |
| backend/internal/services/vulnerability_service_test.go | Added comprehensive tests for new helper functions including edge cases for prefiltering, severity mapping, and inline ignored vulnerability filtering |

</details>


</details>


<sub>Last reviewed commit: d774193</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - What: All unexported functions must have the "Internal" suffix.

Why: Clearly distinguishes private ... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->