### PR TITLE
fix: limit container create options based on docker api

### DIFF
--- a/backend/pkg/libarcane/docker_compat.go
+++ b/backend/pkg/libarcane/docker_compat.go
@@ -1,0 +1,120 @@
+package libarcane
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+)
+
+const NetworkScopedMacAddressMinAPIVersion = "1.44"
+
+// DetectDockerAPIVersion returns the negotiated client API version when
+// available, and falls back to querying the daemon server version.
+func DetectDockerAPIVersion(ctx context.Context, dockerClient *client.Client) string {
+	if dockerClient == nil {
+		return ""
+	}
+
+	if version := strings.TrimSpace(dockerClient.ClientVersion()); version != "" {
+		return version
+	}
+
+	serverVersion, err := dockerClient.ServerVersion(ctx)
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(serverVersion.APIVersion)
+}
+
+// SupportsDockerCreatePerNetworkMACAddress reports whether the daemon API
+// supports per-network mac-address on container create (Docker API >= 1.44).
+func SupportsDockerCreatePerNetworkMACAddress(apiVersion string) bool {
+	return IsDockerAPIVersionAtLeast(apiVersion, NetworkScopedMacAddressMinAPIVersion)
+}
+
+// IsDockerAPIVersionAtLeast performs numeric dot-segment comparison for Docker
+// API versions (e.g. "1.43", "1.44.1"). Returns false when either version
+// cannot be parsed.
+func IsDockerAPIVersionAtLeast(current, minimum string) bool {
+	cur, ok := parseAPIVersion(current)
+	if !ok {
+		return false
+	}
+
+	minV, ok := parseAPIVersion(minimum)
+	if !ok {
+		return false
+	}
+
+	for i := range len(cur) {
+		if cur[i] > minV[i] {
+			return true
+		}
+		if cur[i] < minV[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// SanitizeContainerCreateEndpointSettingsForDockerAPI clones endpoint settings
+// for container recreate and removes per-network mac-address when daemon API
+// does not support it (API < 1.44).
+func SanitizeContainerCreateEndpointSettingsForDockerAPI(endpoints map[string]*network.EndpointSettings, apiVersion string) map[string]*network.EndpointSettings {
+	if len(endpoints) == 0 {
+		return nil
+	}
+
+	keepPerNetworkMAC := SupportsDockerCreatePerNetworkMACAddress(apiVersion)
+	cloned := make(map[string]*network.EndpointSettings, len(endpoints))
+
+	for networkName, endpoint := range endpoints {
+		if endpoint == nil {
+			cloned[networkName] = nil
+			continue
+		}
+
+		endpointCopy := *endpoint
+		if !keepPerNetworkMAC {
+			endpointCopy.MacAddress = ""
+		}
+
+		cloned[networkName] = &endpointCopy
+	}
+
+	return cloned
+}
+
+func parseAPIVersion(version string) ([3]int, bool) {
+	parsed := [3]int{}
+
+	version = strings.TrimSpace(strings.TrimPrefix(version, "v"))
+	if version == "" {
+		return parsed, false
+	}
+
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 {
+		return parsed, false
+	}
+
+	for i := 0; i < len(parsed) && i < len(parts); i++ {
+		part := strings.TrimSpace(parts[i])
+		if part == "" {
+			return [3]int{}, false
+		}
+
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return [3]int{}, false
+		}
+		parsed[i] = n
+	}
+
+	return parsed, true
+}

--- a/backend/pkg/libarcane/docker_compat_test.go
+++ b/backend/pkg/libarcane/docker_compat_test.go
@@ -1,0 +1,79 @@
+package libarcane
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/network"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsDockerAPIVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  string
+		minimum  string
+		expected bool
+	}{
+		{name: "equal", current: "1.44", minimum: "1.44", expected: true},
+		{name: "greater minor", current: "1.45", minimum: "1.44", expected: true},
+		{name: "lesser minor", current: "1.43", minimum: "1.44", expected: false},
+		{name: "patch still greater", current: "1.44.1", minimum: "1.44", expected: true},
+		{name: "podman api", current: "1.41", minimum: "1.44", expected: false},
+		{name: "trims v prefix", current: "v1.44", minimum: "1.44", expected: true},
+		{name: "invalid current", current: "invalid", minimum: "1.44", expected: false},
+		{name: "invalid minimum", current: "1.44", minimum: "invalid", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, IsDockerAPIVersionAtLeast(tt.current, tt.minimum))
+		})
+	}
+}
+
+func TestSupportsDockerCreatePerNetworkMACAddress(t *testing.T) {
+	require.True(t, SupportsDockerCreatePerNetworkMACAddress("1.44"))
+	require.True(t, SupportsDockerCreatePerNetworkMACAddress("1.46"))
+	require.False(t, SupportsDockerCreatePerNetworkMACAddress("1.43"))
+	require.False(t, SupportsDockerCreatePerNetworkMACAddress("1.41"))
+}
+
+func TestSanitizeContainerCreateEndpointSettingsForDockerAPI(t *testing.T) {
+	input := map[string]*network.EndpointSettings{
+		"bridge": {
+			MacAddress: "02:42:ac:11:00:02",
+			IPAddress:  "172.17.0.2",
+			Aliases:    []string{"svc", "svc-1"},
+		},
+		"custom": {
+			MacAddress: "02:42:ac:11:00:03",
+			IPAddress:  "10.0.0.10",
+			Aliases:    []string{"custom-svc"},
+		},
+	}
+
+	t.Run("strips mac for api below 1.44", func(t *testing.T) {
+		out := SanitizeContainerCreateEndpointSettingsForDockerAPI(input, "1.43")
+		require.Len(t, out, 2)
+		require.Empty(t, out["bridge"].MacAddress)
+		require.Empty(t, out["custom"].MacAddress)
+		require.Equal(t, "172.17.0.2", out["bridge"].IPAddress)
+		require.Equal(t, []string{"svc", "svc-1"}, out["bridge"].Aliases)
+
+		// Ensure original map entries are untouched
+		require.Equal(t, "02:42:ac:11:00:02", input["bridge"].MacAddress)
+		require.Equal(t, "02:42:ac:11:00:03", input["custom"].MacAddress)
+	})
+
+	t.Run("preserves mac for api at or above 1.44", func(t *testing.T) {
+		out := SanitizeContainerCreateEndpointSettingsForDockerAPI(input, "1.44")
+		require.Len(t, out, 2)
+		require.Equal(t, "02:42:ac:11:00:02", out["bridge"].MacAddress)
+		require.Equal(t, "02:42:ac:11:00:03", out["custom"].MacAddress)
+	})
+
+	t.Run("nil or empty input", func(t *testing.T) {
+		require.Nil(t, SanitizeContainerCreateEndpointSettingsForDockerAPI(nil, "1.44"))
+		require.Nil(t, SanitizeContainerCreateEndpointSettingsForDockerAPI(map[string]*network.EndpointSettings{}, "1.44"))
+	})
+}


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1332

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Docker API version detection to handle compatibility issues with older Docker daemons (< 1.44) that don't support per-network MAC addresses in container create operations. The implementation introduces a new `docker_compat.go` utility package that detects the Docker API version and sanitizes endpoint settings by stripping MAC addresses when necessary. This fix is applied in both the upgrade CLI and the updater service to prevent container creation failures on older Docker/Podman installations.

- Introduces version detection and comparison utilities (`DetectDockerAPIVersion`, `IsDockerAPIVersionAtLeast`)
- Adds `SanitizeContainerCreateEndpointSettingsForDockerAPI` to conditionally strip per-network MAC addresses based on API version
- Refactors network configuration in `upgrade.go` and `updater_service.go` to use the new compatibility layer
- Includes comprehensive test coverage for version comparison and sanitization logic
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge - well-tested compatibility fix with no breaking changes
- Clean implementation with comprehensive test coverage, defensive nil checks, and proper error handling. The changes are backwards-compatible and solve a real compatibility issue without introducing new dependencies or complexity.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/pkg/libarcane/docker_compat.go | New utility functions to detect Docker API version and sanitize endpoint settings for compatibility with older Docker APIs (< 1.44) |
| backend/pkg/libarcane/docker_compat_test.go | Comprehensive test coverage for version comparison and MAC address sanitization logic |
| backend/cli/upgrade/upgrade.go | Refactored network config creation to use new compatibility layer, removing manual endpoint copying |
| backend/internal/services/updater_service.go | Applied same Docker API compatibility logic to container update flow |

</details>


</details>


<sub>Last reviewed commit: a54b344</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->