### PR TITLE
fix: track active updates in status maps and bound error-event logging path

### DIFF
--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -763,6 +763,7 @@ func (s *ImageUpdateService) buildCredentialMap(ctx context.Context, externalCre
 	}
 
 	if len(externalCreds) > 0 {
+		enabledRegHosts := make(map[string]struct{})
 		for _, c := range externalCreds {
 			if !c.Enabled || c.Username == "" || c.Token == "" {
 				continue
@@ -773,6 +774,9 @@ func (s *ImageUpdateService) buildCredentialMap(ctx context.Context, externalCre
 			}
 			if _, exists := credMap[host]; !exists {
 				credMap[host] = batchCred{username: c.Username, token: c.Token}
+			}
+			if _, exists := enabledRegHosts[host]; exists {
+				continue
 			}
 			encToken, encErr := crypto.Encrypt(c.Token)
 			if encErr != nil {
@@ -785,6 +789,7 @@ func (s *ImageUpdateService) buildCredentialMap(ctx context.Context, externalCre
 				Token:    encToken,
 				Enabled:  c.Enabled,
 			})
+			enabledRegHosts[host] = struct{}{}
 		}
 		slog.DebugContext(ctx, "Using external credentials for batch check", "credentialCount", len(credMap))
 		return credMap, enabledRegs


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes critical concurrency issues and prevents metadata mutation across three backend services.

**Key Changes:**
- **`event_service.go`**: Removed async goroutine from `LogErrorEvent`, made it synchronous with bounded timeout, and implemented deep cloning via `cloneEventMetadataInternal` to prevent input metadata mutation
- **`image_update_service.go`**: Added `enabledRegHosts` map to deduplicate enabled registry records by normalized host, preventing duplicate entries for the same registry
- **`updater_service.go`**: Added `sync.RWMutex` (`statusMu`) to protect concurrent access to `updatingContainers` and `updatingProjects` maps; introduced `beginContainerUpdateInternal` and `beginProjectUpdateInternal` helpers that return cleanup functions for proper lifecycle tracking

The changes address race conditions in status map access and metadata mutation bugs, with comprehensive test coverage added for all new functionality.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- All changes fix legitimate concurrency bugs with well-tested implementations. The mutex protection prevents race conditions, deep cloning prevents metadata mutation, and registry deduplication prevents duplicate entries. Test coverage is comprehensive.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/event_service.go | Removed async goroutine and added deep cloning for metadata to prevent mutation |
| backend/internal/services/image_update_service.go | Added deduplication logic to prevent duplicate enabled registry entries per host |
| backend/internal/services/updater_service.go | Added mutex-protected status tracking for concurrent container/project updates |

</details>


</details>


<sub>Last reviewed commit: 4897acf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->