### PR TITLE
feat: support direct https setup via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,12 @@ ENVIRONMENT=production
 PORT=3552
 APP_URL=https://your-domain.com
 
+# Optional direct TLS server mode (HTTP/2 over TLS)
+# Leave disabled when running behind a reverse proxy that terminates TLS.
+# TLS_ENABLED=false
+# TLS_CERT_FILE=/path/to/fullchain.pem
+# TLS_KEY_FILE=/path/to/privkey.pem
+
 # User/Group IDs for file permissions (used by Docker)
 PUID=1000
 PGID=1000

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -31,6 +31,9 @@ type Config struct {
 	DatabaseURL   string         `env:"DATABASE_URL" default:"file:data/arcane.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(2500)&_txlock=immediate" options:"file"`
 	Port          string         `env:"PORT" default:"3552"`
 	Listen        string         `env:"LISTEN" default:""`
+	TLSEnabled    bool           `env:"TLS_ENABLED" default:"false"`
+	TLSCertFile   string         `env:"TLS_CERT_FILE" default:""`
+	TLSKeyFile    string         `env:"TLS_KEY_FILE" default:""`
 	Environment   AppEnvironment `env:"ENVIRONMENT" default:"production"`
 	JWTSecret     string         `env:"JWT_SECRET" default:"default-jwt-secret-change-me" options:"file"` //nolint:gosec // configuration field name is part of stable config API
 	EncryptionKey string         `env:"ENCRYPTION_KEY" default:"arcane-dev-key-32-characters!!!" options:"file"`

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -262,6 +262,37 @@ func TestConfig_ListenAddr(t *testing.T) {
 	}
 }
 
+func TestConfig_TLSSettings(t *testing.T) {
+	origTLSEnabled := os.Getenv("TLS_ENABLED")
+	origTLSCertFile := os.Getenv("TLS_CERT_FILE")
+	origTLSKeyFile := os.Getenv("TLS_KEY_FILE")
+	defer restoreEnv("TLS_ENABLED", origTLSEnabled)
+	defer restoreEnv("TLS_CERT_FILE", origTLSCertFile)
+	defer restoreEnv("TLS_KEY_FILE", origTLSKeyFile)
+
+	t.Run("defaults to tls disabled", func(t *testing.T) {
+		unsetEnv(t, "TLS_ENABLED")
+		unsetEnv(t, "TLS_CERT_FILE")
+		unsetEnv(t, "TLS_KEY_FILE")
+
+		cfg := Load()
+		assert.False(t, cfg.TLSEnabled)
+		assert.Equal(t, "", cfg.TLSCertFile)
+		assert.Equal(t, "", cfg.TLSKeyFile)
+	})
+
+	t.Run("loads tls settings from env", func(t *testing.T) {
+		setEnv(t, "TLS_ENABLED", "true")
+		setEnv(t, "TLS_CERT_FILE", "/etc/ssl/certs/fullchain.pem")
+		setEnv(t, "TLS_KEY_FILE", "/etc/ssl/private/privkey.pem")
+
+		cfg := Load()
+		assert.True(t, cfg.TLSEnabled)
+		assert.Equal(t, "/etc/ssl/certs/fullchain.pem", cfg.TLSCertFile)
+		assert.Equal(t, "/etc/ssl/private/privkey.pem", cfg.TLSKeyFile)
+	})
+}
+
 func TestConfig_GetManagerGRPCAddr(t *testing.T) {
 	t.Run("uses manager api url explicit port when present", func(t *testing.T) {
 		cfg := &Config{


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

Added support for direct HTTPS/TLS mode via environment variables (`TLS_ENABLED`, `TLS_CERT_FILE`, `TLS_KEY_FILE`), allowing the backend to serve HTTPS directly without requiring a reverse proxy.

**Key changes:**
- Configuration fields added for TLS enable flag and certificate file paths
- HTTP/2 protocol negotiation properly configured for both TLS and non-TLS modes
- Validation ensures certificate and key files are provided when TLS is enabled
- h2c wrapper correctly applied only when TLS is disabled
- Comprehensive test coverage for new TLS configuration
- Clear documentation in `.env.example` explaining when to use this feature
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no identified issues
- The implementation is clean, well-tested, and follows Go best practices. The TLS setup logic correctly handles HTTP/2 protocol negotiation for both encrypted and unencrypted modes, properly validates required configuration, and includes comprehensive test coverage. The changes are backward compatible (TLS disabled by default) and don't modify existing functionality
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .env.example | Added clear documentation for optional TLS environment variables with helpful comments |
| backend/internal/config/config.go | Added three new TLS configuration fields (`TLSEnabled`, `TLSCertFile`, `TLSKeyFile`) with proper defaults |
| backend/internal/config/config_test.go | Added comprehensive test coverage for TLS configuration loading with proper env cleanup |
| backend/internal/bootstrap/bootstrap.go | Implemented TLS support with proper HTTP/2 protocol negotiation, validation, and h2c handling for non-TLS mode |

</details>


</details>


<sub>Last reviewed commit: e7a3bd9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->