### PR TITLE
fix: image pulls failing for certain public images

### DIFF
--- a/backend/internal/services/image_service_test.go
+++ b/backend/internal/services/image_service_test.go
@@ -1,8 +1,22 @@
 package services
 
 import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"testing"
 
+	glsqlite "github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/docker/docker/api/types/image"
+	dockerregistry "github.com/docker/docker/api/types/registry"
+	"github.com/getarcaneapp/arcane/backend/internal/config"
+	"github.com/getarcaneapp/arcane/backend/internal/database"
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/internal/utils/crypto"
 	imagetypes "github.com/getarcaneapp/arcane/types/image"
 	"github.com/getarcaneapp/arcane/types/vulnerability"
 	"github.com/stretchr/testify/assert"
@@ -38,4 +52,96 @@ func TestApplyVulnerabilitySummariesToItemsInternal(t *testing.T) {
 
 	assert.Equal(t, summary, items[0].VulnerabilityScan)
 	assert.Nil(t, items[1].VulnerabilityScan)
+}
+
+func setupImageServiceAuthTest(t *testing.T) (*ImageService, *database.DB) {
+	t.Helper()
+
+	db, err := gorm.Open(glsqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.ContainerRegistry{}))
+
+	crypto.InitEncryption(&config.Config{
+		Environment:   config.AppEnvironmentTest,
+		EncryptionKey: "test-encryption-key-for-testing-32bytes-min",
+	})
+
+	dbWrap := &database.DB{DB: db}
+	svc := &ImageService{
+		registryService: NewContainerRegistryService(dbWrap),
+	}
+
+	return svc, dbWrap
+}
+
+func createTestPullRegistry(t *testing.T, db *database.DB, url, username, token string) {
+	t.Helper()
+
+	encryptedToken, err := crypto.Encrypt(token)
+	require.NoError(t, err)
+
+	reg := &models.ContainerRegistry{
+		URL:      url,
+		Username: username,
+		Token:    encryptedToken,
+		Enabled:  true,
+	}
+	require.NoError(t, db.WithContext(context.Background()).Create(reg).Error)
+}
+
+func decodeRegistryAuth(t *testing.T, encoded string) dockerregistry.AuthConfig {
+	t.Helper()
+
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+
+	var cfg dockerregistry.AuthConfig
+	require.NoError(t, json.Unmarshal(raw, &cfg))
+	return cfg
+}
+
+func TestGetPullOptionsWithAuth_DBRegistrySkipsEmptyToken(t *testing.T) {
+	svc, db := setupImageServiceAuthTest(t)
+	createTestPullRegistry(t, db, "https://docker.io", "docker-user", "   ")
+
+	pullOptions, err := svc.getPullOptionsWithAuth(context.Background(), "docker.io/library/nginx:latest", nil)
+	require.NoError(t, err)
+	assert.Empty(t, pullOptions.RegistryAuth)
+}
+
+func TestGetPullOptionsWithAuth_DBRegistrySkipsEmptyUsername(t *testing.T) {
+	svc, db := setupImageServiceAuthTest(t)
+	createTestPullRegistry(t, db, "https://docker.io", "   ", "docker-token")
+
+	pullOptions, err := svc.getPullOptionsWithAuth(context.Background(), "docker.io/library/nginx:latest", nil)
+	require.NoError(t, err)
+	assert.Empty(t, pullOptions.RegistryAuth)
+}
+
+func TestGetPullOptionsWithAuth_DBRegistryUsesValidCredentials(t *testing.T) {
+	svc, db := setupImageServiceAuthTest(t)
+	createTestPullRegistry(t, db, "https://index.docker.io/v1/", "docker-user", "docker-token")
+
+	pullOptions, err := svc.getPullOptionsWithAuth(context.Background(), "docker.io/library/nginx:latest", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, pullOptions.RegistryAuth)
+
+	authCfg := decodeRegistryAuth(t, pullOptions.RegistryAuth)
+	assert.Equal(t, "docker-user", authCfg.Username)
+	assert.Equal(t, "docker-token", authCfg.Password)
+	assert.Equal(t, "https://index.docker.io/v1/", authCfg.ServerAddress)
+}
+
+func TestShouldRetryAnonymousPullInternal_UnauthorizedWithAuth(t *testing.T) {
+	err := errors.New(`Error response from daemon: Head "registry-1.docker.io/v2/library/nginx/manifests/latest": unauthorized: incorrect username or password`)
+
+	assert.True(t, shouldRetryAnonymousPullInternal(image.PullOptions{RegistryAuth: "encoded-auth"}, err))
+}
+
+func TestShouldRetryAnonymousPullInternal_SkipsRetryWithoutUnauthorizedOrAuth(t *testing.T) {
+	nonAuthErr := errors.New("Error response from daemon: i/o timeout")
+	unauthorizedErr := errors.New("unauthorized: authentication required")
+
+	assert.False(t, shouldRetryAnonymousPullInternal(image.PullOptions{RegistryAuth: "encoded-auth"}, nonAuthErr))
+	assert.False(t, shouldRetryAnonymousPullInternal(image.PullOptions{}, unauthorizedErr))
 }

