### PR TITLE
fix: vulnerability image filter only shows images on current page

### DIFF
--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"net"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -745,6 +746,56 @@ func (s *VulnerabilityService) ListAllVulnerabilities(ctx context.Context, envID
 	response := pagination.BuildResponseFromFilterResult(filtered, params)
 
 	return filtered.Items, response, nil
+}
+
+// ListAllVulnerabilityImageOptions returns unique image names (or image IDs when name is empty)
+// for vulnerability filtering, optionally constrained by severity.
+func (s *VulnerabilityService) ListAllVulnerabilityImageOptions(ctx context.Context, severityFilter string) ([]string, error) {
+	if s.db == nil {
+		return []string{}, nil
+	}
+
+	query := s.db.WithContext(ctx).
+		Model(&models.VulnerabilityScanRecord{}).
+		Select("id", "image_name").
+		Where("status = ?", models.ScanStatusCompleted).
+		Where("total_count > 0")
+
+	if strings.TrimSpace(severityFilter) != "" {
+		var hasPossibleMatches bool
+		query, hasPossibleMatches = applyListAllVulnerabilityRecordPrefiltersInternal(query, map[string]string{
+			"severity": severityFilter,
+		})
+		if !hasPossibleMatches {
+			return []string{}, nil
+		}
+	}
+
+	var records []models.VulnerabilityScanRecord
+	if err := query.Find(&records).Error; err != nil {
+		return nil, fmt.Errorf("failed to list vulnerability image options: %w", err)
+	}
+
+	seen := make(map[string]struct{}, len(records))
+	options := make([]string, 0, len(records))
+	for _, record := range records {
+		label := strings.TrimSpace(record.ImageName)
+		if label == "" {
+			label = strings.TrimSpace(record.ID)
+		}
+		if label == "" {
+			continue
+		}
+		if _, exists := seen[label]; exists {
+			continue
+		}
+
+		seen[label] = struct{}{}
+		options = append(options, label)
+	}
+
+	sort.Strings(options)
+	return options, nil
 }
 
 func applyListAllVulnerabilityRecordPrefiltersInternal(query *gorm.DB, filters map[string]string) (*gorm.DB, bool) {

--- a/backend/internal/services/vulnerability_service_test.go
+++ b/backend/internal/services/vulnerability_service_test.go
@@ -653,3 +653,52 @@ func TestVulnerabilityService_ListAllVulnerabilities_FiltersIgnoredInline(t *tes
 	require.Equal(t, int64(0), page.TotalItems)
 	require.Equal(t, int64(0), page.GrandTotalItems)
 }
+
+func TestVulnerabilityService_ListAllVulnerabilityImageOptions_SeverityFilter(t *testing.T) {
+	ctx := context.Background()
+	db := setupVulnerabilityScanTestDB(t)
+	svc := &VulnerabilityService{db: db}
+
+	now := time.Now()
+	records := []models.VulnerabilityScanRecord{
+		{ID: "sha256:critical-a", ImageName: "zeta:latest", Status: models.ScanStatusCompleted, ScanTime: now, CriticalCount: 2, TotalCount: 2},
+		{ID: "sha256:high-a", ImageName: "alpha:latest", Status: models.ScanStatusCompleted, ScanTime: now, HighCount: 4, TotalCount: 4},
+		{ID: "sha256:critical-b", ImageName: "", Status: models.ScanStatusCompleted, ScanTime: now, CriticalCount: 1, TotalCount: 1},
+		{ID: "sha256:critical-c", ImageName: "zeta:latest", Status: models.ScanStatusCompleted, ScanTime: now, CriticalCount: 1, TotalCount: 1},
+		{ID: "sha256:failed", ImageName: "failed:latest", Status: models.ScanStatusFailed, ScanTime: now, CriticalCount: 9, TotalCount: 9},
+		{ID: "sha256:zero", ImageName: "zero:latest", Status: models.ScanStatusCompleted, ScanTime: now, CriticalCount: 1, TotalCount: 0},
+	}
+
+	for i := range records {
+		require.NoError(t, db.Create(&records[i]).Error)
+	}
+
+	items, err := svc.ListAllVulnerabilityImageOptions(ctx, "critical")
+	require.NoError(t, err)
+	require.Equal(t, []string{"sha256:critical-b", "zeta:latest"}, items)
+}
+
+func TestVulnerabilityService_ListAllVulnerabilityImageOptions_InvalidSeverityAndNoFilter(t *testing.T) {
+	ctx := context.Background()
+	db := setupVulnerabilityScanTestDB(t)
+	svc := &VulnerabilityService{db: db}
+
+	now := time.Now()
+	records := []models.VulnerabilityScanRecord{
+		{ID: "sha256:one", ImageName: "beta:latest", Status: models.ScanStatusCompleted, ScanTime: now, HighCount: 1, TotalCount: 1},
+		{ID: "sha256:two", ImageName: "", Status: models.ScanStatusCompleted, ScanTime: now, MediumCount: 2, TotalCount: 2},
+		{ID: "sha256:three", ImageName: "alpha:latest", Status: models.ScanStatusCompleted, ScanTime: now, LowCount: 1, TotalCount: 1},
+	}
+
+	for i := range records {
+		require.NoError(t, db.Create(&records[i]).Error)
+	}
+
+	invalid, err := svc.ListAllVulnerabilityImageOptions(ctx, "not-a-severity")
+	require.NoError(t, err)
+	require.Empty(t, invalid)
+
+	all, err := svc.ListAllVulnerabilityImageOptions(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha:latest", "beta:latest", "sha256:two"}, all)
+}

--- a/frontend/src/lib/services/vulnerability-service.ts
+++ b/frontend/src/lib/services/vulnerability-service.ts
@@ -103,6 +103,29 @@ export class VulnerabilityService extends BaseAPIService {
 	}
 
 	/**
+	 * Get available image filter options for environment vulnerabilities.
+	 * This endpoint is independent from rows pagination and currently supports severity-only filtering.
+	 */
+	async getAllVulnerabilityImageOptions(options?: SearchPaginationSortRequest): Promise<string[]> {
+		const envId = await this.resolveEnvironmentId();
+		return this.getAllVulnerabilityImageOptionsForEnvironment(envId, options);
+	}
+
+	async getAllVulnerabilityImageOptionsForEnvironment(
+		environmentId: string,
+		options?: SearchPaginationSortRequest
+	): Promise<string[]> {
+		const severityFilter = options?.filters?.severity;
+		const params: Record<string, string> = {};
+
+		if (severityFilter !== undefined && severityFilter !== null) {
+			params.severity = Array.isArray(severityFilter) ? severityFilter.join(',') : String(severityFilter);
+		}
+
+		return this.handleResponse(this.api.get(`/environments/${environmentId}/vulnerabilities/image-options`, { params }));
+	}
+
+	/**
 	 * Ignore a vulnerability
 	 */
 	async ignoreVulnerability(payload: IgnoreVulnerabilityPayload): Promise<IgnoredVulnerability> {

--- a/frontend/src/routes/(app)/security/security-vulnerability-table.svelte
+++ b/frontend/src/routes/(app)/security/security-vulnerability-table.svelte
@@ -9,7 +9,7 @@
 	import type { VulnerabilityWithImage } from '$lib/types/vulnerability.type';
 	import { ShieldAlertIcon, CodeIcon, CheckIcon, ImagesIcon, EyeOffIcon } from '$lib/icons';
 	import { toast } from 'svelte-sonner';
-	import type { BulkAction } from '$lib/components/arcane-table/arcane-table.types.svelte';
+	import { onMount } from 'svelte';
 
 	const DEFAULT_PAGE_SIZE = 20;
 
@@ -22,6 +22,8 @@
 		vulnerabilities: Paginated<VulnerabilityRow>;
 		requestOptions: SearchPaginationSortRequest;
 	} = $props();
+
+	let imageNameFilterOptions = $state<string[]>([]);
 
 	function getSeverityLabel(severity: string): string {
 		switch (severity) {
@@ -79,6 +81,41 @@
 		].join('-');
 	}
 
+	function resolveSeverityFilter(options?: SearchPaginationSortRequest): string | undefined {
+		const rawSeverity = options?.filters?.severity ?? options?.filters?.vulnSeverity;
+		if (Array.isArray(rawSeverity)) {
+			const values = rawSeverity.map((entry) => String(entry).trim()).filter(Boolean);
+			return values.length ? values.join(',') : undefined;
+		}
+
+		if (rawSeverity === undefined || rawSeverity === null) {
+			return undefined;
+		}
+
+		const value = String(rawSeverity).trim();
+		return value || undefined;
+	}
+
+	function deriveImageOptionsFromRows(rows: VulnerabilityRow[]): string[] {
+		return [...new Set(rows.map((row) => row.imageName || row.imageId).filter(Boolean) as string[])].sort();
+	}
+
+	async function refreshImageNameFilterOptions(options?: SearchPaginationSortRequest): Promise<string[]> {
+		const severity = resolveSeverityFilter(options);
+		const request: SearchPaginationSortRequest = {
+			filters: severity ? { severity } : undefined
+		};
+
+		try {
+			const optionsResponse = await vulnerabilityService.getAllVulnerabilityImageOptions(request);
+			imageNameFilterOptions = optionsResponse;
+			return optionsResponse;
+		} catch (error) {
+			console.error('Failed to refresh vulnerability image filter options:', error);
+			return imageNameFilterOptions;
+		}
+	}
+
 	async function refreshVulnerabilityTable(options: SearchPaginationSortRequest) {
 		const mergedFilters = { ...(options.filters ?? {}) };
 		if (mergedFilters.vulnSeverity) {
@@ -94,7 +131,10 @@
 			filters: Object.keys(mergedFilters).length ? mergedFilters : undefined
 		};
 
-		const response = await vulnerabilityService.getAllVulnerabilities(request);
+		const [response, optionsResponse] = await Promise.all([
+			vulnerabilityService.getAllVulnerabilities(request),
+			refreshImageNameFilterOptions(request)
+		]);
 		const page = request.pagination?.page ?? 1;
 		const limit = request.pagination?.limit ?? DEFAULT_PAGE_SIZE;
 		const offset = (page - 1) * limit;
@@ -106,6 +146,11 @@
 			}))
 		};
 		vulnerabilities = mapped;
