### PR TITLE
fix: disable cors on edge agent requests

### DIFF
--- a/backend/pkg/libarcane/edge/proxy_headers_test.go
+++ b/backend/pkg/libarcane/edge/proxy_headers_test.go
@@ -1,0 +1,358 @@
+package edge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/getarcaneapp/arcane/backend/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsBrowserSecurityHeader(t *testing.T) {
+	browserHeaders := []string{
+		"Origin",
+		"Referer",
+		"Cookie",
+		"Access-Control-Request-Method",
+		"Access-Control-Request-Headers",
+		"Sec-Fetch-Mode",
+		"Sec-Fetch-Site",
+		"Sec-Fetch-Dest",
+	}
+
+	for _, h := range browserHeaders {
+		assert.True(t, isBrowserSecurityHeader(h), "expected %q to be a browser security header", h)
+	}
+
+	nonBrowserHeaders := []string{
+		"Content-Type",
+		"Authorization",
+		"X-Custom-Header",
+		"X-Arcane-Agent-Token",
+		"X-API-Key",
+		"Accept",
+	}
+
+	for _, h := range nonBrowserHeaders {
+		assert.False(t, isBrowserSecurityHeader(h), "expected %q to NOT be a browser security header", h)
+	}
+}
+
+func TestProxyHTTPRequest_StripsBrowserHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Track what headers the agent receives
+	var receivedHeaders map[string]string
+
+	server, tunnel := setupMockAgentServer(t, func(msg *TunnelMessage) *TunnelMessage {
+		receivedHeaders = msg.Headers
+		return &TunnelMessage{
+			ID:      msg.ID,
+			Type:    MessageTypeResponse,
+			Status:  http.StatusOK,
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Body:    []byte(`{"ok":true}`),
+		}
+	})
+	defer server.Close()
+	defer func() { _ = tunnel.Close() }()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/test", bytes.NewBufferString(`{"name":"test"}`))
+
+	// Set headers that browsers add
+	c.Request.Header.Set("Origin", "http://192.168.1.42:30258")
+	c.Request.Header.Set("Referer", "http://192.168.1.42:30258/projects/new")
+	c.Request.Header.Set("Cookie", "token=some-jwt-token")
+	c.Request.Header.Set("Sec-Fetch-Mode", "cors")
+	c.Request.Header.Set("Sec-Fetch-Site", "same-origin")
+	c.Request.Header.Set("Sec-Fetch-Dest", "empty")
+	c.Request.Header.Set("Access-Control-Request-Method", "POST")
+	c.Request.Header.Set("Access-Control-Request-Headers", "Content-Type")
+
+	// Set headers that SHOULD be forwarded
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("X-Arcane-Agent-Token", "agent-tok-123")
+	c.Request.Header.Set("X-API-Key", "agent-tok-123")
+	c.Request.Header.Set("Authorization", "Bearer jwt-token")
+
+	ProxyHTTPRequest(c, tunnel, "/api/environments/0/projects")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Browser security headers should NOT be present on the agent side
+	assert.Empty(t, receivedHeaders["Origin"], "Origin header should be stripped")
+	assert.Empty(t, receivedHeaders["Referer"], "Referer header should be stripped")
+	assert.Empty(t, receivedHeaders["Cookie"], "Cookie header should be stripped")
+	assert.Empty(t, receivedHeaders["Sec-Fetch-Mode"], "Sec-Fetch-Mode header should be stripped")
+	assert.Empty(t, receivedHeaders["Sec-Fetch-Site"], "Sec-Fetch-Site header should be stripped")
+	assert.Empty(t, receivedHeaders["Sec-Fetch-Dest"], "Sec-Fetch-Dest header should be stripped")
+	assert.Empty(t, receivedHeaders["Access-Control-Request-Method"], "Access-Control-Request-Method should be stripped")
+	assert.Empty(t, receivedHeaders["Access-Control-Request-Headers"], "Access-Control-Request-Headers should be stripped")
+
+	// Important headers SHOULD still be forwarded
+	assert.Equal(t, "application/json", receivedHeaders["Content-Type"])
+	assert.Equal(t, "agent-tok-123", receivedHeaders["X-Arcane-Agent-Token"])
+	assert.Equal(t, "agent-tok-123", receivedHeaders["X-Api-Key"])
+	assert.Equal(t, "Bearer jwt-token", receivedHeaders["Authorization"])
+}
+
+func TestProxyHTTPRequest_ForwardsBodyCorrectly(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var receivedBody []byte
+	var receivedMethod string
+
+	server, tunnel := setupMockAgentServer(t, func(msg *TunnelMessage) *TunnelMessage {
+		receivedBody = msg.Body
+		receivedMethod = msg.Method
+		return &TunnelMessage{
+			ID:      msg.ID,
+			Type:    MessageTypeResponse,
+			Status:  http.StatusCreated,
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Body:    []byte(`{"id":"proj-1","name":"test"}`),
+		}
+	})
+	defer server.Close()
+	defer func() { _ = tunnel.Close() }()
+
+	requestBody := `{"name":"My Project"}`
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/environments/abc/projects", bytes.NewBufferString(requestBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("X-Arcane-Agent-Token", "tok")
+
+	ProxyHTTPRequest(c, tunnel, "/api/environments/0/projects")
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, http.MethodPost, receivedMethod)
+	assert.Equal(t, requestBody, string(receivedBody), "Request body should be forwarded intact through the tunnel")
+}
+
+func TestHandleRequest_SetsHostField(t *testing.T) {
+	localHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify Host is properly set from the tunneled headers
+		assert.Equal(t, "my-agent-host:3552", r.Host, "Host field should be set from tunnel message headers")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	client := NewTunnelClient(&config.Config{}, localHandler)
+	conn := &capturingTunnelConnForHandleRequest{}
+	client.conn = conn
+
+	client.handleRequest(context.Background(), &TunnelMessage{
+		ID:     "req-host-1",
+		Type:   MessageTypeRequest,
+		Method: http.MethodGet,
+		Path:   "/api/test",
+		Headers: map[string]string{
+			"Host":                 "my-agent-host:3552",
+			"X-Arcane-Agent-Token": "tok-123",
+			"Content-Type":         "application/json",
+		},
+	})
+
+	require.Len(t, conn.sent, 1)
+	assert.Equal(t, http.StatusOK, conn.sent[0].Status)
+}
+
+func TestHandleRequest_ForwardsBody(t *testing.T) {
+	requestBody := `{"name":"My Project"}`
+	var receivedBody string
+
+	localHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		receivedBody = string(body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"p1"}`))
+	})
+
+	client := NewTunnelClient(&config.Config{}, localHandler)
+	conn := &capturingTunnelConnForHandleRequest{}
+	client.conn = conn
+
+	client.handleRequest(context.Background(), &TunnelMessage{
+		ID:     "req-body-1",
+		Type:   MessageTypeRequest,
+		Method: http.MethodPost,
+		Path:   "/api/environments/0/projects",
+		Headers: map[string]string{
+			"Content-Type":         "application/json",
+			"X-Arcane-Agent-Token": "tok-123",
+		},
+		Body: []byte(requestBody),
+	})
+
+	require.Len(t, conn.sent, 1)
+	assert.Equal(t, http.StatusCreated, conn.sent[0].Status)
+	assert.Equal(t, requestBody, receivedBody, "Request body should be forwarded to the local handler")
+}
+
+func TestHandleRequest_NoBrowserHeadersInTunnelMessage(t *testing.T) {
+	// Verify that if somehow browser headers leaked into a tunnel message,
+	// they are still forwarded as-is (stripping happens on the proxy side, not the client side).
+	// This test documents that the client sets all received headers.
+	var receivedOrigin string
+
+	localHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedOrigin = r.Header.Get("Origin")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	client := NewTunnelClient(&config.Config{}, localHandler)
+	conn := &capturingTunnelConnForHandleRequest{}
+	client.conn = conn
+
+	// Simulate an old manager that doesn't strip Origin
+	client.handleRequest(context.Background(), &TunnelMessage{
+		ID:     "req-origin-1",
+		Type:   MessageTypeRequest,
+		Method: http.MethodPost,
+		Path:   "/test",
+		Headers: map[string]string{
+			"Origin": "http://bad-origin:1234",
+		},
+	})
+
+	// The client doesn't strip - it passes whatever it gets to the handler
+	assert.Equal(t, "http://bad-origin:1234", receivedOrigin,
+		"Client should forward all headers; stripping is the proxy's responsibility")
+}
+
+func TestProxyHTTPRequest_EndToEnd_BrowserOriginStripped(t *testing.T) {
+	// Full end-to-end test: browser sends POST with Origin header via edge tunnel.
+	// The agent should NOT receive the Origin header.
+	gin.SetMode(gin.TestMode)
+
+	// This handler simulates what the agent's Gin handler would do.
+	// In a real scenario, if Origin is present and doesn't match allowed origins,
+	// gin-contrib/cors would return 403 before this handler runs.
+	agentHandlerCalled := false
+	agentHandler := func(msg *TunnelMessage) *TunnelMessage {
+		agentHandlerCalled = true
+		// If Origin is present, that would cause a 403 in real life
+		if msg.Headers["Origin"] != "" {
+			return &TunnelMessage{
+				ID:     msg.ID,
+				Type:   MessageTypeResponse,
+				Status: http.StatusForbidden,
+				Body:   []byte("Origin header should have been stripped"),
+			}
+		}
+		return &TunnelMessage{
+			ID:      msg.ID,
+			Type:    MessageTypeResponse,
+			Status:  http.StatusCreated,
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Body:    []byte(`{"id":"project-1"}`),
+		}
+	}
+
+	server, tunnel := setupMockAgentServer(t, agentHandler)
+	defer server.Close()
+	defer func() { _ = tunnel.Close() }()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	body := `{"name":"New Project"}`
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/environments/env-123/projects", bytes.NewBufferString(body))
+	c.Request.Header.Set("Origin", "http://192.168.1.42:30258")
+	c.Request.Header.Set("Referer", "http://192.168.1.42:30258/projects/new")
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("X-Arcane-Agent-Token", "agent-tok")
+
+	ProxyHTTPRequest(c, tunnel, "/api/environments/0/projects")
+
+	assert.True(t, agentHandlerCalled, "Agent handler should have been called")
+	assert.Equal(t, http.StatusCreated, w.Code, "Request should succeed because Origin was stripped")
+	assert.Contains(t, w.Body.String(), "project-1")
+}
+
+func TestProxyHTTPRequest_BodyPreservation_WebSocket(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Test that a POST body survives WebSocket JSON serialization round-trip
+	var receivedBody string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		for {
+			_, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+
+			var msg TunnelMessage
+			_ = json.Unmarshal(data, &msg)
+
+			if msg.Type == MessageTypeRequest {
+				receivedBody = string(msg.Body)
+				resp := &TunnelMessage{
+					ID:      msg.ID,
+					Type:    MessageTypeResponse,
+					Status:  http.StatusCreated,
+					Headers: map[string]string{"Content-Type": "application/json"},
+					Body:    []byte(`{"ok":true}`),
+				}
+				respData, _ := json.Marshal(resp)
+				_ = conn.WriteMessage(websocket.TextMessage, respData)
+			}
+		}
+	}))
+	defer server.Close()
+
+	url := "ws" + server.URL[4:]
+	wsConn, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	require.NoError(t, err)
+	if resp != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	tunnel := NewAgentTunnel("env-body-test", wsConn)
+	defer func() { _ = tunnel.Close() }()
+
+	go func() {
+		for {
+			msg, err := tunnel.Conn.Receive()
+			if err != nil {
+				return
+			}
+			if req, ok := tunnel.Pending.Load(msg.ID); ok {
+				pendingReq := req.(*PendingRequest)
+				pendingReq.ResponseCh <- msg
+			}
+		}
+	}()
+
+	requestBody := `{"name":"My Project","description":"A test project with special chars: <>&\""}`
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/test", bytes.NewBufferString(requestBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	ProxyHTTPRequest(c, tunnel, "/api/environments/0/projects")
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, requestBody, receivedBody, "Request body should survive WebSocket JSON serialization round-trip")
+}


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1829

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes CORS 403 errors on edge agent requests by implementing a dual-layer solution: (1) completely disabling CORS middleware on edge agents since they only receive server-to-server requests through the tunnel, and (2) stripping browser-security headers (Origin, Referer, Cookie, etc.) when the manager proxies requests through the tunnel. Additionally fixes proper `Host` header forwarding by setting `req.Host` field explicitly.

**Key changes:**
- Edge agents now bypass CORS entirely via early return in `CORSMiddleware.Add()`
- Proxy strips 8 browser-security headers to prevent CORS origin mismatches
- `Host` header correctly set on `req.Host` field (not via `Header.Set`)
- Comprehensive test coverage added for header handling

**Note:** The PR description template is incomplete — "Changes Made" section is empty and testing checklist items are unchecked, making it harder to understand what manual testing was performed.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minimal risk
- The code is well-written, follows Go best practices, and includes comprehensive test coverage. The fix is sound and addresses the root cause of CORS rejections. Score is 4/5 instead of 5/5 because the PR description is incomplete (empty sections, unchecked testing boxes), which reduces confidence about what manual testing was performed.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/middleware/cors_middleware.go | Added EdgeAgent mode bypass to skip CORS entirely for server-to-server tunnel communication; added `X-API-Key` to allowed headers |
| backend/pkg/libarcane/edge/client.go | Added explicit `req.Host` field handling (Go doesn't populate it from `Header.Set`) and bodyLength debug logging |
| backend/pkg/libarcane/edge/proxy.go | Added `isBrowserSecurityHeader` function to strip Origin, Referer, Cookie, etc. when proxying through tunnel to prevent CORS rejections |
| backend/pkg/libarcane/edge/proxy_headers_test.go | New comprehensive test suite verifying browser header stripping, body preservation, and Host header handling through the tunnel |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant Manager
    participant Tunnel
    participant EdgeAgent
    participant LocalService

    Browser->>Manager: POST /api/projects<br/>Headers: Origin, Cookie,<br/>X-Arcane-Agent-Token
    
    Note over Manager: ProxyHTTPRequest()<br/>Strips browser headers:<br/>- Origin<br/>- Referer<br/>- Cookie<br/>- Sec-Fetch-*<br/>- Access-Control-*
    
    Manager->>Tunnel: TunnelMessage<br/>Headers: Host, X-Arcane-Agent-Token<br/>(browser headers removed)
    
    Tunnel->>EdgeAgent: WebSocket/gRPC<br/>forward request
    
    Note over EdgeAgent: CORSMiddleware.Add()<br/>if cfg.EdgeAgent:<br/>  return noop handler<br/>CORS completely bypassed
    
    Note over EdgeAgent: handleRequest()<br/>Sets req.Host field explicitly<br/>(Header.Set does not work)
    
    EdgeAgent->>LocalService: HTTP Request<br/>with proper Host field
    
    LocalService-->>EdgeAgent: 201 Created
    EdgeAgent-->>Tunnel: TunnelMessage response
    Tunnel-->>Manager: Response
    Manager-->>Browser: 201 Created
```
</details>


<sub>Last reviewed commit: 34cffa7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->