--- a/backend/pkg/scheduler/auto_heal_job.go
+++ b/backend/pkg/scheduler/auto_heal_job.go
@@ -213,7 +213,7 @@ func (j *AutoHealJob) parseExcludedContainers(ctx context.Context) map[string]st
 	if raw == "" {
 		return excluded
 	}
-	for _, name := range strings.Split(raw, ",") {
+	for name := range strings.SplitSeq(raw, ",") {
 		trimmed := strings.TrimSpace(name)
 		if trimmed != "" {
 			excluded[trimmed] = struct{}{}

--- a/backend/pkg/scheduler/auto_heal_job_test.go
+++ b/backend/pkg/scheduler/auto_heal_job_test.go
@@ -20,7 +20,7 @@ func TestAutoHeal_CanRestart_UnderLimit(t *testing.T) {
 	require.True(t, job.CanRestartExported("container-1", 5, 30*time.Minute))
 
 	// Record 4 restarts (under limit of 5)
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		job.RecordRestartExported("container-1")
 	}
 
@@ -31,7 +31,7 @@ func TestAutoHeal_CanRestart_AtLimit(t *testing.T) {
 	job := newTestAutoHealJob()
 
 	// Record exactly 5 restarts (at limit)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		job.RecordRestartExported("container-1")
 	}
 
@@ -43,7 +43,7 @@ func TestAutoHeal_CanRestart_WindowExpiry(t *testing.T) {
 
 	// Record 5 restarts 31 minutes ago (outside window)
 	oldTime := time.Now().Add(-31 * time.Minute)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		job.RecordRestartAtExported("container-1", oldTime)
 	}
 
@@ -56,12 +56,12 @@ func TestAutoHeal_CanRestart_MixedTimestamps(t *testing.T) {
 
 	// Record 3 old restarts (outside window)
 	oldTime := time.Now().Add(-31 * time.Minute)
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		job.RecordRestartAtExported("container-1", oldTime)
 	}
 
 	// Record 4 recent restarts (inside window)
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		job.RecordRestartExported("container-1")
 	}
 
@@ -79,7 +79,7 @@ func TestAutoHeal_CanRestart_DifferentContainers(t *testing.T) {
 	job := newTestAutoHealJob()
 
 	// Fill up container-1
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		job.RecordRestartExported("container-1")
 	}
 
@@ -101,7 +101,7 @@ func TestAutoHeal_ResetRestartTracking(t *testing.T) {
 	job := newTestAutoHealJob()
 
 	// Fill up container-1
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		job.RecordRestartExported("container-1")
 	}
 	require.False(t, job.CanRestartExported("container-1", 5, 30*time.Minute))


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1818

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes image pull failures for public images when invalid or expired registry credentials are stored in the database. The fix implements automatic retry with anonymous authentication when authenticated pulls fail with authorization errors.

**Key Changes:**

- Added retry mechanism in `PullImage` that falls back to anonymous pulls when authenticated pulls fail with unauthorized errors
- Implemented validation to skip database credentials with empty/whitespace usernames or tokens
- Improved container update logic to resolve pullable image references from container inspect data when the summary image is an ID
- Updated to use Go 1.26 features (`strings.SplitSeq`, `for range N`)

**Review Notes:**

- The retry logic correctly identifies unauthorized errors through string matching on common error messages
- Empty credential validation prevents sending invalid auth headers to registries
- Image reference resolution now checks multiple sources (inspect config, summary, repo tags) with proper fallback logic
- All changes include comprehensive test coverage
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The changes are well-tested, implement defensive fallback logic for authentication failures, and include proper validation to prevent invalid credentials from being used. The image reference resolution improvements handle edge cases gracefully with appropriate skipping behavior.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/image_service.go | Added retry logic for anonymous pulls when auth fails, and validation to skip empty credentials |
| backend/internal/services/updater_service.go | Improved image reference resolution to handle containers running from image IDs |

</details>


</details>


<sub>Last reviewed commit: 467a8af</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->