+
+		if (optionsResponse.length === 0) {
+			imageNameFilterOptions = deriveImageOptionsFromRows(mapped.data ?? []);
+		}
+
 		return mapped;
 	}
 
@@ -143,9 +188,9 @@
 		{ accessorKey: 'imageName', title: m.common_image(), sortable: true, cell: ImageCell }
 	] satisfies ColumnSpec<VulnerabilityRow>[]);
 
-	const uniqueImageNames = $derived(
-		[...new Set((vulnerabilities.data ?? []).map((r) => r.imageName || r.imageId).filter(Boolean) as string[])].sort()
-	);
+	onMount(() => {
+		void refreshImageNameFilterOptions(requestOptions);
+	});
 
 	const mobileFields = [
 		{ id: 'vulnerabilityId', label: 'CVE', defaultVisible: true },
@@ -271,6 +316,6 @@
 	{mobileFields}
 	persistKey="arcane-security-vuln-table"
 	selectionDisabled
-	imageNameFilterOptions={uniqueImageNames}
+	{imageNameFilterOptions}
 	{rowActions}
 />


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1827

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR successfully addresses the issue where vulnerability image filters only showed images from the current page by adding a new backend endpoint `/environments/{id}/vulnerabilities/image-options` that returns all available image options independent of pagination. The implementation is clean and well-tested.

**Key Changes:**
- Backend: New endpoint and service method to fetch all available image filter options with optional severity filtering
- Frontend: Replaced reactive computed filter derived from current page with API-fetched options, includes error handling and fallback
- Tests: Comprehensive coverage of severity filtering, duplicates, empty names, and edge cases

**Minor Observation:**
The `EnvironmentID` path parameter is accepted but not used in the implementation. Since vulnerability scans are stored globally (not per-environment), this appears intentional to maintain API consistency, though the parameter remains unused.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-tested, and follows established patterns. Only minor style concern is the unused EnvironmentID parameter. No logical errors or security issues detected.
- No files require special attention - all changes follow best practices and include appropriate tests
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/huma/handlers/vulnerabilities.go | Added new endpoint for fetching image filter options. The `EnvironmentID` path parameter is defined but not used in the implementation, which may cause confusion but doesn't affect functionality. |
| backend/internal/services/vulnerability_service.go | Implemented `ListAllVulnerabilityImageOptions` with proper error handling, deduplication, and sorting. Follows Go best practices with pre-allocated slices and clear logic. |
| frontend/src/routes/(app)/security/security-vulnerability-table.svelte | Replaced reactive computed filter options with API-fetched options. Includes proper error handling, parallel fetching, and fallback to current-page derivation when API returns empty. |

</details>


</details>


<sub>Last reviewed commit: edfa38c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->