### PR TITLE
fix: registry syncing to environments not running on initially pairing

### DIFF
--- a/backend/internal/huma/huma.go
+++ b/backend/internal/huma/huma.go
@@ -349,7 +349,7 @@ func registerHandlers(api huma.API, svc *Services) {
 	handlers.RegisterEvents(api, eventSvc)
 	handlers.RegisterOidc(api, authSvc, oidcSvc, cfg)
 	handlers.RegisterEnvironments(api, environmentSvc, settingsSvc, apiKeySvc, eventSvc, cfg)
-	handlers.RegisterContainerRegistries(api, containerRegistrySvc)
+	handlers.RegisterContainerRegistries(api, containerRegistrySvc, environmentSvc)
 	handlers.RegisterTemplates(api, templateSvc)
 	handlers.RegisterImages(api, dockerSvc, imageSvc, imageUpdateSvc, settingsSvc)
 	handlers.RegisterImageUpdates(api, imageUpdateSvc)

--- a/backend/internal/services/environment_service_test.go
+++ b/backend/internal/services/environment_service_test.go
@@ -1,0 +1,185 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	glsqlite "github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/getarcaneapp/arcane/backend/internal/config"
+	"github.com/getarcaneapp/arcane/backend/internal/database"
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/internal/utils/crypto"
+	"github.com/getarcaneapp/arcane/types/containerregistry"
+)
+
+func setupEnvironmentServiceTestDB(t *testing.T) *database.DB {
+	t.Helper()
+
+	db, err := gorm.Open(glsqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Environment{}, &models.ContainerRegistry{}))
+
+	testCfg := &config.Config{
+		EncryptionKey: "test-encryption-key-for-testing-32bytes-min",
+		Environment:   "test",
+	}
+	crypto.InitEncryption(testCfg)
+
+	return &database.DB{DB: db}
+}
+
+func createTestEnvironment(t *testing.T, db *database.DB, id string, apiURL string, accessToken *string) {
+	t.Helper()
+
+	now := time.Now()
+	env := &models.Environment{
+		BaseModel: models.BaseModel{
+			ID:        id,
+			CreatedAt: now,
+			UpdatedAt: &now,
+		},
+		Name:        "env-" + id,
+		ApiUrl:      apiURL,
+		Status:      string(models.EnvironmentStatusOnline),
+		Enabled:     true,
+		AccessToken: accessToken,
+	}
+
+	require.NoError(t, db.WithContext(context.Background()).Create(env).Error)
+}
+
+func createTestRegistry(t *testing.T, db *database.DB, id string) {
+	t.Helper()
+
+	encryptedToken, err := crypto.Encrypt("registry-token")
+	require.NoError(t, err)
+
+	now := time.Now()
+	registry := &models.ContainerRegistry{
+		BaseModel: models.BaseModel{
+			ID:        id,
+			CreatedAt: now,
+			UpdatedAt: &now,
+		},
+		URL:       "registry.example.com",
+		Username:  "registry-user",
+		Token:     encryptedToken,
+		Enabled:   true,
+		Insecure:  false,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	require.NoError(t, db.WithContext(context.Background()).Create(registry).Error)
+}
+
+func TestEnvironmentService_SyncRegistriesToRemoteEnvironments_SyncsEligibleRemotes(t *testing.T) {
+	ctx := context.Background()
+	db := setupEnvironmentServiceTestDB(t)
+	svc := NewEnvironmentService(db, nil, nil, nil, nil)
+
+	createTestRegistry(t, db, "reg-1")
+
+	var env1Calls atomic.Int32
+	env1Token := "token-1"
+	env1Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/container-registries/sync", r.URL.Path)
+		require.Equal(t, env1Token, r.Header.Get("X-API-Key"))
+		require.Equal(t, env1Token, r.Header.Get("X-Arcane-Agent-Token"))
+
+		var syncReq containerregistry.SyncRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&syncReq))
+		require.Len(t, syncReq.Registries, 1)
+		env1Calls.Add(1)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"message":"ok"}}`))
+	}))
+	defer env1Server.Close()
+
+	var env2Calls atomic.Int32
+	env2Token := "token-2"
+	env2Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/container-registries/sync", r.URL.Path)
+		require.Equal(t, env2Token, r.Header.Get("X-API-Key"))
+		require.Equal(t, env2Token, r.Header.Get("X-Arcane-Agent-Token"))
+
+		var syncReq containerregistry.SyncRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&syncReq))
+		require.Len(t, syncReq.Registries, 1)
+		env2Calls.Add(1)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"message":"ok"}}`))
+	}))
+	defer env2Server.Close()
+
+	createTestEnvironment(t, db, "0", "http://localhost:3552", nil) // local env should be excluded
+	createTestEnvironment(t, db, "env-1", env1Server.URL, &env1Token)
+	createTestEnvironment(t, db, "env-2", env2Server.URL, &env2Token)
+
+	err := svc.SyncRegistriesToRemoteEnvironments(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, env1Calls.Load())
+	require.EqualValues(t, 1, env2Calls.Load())
+}
+
+func TestEnvironmentService_SyncRegistriesToRemoteEnvironments_SkipsRemoteWithoutAccessToken(t *testing.T) {
+	ctx := context.Background()
+	db := setupEnvironmentServiceTestDB(t)
+	svc := NewEnvironmentService(db, nil, nil, nil, nil)
+
+	createTestRegistry(t, db, "reg-1")
+
+	var syncCalls atomic.Int32
+	token := "token-with-auth"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		syncCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"message":"ok"}}`))
+	}))
+	defer server.Close()
+
+	createTestEnvironment(t, db, "env-auth", server.URL, &token)
+	createTestEnvironment(t, db, "env-no-token", "http://127.0.0.1:1", nil)
+
+	err := svc.SyncRegistriesToRemoteEnvironments(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, syncCalls.Load())
+}
+
+func TestEnvironmentService_SyncRegistriesToRemoteEnvironments_ReportsFailuresButContinues(t *testing.T) {
+	ctx := context.Background()
+	db := setupEnvironmentServiceTestDB(t)
+	svc := NewEnvironmentService(db, nil, nil, nil, nil)
+
+	createTestRegistry(t, db, "reg-1")
+
+	var successCalls atomic.Int32
+	successToken := "token-success"
+	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		successCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"message":"ok"}}`))
+	}))
+	defer successServer.Close()
+
+	failingToken := "token-fail"
+	createTestEnvironment(t, db, "env-success", successServer.URL, &successToken)
+	createTestEnvironment(t, db, "env-fail", "http://127.0.0.1:1", &failingToken)
+
+	err := svc.SyncRegistriesToRemoteEnvironments(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to sync registries to 1 remote environment")
+	require.EqualValues(t, 1, successCalls.Load())
+}


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1777

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes registry syncing to remote environments that aren't running when initially paired. The solution broadcasts registry changes to all remote environments when registries are modified, and triggers resource sync after environment pairing completes.

