### PR TITLE
fix: edge agent status being incorrectly reported

### DIFF
--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -132,6 +132,12 @@ func initializeStartupState(appCtx context.Context, cfg *config.Config, appServi
 		slog.WarnContext(appCtx, "Failed to ensure local environment", "error", err)
 	}
 
+	if !cfg.AgentMode {
+		if err := appServices.Environment.ReconcileEdgeStatusesOnStartup(appCtx); err != nil {
+			slog.WarnContext(appCtx, "Failed to reconcile edge environment statuses on startup", "error", err)
+		}
+	}
+
 	utils.TestDockerConnection(appCtx, func(ctx context.Context) error {
 		dockerClient, err := dockerClientService.GetClient()
 		if err != nil {

--- a/backend/internal/bootstrap/edge_bootstrap.go
+++ b/backend/internal/bootstrap/edge_bootstrap.go
@@ -38,25 +38,22 @@ func registerEdgeTunnelRoutes(
 
 	// Status callback to update environment status when agent connects/disconnects
 	statusCallback := func(ctx context.Context, envID string, connected bool) {
-		var status string
-		if connected {
-			status = string(models.EnvironmentStatusOnline)
-			// Update heartbeat when connecting
-			if err := appServices.Environment.UpdateEnvironmentHeartbeat(ctx, envID); err != nil {
-				slog.WarnContext(ctx, "Failed to update heartbeat on edge connect", "environment_id", envID, "error", err)
-			}
-		} else {
-			status = string(models.EnvironmentStatusOffline)
+		envName := envID
+		env, getErr := appServices.Environment.GetEnvironmentByID(ctx, envID)
+		if getErr != nil {
+			slog.WarnContext(ctx, "Failed to load environment before edge status update", "environment_id", envID, "error", getErr)
+		} else if env != nil && env.Name != "" {
+			envName = env.Name
 		}
 
-		updates := map[string]any{
-			"status": status,
-		}
-		_, err := appServices.Environment.UpdateEnvironment(ctx, envID, updates, nil, nil)
-		if err != nil {
+		if err := appServices.Environment.UpdateEnvironmentConnectionState(ctx, envID, connected); err != nil {
 			slog.WarnContext(ctx, "Failed to update environment status on edge connect/disconnect", "environment_id", envID, "connected", connected, "error", err)
 		} else {
-			slog.InfoContext(ctx, "Updated environment status", "environment_id", envID, "status", status)
+			slog.InfoContext(ctx, "Updated edge environment connection state", "environment_id", envID, "connected", connected)
+		}
+
+		if err := createEdgeConnectionEvent(ctx, appServices.Event, envID, envName, connected); err != nil {
+			slog.WarnContext(ctx, "Failed to create edge connection event", "environment_id", envID, "connected", connected, "error", err)
 		}
 	}
 
@@ -109,4 +106,39 @@ func optionalStringPtr(value string) *string {
 		return nil
 	}
 	return &value
+}
+
+func createEdgeConnectionEvent(ctx context.Context, eventService *services.EventService, envID, envName string, connected bool) error {
+	if eventService == nil {
+		return nil
+	}
+
+	eventType := models.EventTypeEnvironmentDisconnect
+	title := "Edge Agent Disconnected"
+	description := fmt.Sprintf("Edge agent for environment '%s' disconnected", envName)
+	severity := models.EventSeverityWarning
+
+	if connected {
+		eventType = models.EventTypeEnvironmentConnect
+		title = "Edge Agent Connected"
+		description = fmt.Sprintf("Edge agent for environment '%s' connected", envName)
+		severity = models.EventSeveritySuccess
+	}
+
+	resourceType := "environment"
+	_, err := eventService.CreateEvent(ctx, services.CreateEventRequest{
+		Type:          eventType,
+		Severity:      severity,
+		Title:         title,
+		Description:   description,
+		ResourceType:  &resourceType,
+		ResourceID:    &envID,
+		ResourceName:  &envName,
+		EnvironmentID: &envID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create edge lifecycle event: %w", err)
+	}
+
+	return nil
 }

--- a/backend/internal/huma/handlers/environments_test.go
+++ b/backend/internal/huma/handlers/environments_test.go
@@ -1,0 +1,103 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/edge"
+	envtypes "github.com/getarcaneapp/arcane/types/environment"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvironmentHandlerApplyEdgeRuntimeState(t *testing.T) {
+	t.Run("leaves non-edge environments unchanged", func(t *testing.T) {
+		handler := &EnvironmentHandler{}
+		env := envtypes.Environment{
+			ID:     "0",
+			Status: string(models.EnvironmentStatusOnline),
+			IsEdge: false,
+		}
+
+		handler.applyEdgeRuntimeState(&env)
+
+		assert.Equal(t, string(models.EnvironmentStatusOnline), env.Status)
+		assert.Nil(t, env.EdgeTransport)
+		assert.Nil(t, env.Connected)
+		assert.Nil(t, env.ConnectedAt)
+		assert.Nil(t, env.LastHeartbeat)
+	})
+
+	t.Run("marks stale edge status offline when no live tunnel exists", func(t *testing.T) {
+		handler := &EnvironmentHandler{}
+		envID := "env-edge-offline"
+		edge.GetRegistry().Unregister(envID)
+		t.Cleanup(func() { edge.GetRegistry().Unregister(envID) })
+
+		env := envtypes.Environment{
+			ID:     envID,
+			Status: string(models.EnvironmentStatusOnline),
+			IsEdge: true,
+		}
+
+		handler.applyEdgeRuntimeState(&env)
+
+		assert.Equal(t, string(models.EnvironmentStatusOffline), env.Status)
+		assert.Nil(t, env.EdgeTransport)
+		if assert.NotNil(t, env.Connected) {
+			assert.False(t, *env.Connected)
+		}
+		assert.Nil(t, env.ConnectedAt)
+		assert.Nil(t, env.LastHeartbeat)
+	})
+
+	t.Run("preserves pending edge environments until they connect", func(t *testing.T) {
+		handler := &EnvironmentHandler{}
+		envID := "env-edge-pending"
+		edge.GetRegistry().Unregister(envID)
+		t.Cleanup(func() { edge.GetRegistry().Unregister(envID) })
+
+		env := envtypes.Environment{
+			ID:     envID,
+			Status: string(models.EnvironmentStatusPending),
+			IsEdge: true,
+		}
+
+		handler.applyEdgeRuntimeState(&env)
+
+		assert.Equal(t, string(models.EnvironmentStatusPending), env.Status)
+		assert.Nil(t, env.EdgeTransport)
+		if assert.NotNil(t, env.Connected) {
+			assert.False(t, *env.Connected)
+		}
+		assert.Nil(t, env.ConnectedAt)
+		assert.Nil(t, env.LastHeartbeat)
+	})
+
+	t.Run("reports live tunnel status as online", func(t *testing.T) {
+		handler := &EnvironmentHandler{}
+		envID := "env-edge-live"
+		edge.GetRegistry().Unregister(envID)
+		t.Cleanup(func() { edge.GetRegistry().Unregister(envID) })
+
+		tunnel := edge.NewAgentTunnelWithConn(envID, edge.NewGRPCManagerTunnelConn(nil))
+		edge.GetRegistry().Register(envID, tunnel)
+
+		env := envtypes.Environment{
+			ID:     envID,
+			Status: string(models.EnvironmentStatusOffline),
+			IsEdge: true,
+		}
+
+		handler.applyEdgeRuntimeState(&env)
+
+		assert.Equal(t, string(models.EnvironmentStatusOnline), env.Status)
+		if assert.NotNil(t, env.EdgeTransport) {
+			assert.Equal(t, edge.EdgeTransportGRPC, *env.EdgeTransport)
+		}
+		if assert.NotNil(t, env.Connected) {
+			assert.True(t, *env.Connected)
+		}
+		assert.NotNil(t, env.ConnectedAt)
+		assert.NotNil(t, env.LastHeartbeat)
+	})
+}

--- a/backend/internal/middleware/environment_middleware_test.go
+++ b/backend/internal/middleware/environment_middleware_test.go
@@ -1,0 +1,106 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/edge"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestEnvironmentMiddleware() *EnvironmentMiddleware {
+	return &EnvironmentMiddleware{
+		localID:   "0",
+		paramName: "id",
+		resolver: func(ctx context.Context, id string) (string, *string, bool, error) {
+			_ = ctx
+			return "edge://oracle-1", nil, true, nil
+		},
+		authValidator: func(ctx context.Context, c *gin.Context) bool {
+			_ = ctx
+			_ = c
+			return true
+		},
+		httpClient: &http.Client{Timeout: proxyTimeout},
+		registry:   edge.NewTunnelRegistry(),
+	}
+}
+
+func TestEnvironmentMiddleware_ReturnsBadGatewayForEdgeResourcesWithoutTunnel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	middleware := newTestEnvironmentMiddleware()
+	router := gin.New()
+	api := router.Group("/api")
+	api.Use(middleware.Handle)
+
+	localHandlerHit := false
+	api.GET("/environments/:id/containers", func(c *gin.Context) {
+		localHandlerHit = true
+		c.JSON(http.StatusOK, gin.H{"success": true})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/environments/env-edge/containers", nil)
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusBadGateway, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "Edge agent is not connected")
+	assert.False(t, localHandlerHit)
+}
+
+func TestEnvironmentMiddleware_KeepsEdgeManagementEndpointsLocal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	middleware := newTestEnvironmentMiddleware()
+	router := gin.New()
+	api := router.Group("/api")
+	api.Use(middleware.Handle)
+
+	localHandlerHit := false
+	api.GET("/environments/:id/settings", func(c *gin.Context) {
+		localHandlerHit = true
+		c.JSON(http.StatusOK, gin.H{"success": true})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/environments/env-edge/settings", nil)
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "\"success\":true")
+	assert.True(t, localHandlerHit)
+}
+
+func TestEnvironmentMiddleware_ProxyWebSocketRejectsEdgeTargetsWithoutTunnel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	middleware := newTestEnvironmentMiddleware()
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/environments/env-edge/ws/system/stats", nil)
+
+	middleware.proxyWebSocket(c, "edge://oracle-1/api/environments/0/ws/system/stats", nil, "env-edge")
+
+	assert.Equal(t, http.StatusBadGateway, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "Edge agent is not connected")
+}
+
+func TestEnvironmentMiddleware_ProxyHTTPRejectsEdgeTargetsWithoutTunnel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	middleware := newTestEnvironmentMiddleware()
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/environments/env-edge/containers", nil)
+
+	middleware.proxyHTTP(c, "edge://oracle-1/api/environments/0/containers", nil)
+
+	assert.Equal(t, http.StatusBadGateway, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "Edge agent is not connected")
+}

--- a/backend/internal/models/event.go
+++ b/backend/internal/models/event.go
@@ -72,6 +72,8 @@ const (
 	EventTypeSystemUpgrade    EventType = "system.upgrade"
 
 	EventTypeEnvironmentCreate            EventType = "environment.create"
+	EventTypeEnvironmentConnect           EventType = "environment.connect"
+	EventTypeEnvironmentDisconnect        EventType = "environment.disconnect"
 	EventTypeEnvironmentUpdate            EventType = "environment.update"
 	EventTypeEnvironmentDelete            EventType = "environment.delete"
 	EventTypeEnvironmentApiKeyRegenerated EventType = "environment.api_key.regenerated"

--- a/cli/pkg/root.go
+++ b/cli/pkg/root.go
@@ -300,7 +300,7 @@ func renderCommandHelp(cmd *cobra.Command) {
 	examples := strings.TrimSpace(cmd.Example)
 	if examples != "" {
 		lipgloss.Println(helpSectionStyle.Render("Examples"))
-		for _, line := range strings.Split(examples, "\n") {
+		for line := range strings.SplitSeq(examples, "\n") {
 			trimmed := strings.TrimSpace(line)
 			if trimmed == "" {
 				lipgloss.Println()

--- a/frontend/src/lib/types/environment.type.ts
+++ b/frontend/src/lib/types/environment.type.ts
@@ -8,6 +8,9 @@ export type Environment = {
 	enabled: boolean;
 	isEdge: boolean;
 	edgeTransport?: 'grpc' | 'websocket';
+	connected?: boolean;
+	connectedAt?: string;
+	lastHeartbeat?: string;
 	lastSeen?: string;
 	apiKey?: string;
 };

--- a/frontend/src/lib/utils/environment-status.ts
+++ b/frontend/src/lib/utils/environment-status.ts
@@ -1,0 +1,43 @@
+import type { Environment, EnvironmentStatus } from '$lib/types/environment.type';
+
+type RuntimeEnvironmentState = Pick<Environment, 'isEdge' | 'connected' | 'status'>;
+
+export function resolveEnvironmentStatus(
+	environment: RuntimeEnvironmentState,
+	overrideStatus?: EnvironmentStatus | null
+): EnvironmentStatus {
+	const status = overrideStatus ?? environment.status;
+
+	if (!environment.isEdge) {
+		return status;
+	}
+
+	if (status === 'pending') {
+		return 'pending';
+	}
+
+	if (environment.connected === true) {
+		return 'online';
+	}
+
+	if (environment.connected === false) {
+		return 'offline';
+	}
+
+	return status;
+}
+
+export function isEnvironmentOnline(environment: RuntimeEnvironmentState, overrideStatus?: EnvironmentStatus | null): boolean {
+	return resolveEnvironmentStatus(environment, overrideStatus) === 'online';
+}
+
+export function getEnvironmentStatusVariant(status: EnvironmentStatus): 'green' | 'amber' | 'red' {
+	switch (status) {
+		case 'online':
+			return 'green';
+		case 'pending':
+			return 'amber';
+		default:
+			return 'red';
+	}
+}

--- a/tests/spec/edge-agent.spec.ts
+++ b/tests/spec/edge-agent.spec.ts
@@ -121,7 +121,7 @@ test.describe("Edge Agent Environment", () => {
         has: page.getByRole("button", { name: environmentName, exact: true }),
       });
       await expect(environmentRow.getByText("edge://edge-agent-").first()).toBeVisible();
-      await expect(environmentRow.getByText("gRPC", { exact: true })).toBeVisible();
+      await expect(environmentRow.getByText("Edge", { exact: true })).toBeVisible();
 
       await page.getByRole("button", { name: environmentName, exact: true }).click();
       if (createdEnvironmentId) {
@@ -129,7 +129,8 @@ test.describe("Edge Agent Environment", () => {
       }
 
       await expect(page.locator("#api-url")).toHaveValue(/edge:\/\/edge-agent-/);
-      await expect(page.getByText("gRPC", { exact: true }).first()).toBeVisible();
+      await expect(page.getByText("Edge", { exact: true }).first()).toBeVisible();
+      await expect(page.getByText("Tunnel", { exact: true })).toBeVisible();
     } finally {
       if (createdEnvironmentId) {
         await page.request.delete(`/api/environments/${createdEnvironmentId}`);

--- a/tests/spec/settings-notifications.spec.ts
+++ b/tests/spec/settings-notifications.spec.ts
@@ -1,6 +1,13 @@
 import { test, expect, type Page } from '@playwright/test';
 
 test.describe('Notification settings', () => {
+  const openProviderTab = async (page: Page, name: string) => {
+    const tab = page.getByRole('tab', { name });
+    await tab.scrollIntoViewIfNeeded();
+    await expect(tab).toBeVisible();
+    await tab.click();
+  };
+
   // Shared setup for all notification tests
   const setupNotificationTest = async (page: Page, provider: string) => {
     const observedErrors: string[] = [];
@@ -84,7 +91,7 @@ test.describe('Notification settings', () => {
   test('should allow testing discord notifications', async ({ page }) => {
     const { getErrorCheck, wasTestEndpointCalled } = await setupNotificationTest(page, 'discord');
 
-    await page.getByRole('tab', { name: 'Discord' }).click();
+    await openProviderTab(page, 'Discord');
     await page.locator('#discord-enabled').click();
 
     // Discord split fields
@@ -106,7 +113,7 @@ test.describe('Notification settings', () => {
   test('should allow testing slack notifications', async ({ page }) => {
     const { getErrorCheck, wasTestEndpointCalled } = await setupNotificationTest(page, 'slack');
 
-    await page.getByRole('tab', { name: 'Slack' }).click();
+    await openProviderTab(page, 'Slack');
     await page.locator('#slack-enabled').click();
 
     // Slack OAuth token (xoxb- or xoxp- format)
@@ -127,7 +134,7 @@ test.describe('Notification settings', () => {
   test('should allow testing telegram notifications', async ({ page }) => {
     const { getErrorCheck, wasTestEndpointCalled } = await setupNotificationTest(page, 'telegram');
 
-    await page.getByRole('tab', { name: 'Telegram' }).click();
+    await openProviderTab(page, 'Telegram');
     await page.locator('#telegram-enabled').click();
 
     // Telegram fields (placeholders are hardcoded in component)
@@ -149,7 +156,7 @@ test.describe('Notification settings', () => {
   test('should allow testing generic webhook notifications', async ({ page }) => {
     const { getErrorCheck, wasTestEndpointCalled } = await setupNotificationTest(page, 'generic');
 
-    await page.getByRole('tab', { name: 'Generic' }).click();
+    await openProviderTab(page, 'Generic');
     await page.locator('#generic-enabled').click();
 
     await page.getByPlaceholder('https://example.com/webhook').fill('https://example.com/webhook');
@@ -169,7 +176,7 @@ test.describe('Notification settings', () => {
   test('should allow testing signal notifications', async ({ page }) => {
     const { getErrorCheck, wasTestEndpointCalled } = await setupNotificationTest(page, 'signal');
 
-    await page.getByRole('tab', { name: 'Signal' }).click();
+    await openProviderTab(page, 'Signal');
     await page.locator('#signal-enabled').click();
 
     await page.getByPlaceholder('localhost').fill('signal-api.example.com');
@@ -192,7 +199,7 @@ test.describe('Notification settings', () => {
   test('should allow testing ntfy notifications', async ({ page }) => {
     const { getErrorCheck, wasTestEndpointCalled } = await setupNotificationTest(page, 'ntfy');
 
-    await page.getByRole('tab', { name: 'Ntfy' }).click();
+    await openProviderTab(page, 'Ntfy');
     await page.locator('#ntfy-enabled').click();
 
     await page.getByPlaceholder('ntfy.sh').fill('ntfy.sh');

--- a/types/environment/environment.go
+++ b/types/environment/environment.go
@@ -1,5 +1,7 @@
 package environment
 
+import "time"
+
 type Create struct {
 	// ApiUrl is the URL of the environment API.
 	//
@@ -126,6 +128,22 @@ type Environment struct {
 	//
 	// Required: false
 	EdgeTransport *string `json:"edgeTransport,omitempty"`
+
+	// Connected reports whether an edge environment currently has a live tunnel.
+	//
+	// Required: false
+	Connected *bool `json:"connected,omitempty"`
+
+	// ConnectedAt is when the current edge tunnel connection was established.
+	//
+	// Required: false
+	ConnectedAt *time.Time `json:"connectedAt,omitempty"`
+
+	// LastHeartbeat is the timestamp of the most recent heartbeat received
+	// from the current edge tunnel connection.
+	//
+	// Required: false
+	LastHeartbeat *time.Time `json:"lastHeartbeat,omitempty"`
 
 	// ApiKey is returned only when creating or regenerating
 	//


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes edge agent status reporting by separating runtime tunnel connection state from persisted database status. Edge tunnels are ephemeral process-local connections that don't persist across manager restarts, so the previous approach of storing status in the database led to stale "online" statuses after restarts.

**Backend changes:**
- Added `ReconcileEdgeStatusesOnStartup` to reset stale edge environment statuses to offline when manager starts (except pending environments)
- Added `UpdateEnvironmentConnectionState` to update status based on tunnel connect/disconnect events without creating generic update events
- Enhanced `applyEdgeRuntimeState` to populate runtime metadata (`connected`, `connectedAt`, `lastHeartbeat`, `edgeTransport`) from live tunnel registry
- Refactored edge status callback to use service methods instead of direct database updates
- Added `GetTunnelRuntimeState` to retrieve live tunnel metadata

**Frontend changes:**
- Added `resolveEnvironmentStatus` utility that returns runtime status based on `connected` field for edge environments
- Updated all UI components to use resolved status instead of persisted database status
- Added tunnel connection metadata display (connected since, last heartbeat) in details view
- Fixed status override logic to only apply to non-edge custom URL tests

**Test coverage:**
- Comprehensive tests added for new connection state management methods
- Tests verify reconciliation behavior for different environment states
- Tests cover runtime state retrieval for active/closed tunnels
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The changes are well-architected, properly tested, and address a clear architectural mismatch (ephemeral runtime state vs persistent database state). All modifications follow Go and TypeScript best practices, include comprehensive test coverage, and maintain backward compatibility. The separation of concerns between runtime tunnel state and persisted configuration is the correct solution.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/bootstrap/edge_bootstrap.go | Refactored status callback to use service method instead of direct database updates, improved logging |
| backend/internal/services/environment_service.go | Added `UpdateEnvironmentConnectionState` and `ReconcileEdgeStatusesOnStartup` methods to properly manage edge tunnel connection states |
| backend/internal/huma/handlers/environments.go | Enhanced `applyEdgeRuntimeState` to populate runtime tunnel metadata (`connected`, `connectedAt`, `lastHeartbeat`) and override status based on actual tunnel state |
| backend/pkg/libarcane/edge/transport.go | Added `GetTunnelRuntimeState` function to retrieve live tunnel metadata including transport type and timestamps |
| frontend/src/lib/utils/environment-status.ts | Added utility to resolve edge environment status based on runtime `connected` field rather than persisted database status |
| frontend/src/routes/(app)/environments/[id]/+page.svelte | Refactored to use `resolveEnvironmentStatus` for edge environments, properly handles status overrides only for non-edge custom URL tests |

</details>


</details>


<sub>Last reviewed commit: 0e6a984</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->