### PR TITLE
fix: allow editing .env files for GitOps-managed projects (#1748)

### DIFF
--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -90,7 +90,6 @@
 		!isGitOpsManaged && !isLoading.saving && project?.status !== 'running' && project?.status !== 'partially running'
 	);
 	let canEditCompose = $derived(!isGitOpsManaged);
-	let canEditEnv = $derived(!isGitOpsManaged);
 
 	let autoScrollStackLogs = $state(true);
 
@@ -544,7 +543,7 @@
 											language="env"
 											bind:value={$inputs.envContent.value}
 											error={$inputs.envContent.error ?? undefined}
-											readOnly={!canEditEnv}
+ 
 										/>
 									{:else}
 										{@const includeFile = project?.includeFiles?.find((f) => f.relativePath === selectedFile)}
@@ -633,14 +632,13 @@
 												readOnly={!canEditCompose}
 											/>
 										{:else if selectedFile === 'env'}
-											<CodePanel
-												bind:open={envOpen}
-												title=".env"
-												language="env"
-												bind:value={$inputs.envContent.value}
-												error={$inputs.envContent.error ?? undefined}
-												readOnly={!canEditEnv}
-											/>
+										<CodePanel
+											bind:open={envOpen}
+											title=".env"
+											language="env"
+											bind:value={$inputs.envContent.value}
+											error={$inputs.envContent.error ?? undefined}
+										/>
 										{:else}
 											{@const includeFile = project?.includeFiles?.find((f) => f.relativePath === selectedFile)}
 											{#if includeFile}
@@ -704,7 +702,7 @@
 											language="env"
 											bind:value={$inputs.envContent.value}
 											error={$inputs.envContent.error ?? undefined}
-											readOnly={!canEditEnv}
+ 
 										/>
 									</div>
 
@@ -735,14 +733,13 @@
 
 										{#snippet second()}
 											<div class="flex min-h-0 flex-1 flex-col">
-												<CodePanel
-													bind:open={envOpen}
-													title=".env"
-													language="env"
-													bind:value={$inputs.envContent.value}
-													error={$inputs.envContent.error ?? undefined}
-													readOnly={!canEditEnv}
-												/>
+										<CodePanel
+											bind:open={envOpen}
+											title=".env"
+											language="env"
+											bind:value={$inputs.envContent.value}
+											error={$inputs.envContent.error ?? undefined}
+										/>
 											</div>
 										{/snippet}
 									</ResizableSplit>

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -411,37 +411,6 @@ test.describe("GitOps Managed Project", () => {
     expect(isReadOnly).toBe(true);
   });
 
-  test("should have env editor in read-only mode when GitOps managed", async ({ page }) => {
-    const gitOpsProject = realProjects.find((p) => p.gitOpsManagedBy);
-    test.skip(!gitOpsProject, "No GitOps-managed projects found");
-
-    await page.goto(`/projects/${gitOpsProject!.id}`);
-    await page.waitForLoadState("networkidle");
-
-    const configTab = page.getByRole("tab", { name: /Configuration|Config/i });
-    await configTab.click();
-    await page.waitForLoadState("networkidle");
-
-    // Wait for Monaco editor to load
-    await page.waitForTimeout(1000);
-
-    // Check that the Monaco editor instance has readOnly option set
-    const isReadOnly = await page.evaluate(() => {
-      const editors = (window as any).monaco?.editor?.getEditors() ?? [];
-      // Find the env/ini editor
-      const envEditor = editors.find((e: any) => {
-        const model = e.getModel();
-        return model && model.getLanguageId() === "ini";
-      });
-      if (envEditor) {
-        return envEditor.getOption((window as any).monaco.editor.EditorOption.readOnly);
-      }
-      return null;
-    });
-
-    expect(isReadOnly).toBe(true);
-  });
-
   test("should allow editing for non-GitOps managed projects", async ({ page }) => {
     const regularProject = realProjects.find((p) => !p.gitOpsManagedBy && p.status === "stopped");
     test.skip(!regularProject, "No regular (non-GitOps) stopped projects found");


### PR DESCRIPTION
## Summary
Fixes #1748 - Allow editing .env files for GitOps-managed projects

Restores original design intent where .env files can be edited in Arcane for environment-specific runtime configuration, even for projects synced from Git.

## Related Issue
Fixes https://github.com/getarcaneapp/arcane/issues/1748

## Background
The bug was introduced in PR #1632 (commit 7f05d17) when adding .env sync capability from Git repositories. The developer made .env editor read-only "for consistency" with compose editor, but this violated original design intent established in PR #1089 and PR #1471.

Key facts:
- UI message explicitly states: "The environment file (.env) can still be edited in Arcane to provide runtime configuration"
- Backend already accepts .env updates for GitOps projects (PR #1471)
- Best practices dictate .env files should be environment-specific (API keys, secrets), not Git-tracked infrastructure

## Changes
- Removed canEditEnv derived variable from project detail page
- Removed readOnly={!canEditEnv} attributes from all .env CodePanel components (4 locations)
- Removed test that incorrectly expected read-only env editor for GitOps projects

## How Both Scenarios Work After Fix
The backend sync logic already handles both cases correctly:

**Scenario 1 (.env in Git)**: Users CAN edit, but Git sync overwrites changes (Git is source of truth)
**Scenario 2 (.env not in Git)**: Users CAN edit, and changes are preserved (local customization)

## Testing
- [x] Frontend code changes verified
- [x] All canEditEnv references removed from project page
- [x] Incorrect test removed from test suite
- [ ] Frontend type checking passes: just lint frontend
- [ ] Manual testing: .env editor is editable for GitOps-managed projects
- [ ] Manual testing: compose.yaml editor remains read-only for GitOps-managed projects (unchanged)
- [ ] Manual testing: Save functionality works correctly

## Technical Details
**Frontend** (frontend/src/routes/(app)/projects/[projectId]/+page.svelte):
- Removed line 93: let canEditEnv = $derived(!isGitOpsManaged);
- Removed readOnly={!canEditEnv} from lines ~547, ~642, ~707, ~744 (all .env CodePanel instances)

**Tests** (tests/spec/project.spec.ts):
- Removed test "should have env editor in read-only mode when GitOps managed" (lines 414-443)

## Verification Steps
To complete testing after merging:

1. **Start dev environment**
   ```bash
   ./scripts/development/dev.sh start
   ```

2. **Run type checking**
   ```bash
   just lint frontend
   # OR
   cd frontend && npm run check
   ```

3. **Manual testing**
   - Navigate to a GitOps-managed project
   - Go to Configuration tab
   - Verify .env editor is editable (not read-only)
   - Verify compose.yaml editor is still read-only
   - Add an environment variable to .env (e.g., `TEST_VAR=test_value`)
   - Click Save
   - Verify save succeeds and variable persists
   - Refresh page and verify variable is still present

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores the original design intent that `.env` files should be editable in Arcane even for GitOps-managed projects, fixing a regression introduced in PR #1632. The change is well-reasoned and consistent with the existing backend behavior and UI messaging.

Key changes:
- Removes the `canEditEnv = $derived(!isGitOpsManaged)` variable from `+page.svelte` (the only meaningful logic change)
- Removes `readOnly={!canEditEnv}` from all four `.env` `CodePanel` instances across the classic and tree layout views
- The save handler already correctly sends `envContent` to the backend for GitOps projects while skipping `namePayload` and `composePayload` (lines 193–198), so the backend integration requires no changes
- The existing GitOps alert banner already displays the `git_managed_env_note` message informing users that the `.env` file can be edited — the UI and code are now consistent
- The old spec that asserted read-only behavior was removed; a counterpart test asserting editable behavior was not added, leaving a minor test coverage gap
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge — the logic change is minimal and the backend already supports the intended behavior.
- The fix is a straightforward removal of a derived variable and its prop bindings. The save logic correctly sends env content for GitOps projects already. The UI message already told users the env file was editable. The only concern is missing test coverage for the new intended behavior, but this is minor and does not affect production correctness.
- No files require special attention beyond the minor test coverage gap in `tests/spec/project.spec.ts`.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/routes/(app)/projects/[projectId]/+page.svelte | Removes `canEditEnv` derived variable and its `readOnly` bindings from all four `.env` CodePanel instances, allowing GitOps-managed projects to edit their env files. The save logic already correctly sends `envContent` to the backend regardless of GitOps status (lines 192–198). The UI already shows a note informing users the env file can be edited. Minor trailing whitespace left at lines 546 and 705 (previously flagged). |
| tests/spec/project.spec.ts | Removes the now-incorrect test that expected the env editor to be read-only for GitOps-managed projects. No replacement test is added to assert the env editor is editable for GitOps projects, leaving a coverage gap for this specific behavior. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User on GitOps Project\nConfiguration Tab] --> B{isGitOpsManaged?}
    B -- Yes --> C[compose.yaml CodePanel\nreadOnly=true\nvia canEditCompose]
    B -- Yes --> D[.env CodePanel\nreadOnly=false\neditable ✅]
    B -- No --> E[compose.yaml CodePanel\nreadOnly=false]
    B -- No --> F[.env CodePanel\nreadOnly=false]
    D --> G[User edits .env\nhasChanges = true]
    G --> H[handleSaveChanges]
    H --> I{isGitOpsManaged?}
    I -- Yes --> J[namePayload = undefined\ncomposePayload = undefined\nenvContent = edited value]
    I -- No --> K[namePayload = name\ncomposePayload = compose\nenvContent = edited value]
    J --> L[projectService.updateProject]
    K --> L
```
</details>


<sub>Last reviewed commit: 35ffb50</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->