**Key changes:**
- Implemented `SyncRegistriesToRemoteEnvironments` to fan out registry changes to all enabled remote environments with access tokens
- Added `triggerRemoteRegistrySync` in container registry handlers to sync after create/update/delete operations
- Refactored environment resource sync into reusable `triggerEnvironmentResourceSync` helper
- Added sync trigger after successful environment pairing (both legacy and API key flows)
- Included comprehensive test coverage validating multi-environment sync, token filtering, and partial failure handling

The implementation properly uses detached contexts for background operations, includes appropriate error logging, and continues syncing to other environments even when individual syncs fail.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns for background sync operations, includes proper error handling and logging, uses detached contexts appropriately, and has comprehensive test coverage. The changes are well-isolated and backwards-compatible.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/huma/handlers/container_registries.go | Added environmentService dependency and triggerRemoteRegistrySync helper to fan out registry changes to remote environments after create/update/delete operations |
| backend/internal/huma/handlers/environments.go | Refactored background sync logic into triggerEnvironmentResourceSync helper and added sync trigger after environment pairing completes |
| backend/internal/services/environment_service.go | Implemented SyncRegistriesToRemoteEnvironments to broadcast registry changes to all eligible remote environments with access tokens |

</details>


</details>


<sub>Last reviewed commit: dea672a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->