### PR TITLE
fix: project logs not streaming

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -1956,7 +1956,7 @@ func (s *ProjectService) StreamProjectLogs(ctx context.Context, projectID string
 	// Writer goroutine: compose logs -> pipe
 	go func() {
 		// since/timestamps not currently supported by ComposeLogs helper; follow/tail are used.
-		err := projects.ComposeLogs(ctx, proj.Name, pw, follow, tail)
+		err := projects.ComposeLogs(ctx, normalizeComposeProjectName(proj.Name), pw, follow, tail)
 		_ = pw.Close()
 		done <- err
 	}()

--- a/frontend/src/lib/components/logs/log-viewer.svelte
+++ b/frontend/src/lib/components/logs/log-viewer.svelte
@@ -145,6 +145,7 @@
 	}
 
 	const humanType = $derived(type === 'project' ? m.project() : m.container());
+	const selectedTargetId = $derived(type === 'project' ? projectId : containerId);
 
 	function buildWebSocketEndpoint(path: string): string {
 		const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
@@ -152,8 +153,7 @@
 	}
 
 	async function buildLogWsEndpoint(): Promise<string> {
-		const currentEnv = environmentStore.selected;
-		const envId = currentEnv?.id || 'local';
+		const envId = await environmentStore.getCurrentEnvironmentId();
 		const basePath =
 			type === 'project'
 				? `/api/environments/${envId}/ws/projects/${projectId}/logs`
@@ -432,7 +432,7 @@
 	>
 		{#if logs.length === 0}
 			<div class="p-4 text-center text-gray-500">
-				{#if !containerId}
+				{#if !selectedTargetId}
 					{m.log_viewer_no_selection({ type: humanType })}
 				{:else if !isStreaming}
 					{m.log_viewer_no_logs_available()}

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -584,6 +584,13 @@ test.describe("Project Detail Page", () => {
       await expect(page.getByText(/Real-time project logs/i)).toBeVisible();
       await expect(page.getByRole("button", { name: /^(Start|Stop)$/i })).toBeVisible();
       await expect(page.getByRole("button", { name: "Clear", exact: true })).toBeVisible();
+
+      const startButton = page.getByRole("button", { name: "Start", exact: true });
+      if ((await startButton.count()) > 0) {
+        await startButton.click();
+      }
+
+      await expect(page.getByText(/No project selected/i)).not.toBeVisible();
     } else {
       await expect(logsTab).toBeEnabled();
     }


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1906
 
## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes project logs not streaming by ensuring consistent project name normalization throughout the log streaming pipeline. The root cause was that `ComposeLogs` was receiving the raw project name instead of the normalized name used by all other Docker Compose operations.

**Key changes:**
- Fixed project name normalization in `StreamProjectLogs` to use `normalizeComposeProjectName()` consistently
- Added proper error handling in the WebSocket handler to catch and report log streaming failures to users
- Improved frontend environment ID retrieval using the async `getCurrentEnvironmentId()` method
- Enhanced test coverage to verify log streaming functionality works correctly
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The fix is straightforward and addresses a clear bug where project names weren't normalized consistently. The changes follow existing patterns in the codebase, add proper error handling, and include test coverage. All modifications are well-scoped and non-breaking.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/project_service.go | Fixed project name normalization in log streaming to match other operations |
| backend/internal/api/ws_handler.go | Added proper error handling and user-facing error messages for log streaming failures |
| frontend/src/lib/components/logs/log-viewer.svelte | Improved environment ID retrieval and unified target selection logic for both projects and containers |
| tests/spec/project.spec.ts | Added test coverage to verify log streaming works correctly after starting |

</details>


</details>


<sub>Last reviewed commit: 75ca980</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->