### PR TITLE
fix: Automatically Place API Key In New Env Run Command

### DIFF
--- a/backend/internal/huma/handlers/environments.go
+++ b/backend/internal/huma/handlers/environments.go
@@ -965,7 +965,7 @@ func (h *EnvironmentHandler) GetDeploymentSnippets(ctx context.Context, input *G
 	if env.AccessToken == nil || *env.AccessToken == "" {
 		return nil, huma.Error400BadRequest("Environment is missing access token")
 	}
-	
+
 	// Generate snippets with API key
 	// Use edge snippets for edge environments
 	var snippets *services.DeploymentSnippets


### PR DESCRIPTION
## What This PR Implements
This PR implements my feature request to display the API key directly in the docker run and docker compose commands when creating a new remote environment. This makes the presented docker run and docker compose commands ready to use as-is when copied out from Arcane and you no longer have to replace `<YOUR_API_KEY>` with the API key provided at environment creation.

## Related Issue
Closes #1931 

## Changes Made
<!-- List specific changes with brief explanations -->
- Added a sanity check to be sure `*env.AccessToken` has a value
- Replaced hard-coded `"<YOUR_API_KEY>"` with `*env.AccessToken` - this will result in the docker run and docker compose commands being ready to use as-is

## Testing Done
<!-- Check all that apply and describe what you tested -->
- [x] Development environment started: `./scripts/development/dev.sh start`
- [x] Frontend verified at http://localhost:3000
- [x] Backend verified at http://localhost:3552
- [x] Manual testing completed: Run test environment but cannot login - even after clean and re-run the default arcane/arcane-admin as printed in the debug output gives me a 403 error at login
- [x] No linting errors (e.g., `just lint all`) - Lint errors present in frontend files untouched by this change
- [x] Backend tests pass: `just test backend`

## Checklist
- [x] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)
<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool: ChatGPT Codex
Assistance Level: Minor
What AI helped with: Discovery, solution proposal
I reviewed and edited all AI-generated output: Yes
I ran all required tests and manually verified changes: Yes

## Additional Context
I tried ChatGPT Codex for the first time on this project. Its initial suggestion was to change the front end to just replace <YOUR_API_KEY> with the key rendered on the page. This felt hacky so I asked it instead to find where in the backend this information was coming from. It showed me the now-changed lines in environments.go

Additionally as noted above the default new deployment login of user `arcane` and password `arcane-admin` does not seem to work for me with the dev environment, instead returning a 403 on the login. I have confirmed the message in the backend log that these are the default credentials but was never able to get in past this.

Still, since this submission is so simple the PR submission feels reasonable. If there is something simple I am doing wrong with the dev environment login please let me know and I will correct that and login and complete testing creating a new environment.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR successfully implements the requested feature to automatically embed the actual API key in Docker deployment commands, eliminating the need for manual replacement of the `<YOUR_API_KEY>` placeholder.

**Key Changes:**
- Added validation to ensure `env.AccessToken` is not nil or empty before use
- Replaced hardcoded `"<YOUR_API_KEY>"` placeholder with `*env.AccessToken` in both edge and standard deployment snippet generation
- Updated comment to reflect that actual API key is now used

**Review Notes:**
- The change is security-appropriate since `GetDeploymentSnippets` is an admin-only endpoint returning deployment instructions to the authenticated environment owner
- Good defensive programming with the nil/empty check before dereferencing the pointer
- The implementation correctly handles both edge and standard environment types
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The changes are focused, well-implemented, and include appropriate validation. The security implications are acceptable for an admin-only endpoint returning deployment snippets to the authenticated owner. The code follows Go best practices with proper error handling and early returns.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/huma/handlers/environments.go | Replaces hardcoded placeholder with actual API key in deployment snippets and adds validation for nil/empty access token |

</details>


</details>


<sub>Last reviewed commit: f4dbcee</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->