### PR TITLE
feat: show template icons based on x-arcane labels

### DIFF
--- a/backend/internal/models/template.go
+++ b/backend/internal/models/template.go
@@ -28,6 +28,7 @@ type ComposeTemplateMetadata struct {
 	RemoteURL        *string  `json:"remoteUrl,omitempty"`
 	EnvURL           *string  `json:"envUrl,omitempty"`
 	DocumentationURL *string  `json:"documentationUrl,omitempty"`
+	IconURL          *string  `json:"iconUrl,omitempty"`
 }
 
 func (TemplateRegistry) TableName() string { return "template_registries" }

--- a/backend/internal/services/template_service_test.go
+++ b/backend/internal/services/template_service_test.go
@@ -1,0 +1,282 @@
+package services
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	glsqlite "github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/getarcaneapp/arcane/backend/internal/database"
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+)
+
+func setupTemplateServiceTestDB(t *testing.T) *database.DB {
+	t.Helper()
+
+	db, err := gorm.Open(glsqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.TemplateRegistry{}, &models.ComposeTemplate{}))
+
+	return &database.DB{DB: db}
+}
+
+func setTestWorkingDir(t *testing.T, dir string) {
+	t.Helper()
+
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalDir))
+	})
+}
+
+func TestResolveTemplateIconURL(t *testing.T) {
+	service := &TemplateService{}
+
+	tests := []struct {
+		name       string
+		compose    string
+		envContent string
+		want       string
+	}{
+		{
+			name: "top level icon",
+			compose: `x-arcane:
+  icon: https://cdn.example/icon.png
+services:
+  app:
+    image: nginx:alpine
+`,
+			want: "https://cdn.example/icon.png",
+		},
+		{
+			name: "icons alias",
+			compose: `x-arcane:
+  icons: https://cdn.example/alias.png
+services:
+  app:
+    image: nginx:alpine
+`,
+			want: "https://cdn.example/alias.png",
+		},
+		{
+			name: "env interpolation",
+			compose: `x-arcane:
+  icon: ${TEMPLATE_ICON}
+services:
+  app:
+    image: nginx:alpine
+`,
+			envContent: "TEMPLATE_ICON=https://cdn.example/from-env.png\n",
+			want:       "https://cdn.example/from-env.png",
+		},
+		{
+			name: "invalid x arcane block",
+			compose: `x-arcane: plain-text
+services:
+  app:
+    image: nginx:alpine
+`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iconURL := service.resolveTemplateIconURL(context.Background(), tt.compose, tt.envContent)
+			if tt.want == "" {
+				require.Nil(t, iconURL)
+				return
+			}
+
+			require.NotNil(t, iconURL)
+			require.Equal(t, tt.want, *iconURL)
+		})
+	}
+}
+
+func TestFetchRegistryTemplates_ReusesCachedIconsOnNotModified(t *testing.T) {
+	var composeHits atomic.Int32
+	var okComposeURL string
+	var badComposeURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/registry.json":
+			if r.Header.Get("If-Modified-Since") != "" {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+
+			w.Header().Set("Last-Modified", "Mon, 02 Jan 2006 15:04:05 GMT")
+			_, _ = w.Write([]byte(`{
+  "name": "Demo Registry",
+  "description": "Registry used in tests",
+  "version": "1.0.0",
+  "author": "Arcane",
+  "templates": [
+    {
+      "id": "good",
+      "name": "Good Template",
+      "description": "Has a compose icon",
+      "version": "1.0.0",
+      "author": "Arcane",
+      "compose_url": "` + okComposeURL + `",
+      "env_url": "",
+      "documentation_url": "",
+      "tags": ["demo"]
+    },
+    {
+      "id": "bad",
+      "name": "Broken Template",
+      "description": "Compose fetch fails",
+      "version": "1.0.0",
+      "author": "Arcane",
+      "compose_url": "` + badComposeURL + `",
+      "env_url": "",
+      "documentation_url": "",
+      "tags": ["demo"]
+    }
+  ]
+}`))
+		case "/ok.yml":
+			composeHits.Add(1)
+			_, _ = w.Write([]byte(`x-arcane:
+  icon: https://cdn.example/good.png
+services:
+  app:
+    image: nginx:alpine
+`))
+		case "/missing.yml":
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	registryURL := server.URL + "/registry.json"
+	okComposeURL = server.URL + "/ok.yml"
+	badComposeURL = server.URL + "/missing.yml"
+
+	service := &TemplateService{
+		httpClient:        server.Client(),
+		registryFetchMeta: make(map[string]*registryFetchMeta),
+	}
+	registry := &models.TemplateRegistry{
+		BaseModel: models.BaseModel{ID: "reg-1"},
+		Name:      "Demo Registry",
+		URL:       registryURL,
+		Enabled:   true,
+	}
+
+	templates, err := service.fetchRegistryTemplates(context.Background(), registry)
+	require.NoError(t, err)
+	require.Len(t, templates, 2)
+	require.NotNil(t, templates[0].Metadata)
+	require.NotNil(t, templates[0].Metadata.IconURL)
+	require.Equal(t, "https://cdn.example/good.png", *templates[0].Metadata.IconURL)
+	require.Nil(t, templates[1].Metadata.IconURL)
+	require.EqualValues(t, 1, composeHits.Load())
+
+	cachedTemplates, err := service.fetchRegistryTemplates(context.Background(), registry)
+	require.NoError(t, err)
+	require.Len(t, cachedTemplates, 2)
+	require.NotNil(t, cachedTemplates[0].Metadata)
+	require.NotNil(t, cachedTemplates[0].Metadata.IconURL)
+	require.Equal(t, "https://cdn.example/good.png", *cachedTemplates[0].Metadata.IconURL)
+	require.EqualValues(t, 1, composeHits.Load())
+}
+
+func TestDownloadTemplate_PreservesIconURL(t *testing.T) {
+	tempDir := t.TempDir()
+	setTestWorkingDir(t, tempDir)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/compose.yaml":
+			_, _ = w.Write([]byte(`x-arcane:
+  icon: https://cdn.example/download.png
+services:
+  app:
+    image: nginx:alpine
+`))
+		case "/template.env":
+			_, _ = w.Write([]byte("DOWNLOAD_ICON=https://cdn.example/download.png\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	service := &TemplateService{
+		db:                setupTemplateServiceTestDB(t),
+		httpClient:        server.Client(),
+		registryFetchMeta: make(map[string]*registryFetchMeta),
+	}
+
+	remoteTemplate := &models.ComposeTemplate{
+		BaseModel:   models.BaseModel{ID: "remote:reg-1:demo"},
+		Name:        "Demo Template",
+		Description: "Remote template",
+		IsRemote:    true,
+		IsCustom:    false,
+		RegistryID:  stringPtr("reg-1"),
+		Metadata: &models.ComposeTemplateMetadata{
+			RemoteURL: stringPtr(server.URL + "/compose.yaml"),
+			EnvURL:    stringPtr(server.URL + "/template.env"),
+			IconURL:   stringPtr("https://cdn.example/download.png"),
+		},
+	}
+
+	downloaded, err := service.DownloadTemplate(context.Background(), remoteTemplate)
+	require.NoError(t, err)
+	require.NotNil(t, downloaded)
+	require.False(t, downloaded.IsRemote)
+	require.NotNil(t, downloaded.Metadata)
+	require.NotNil(t, downloaded.Metadata.IconURL)
+	require.Equal(t, "https://cdn.example/download.png", *downloaded.Metadata.IconURL)
+
+	var stored models.ComposeTemplate
+	require.NoError(t, service.db.WithContext(context.Background()).First(&stored, "id = ?", downloaded.ID).Error)
+	require.NotNil(t, stored.Metadata)
+	require.NotNil(t, stored.Metadata.IconURL)
+	require.Equal(t, "https://cdn.example/download.png", *stored.Metadata.IconURL)
+}
+
+func TestSyncFilesystemTemplatesInternal_PopulatesIconURL(t *testing.T) {
+	tempDir := t.TempDir()
+	setTestWorkingDir(t, tempDir)
+
+	templateDir := filepath.Join(tempDir, "data", "templates", "example")
+	require.NoError(t, os.MkdirAll(templateDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "compose.yaml"), []byte(`x-arcane:
+  icon: https://cdn.example/local.png
+services:
+  app:
+    image: nginx:alpine
+`), 0o644))
+
+	service := &TemplateService{
+		db:                setupTemplateServiceTestDB(t),
+		httpClient:        http.DefaultClient,
+		registryFetchMeta: make(map[string]*registryFetchMeta),
+	}
+
+	require.NoError(t, service.syncFilesystemTemplatesInternal(context.Background()))
+
+	var stored models.ComposeTemplate
+	require.NoError(t, service.db.WithContext(context.Background()).First(&stored, "name = ?", "example").Error)
+	require.NotNil(t, stored.Metadata)
+	require.NotNil(t, stored.Metadata.IconURL)
+	require.Equal(t, "https://cdn.example/local.png", *stored.Metadata.IconURL)
+}

--- a/frontend/src/lib/components/dialogs/template-selection-dialog.svelte
+++ b/frontend/src/lib/components/dialogs/template-selection-dialog.svelte
@@ -10,6 +10,7 @@
 	import * as Select from '$lib/components/ui/select/index.js';
 	import * as Collapsible from '$lib/components/ui/collapsible/index.js';
 	import SwitchWithLabel from '$lib/components/form/labeled-switch.svelte';
+	import IconImage from '$lib/components/icon-image.svelte';
 	import {
 		ArrowDownIcon,
 		ArrowRightIcon,
@@ -157,7 +158,16 @@
 	<Card class="hover:bg-muted/50 hover:border-primary/20 border transition-colors">
 		<div class="p-4">
 			<div class="mb-2 flex items-start justify-between gap-2">
-				<h4 class="truncate pr-2 font-semibold">{template.name}</h4>
+				<div class="flex min-w-0 items-start gap-3">
+					<IconImage
+						src={template.metadata?.iconUrl}
+						alt={template.name}
+						fallback={template.isRemote ? RegistryIcon : ProjectsIcon}
+						class="size-5"
+						containerClass="size-9"
+					/>
+					<h4 class="min-w-0 truncate pr-2 font-semibold">{template.name}</h4>
+				</div>
 				<div class="ml-2 flex flex-shrink-0 flex-wrap items-center gap-1">
 					{#if template.metadata?.version}
 						<Badge variant="outline" class="text-xs">v{template.metadata.version}</Badge>

--- a/frontend/src/lib/types/template.type.ts
+++ b/frontend/src/lib/types/template.type.ts
@@ -25,6 +25,7 @@ export interface Template {
 		remoteUrl?: string;
 		envUrl?: string;
 		documentationUrl?: string;
+		iconUrl?: string;
 		updatedAt?: string;
 	};
 	createdAt: string;

--- a/frontend/src/routes/(app)/customize/templates/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/customize/templates/[id]/+page.svelte
@@ -4,6 +4,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Spinner } from '$lib/components/ui/spinner';
 	import CodeEditor from '$lib/components/code-editor/editor.svelte';
+	import IconImage from '$lib/components/icon-image.svelte';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { m } from '$lib/paraglide/messages.js';
 	import { templateService } from '$lib/services/template-service';
@@ -101,11 +102,20 @@
 			<span>{m.common_back_to({ resource: m.templates_title() })}</span>
 		</ArcaneButton>
 
-		<div>
-			<h1 class="text-xl font-bold break-words sm:text-2xl">{template.name}</h1>
-			{#if template.description}
-				<p class="text-muted-foreground mt-1.5 text-sm break-words sm:text-base">{template.description}</p>
-			{/if}
+		<div class="flex min-w-0 items-start gap-3">
+			<IconImage
+				src={template.metadata?.iconUrl}
+				alt={template.name}
+				fallback={template.isRemote ? GlobeIcon : TemplateIcon}
+				class="size-6"
+				containerClass="size-9 bg-transparent ring-0"
+			/>
+			<div class="min-w-0 flex-1">
+				<h1 class="text-xl font-bold break-words sm:text-2xl">{template.name}</h1>
+				{#if template.description}
+					<p class="text-muted-foreground mt-1.5 text-sm break-words sm:text-base">{template.description}</p>
+				{/if}
+			</div>
 		</div>
 
 		<div class="flex flex-wrap items-center gap-2">

--- a/frontend/src/routes/(app)/customize/templates/template-table.svelte
+++ b/frontend/src/routes/(app)/customize/templates/template-table.svelte
@@ -18,6 +18,7 @@
 	import { truncateString } from '$lib/utils/string.utils';
 	import { PersistedState } from 'runed';
 	import { onMount } from 'svelte';
+	import IconImage from '$lib/components/icon-image.svelte';
 	import {
 		InspectIcon,
 		FolderOpenIcon,
@@ -161,9 +162,18 @@
 </script>
 
 {#snippet NameCell({ item }: { item: Template })}
-	<a class="font-medium hover:underline" href="/customize/templates/{item.id}">
-		{item.name}
-	</a>
+	<div class="flex items-center gap-2">
+		<IconImage
+			src={item.metadata?.iconUrl}
+			alt={item.name}
+			fallback={item.isRemote ? GlobeIcon : FolderOpenIcon}
+			class="size-8"
+			containerClass="size-10"
+		/>
+		<a class="font-medium hover:underline" href="/customize/templates/{item.id}">
+			{item.name}
+		</a>
+	</div>
 {/snippet}
 
 {#snippet DescriptionCell({ item }: { item: Template })}
@@ -210,7 +220,9 @@
 		{item}
 		icon={(item) => ({
 			component: item.isRemote ? GlobeIcon : FolderOpenIcon,
-			variant: item.isRemote ? 'emerald' : 'blue'
+			variant: item.isRemote ? 'emerald' : 'blue',
+			imageUrl: item.metadata?.iconUrl,
+			alt: item.name
 		})}
 		title={(item) => item.name}
 		subtitle={(item) => ((mobileFieldVisibility.description ?? true) ? item.description : null)}

--- a/types/meta/template_meta.go
+++ b/types/meta/template_meta.go
@@ -32,6 +32,11 @@ type TemplateMeta struct {
 	// Required: false
 	DocumentationURL *string `json:"documentationUrl,omitempty"`
 
+	// IconURL is the URL to the template icon extracted from x-arcane metadata.
+	//
+	// Required: false
+	IconURL *string `json:"iconUrl,omitempty"`
+
 	// UpdatedAt is the date and time when the template was last updated.
 	//
 	// Required: false


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

Added template icon display functionality by extracting icon URLs from the `x-arcane` metadata block in Docker Compose files. Changes include:

- Backend: Added `IconURL` field to template metadata models and implemented icon extraction from compose files using the `x-arcane.icon` or `x-arcane.icons` keys with environment variable interpolation support
- Service layer: Integrated icon resolution throughout template lifecycle (create, update, sync, fetch) with concurrent icon enrichment for remote templates (limited to 4 concurrent operations)
- Frontend: Updated all template UI views (selection dialog, detail page, table) to display icons using the `IconImage` component with appropriate fallback icons
- Testing: Added comprehensive test coverage for icon resolution, caching, and filesystem sync

The implementation includes proper cloning of template data structures and helper functions for string handling. Minor performance consideration: icon extraction occurs on every template detail view even when already cached in database.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with one minor performance consideration that doesn't affect correctness
- The implementation is well-tested, functionally correct, and includes proper error handling. The score is 4 rather than 5 due to a performance inefficiency in `GetTemplateContentWithParsedData` which re-parses compose files on every call to extract icon URLs, even though the icon is already stored in the database. While this doesn't break functionality, it adds unnecessary overhead to template detail views. The concurrent icon enrichment for remote templates is properly limited to avoid overwhelming the system.
- Pay attention to `backend/internal/services/template_service.go` for the performance consideration in the `GetTemplateContentWithParsedData` method
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/models/template.go | Added `IconURL` field to `ComposeTemplateMetadata` struct to store template icon URLs extracted from compose files |
| backend/internal/services/template_service.go | Implemented icon URL extraction from compose `x-arcane` metadata blocks, added helper functions for cloning and string handling, integrated icon resolution throughout template lifecycle (create/update/sync/fetch) |
| frontend/src/lib/components/dialogs/template-selection-dialog.svelte | Integrated `IconImage` component to display template icons in template selection cards with fallback to appropriate icons based on template type |
| frontend/src/routes/(app)/customize/templates/template-table.svelte | Added icon display to both desktop table view and mobile card view for templates |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Template Source] --> B{Template Type?}
    B -->|Local/Filesystem| C[Compose File Content]
    B -->|Remote| D[Fetch Remote Compose]
    
    C --> E[resolveTemplateIconURL]
    D --> E
    
    E --> F[Parse Compose File]
    F --> G{x-arcane block exists?}
    
    G -->|No| H[Return nil]
    G -->|Yes| I[Extract icon/icons field]
    
    I --> J[Apply env variable interpolation]
    J --> K[Trim & validate]
    K --> L{Empty?}
    
    L -->|Yes| H
    L -->|No| M[Return icon URL pointer]
    
    M --> N[setTemplateIconURL]
    H --> N
    
    N --> O[Store in Metadata.IconURL]
    O --> P{All fields empty?}
    P -->|Yes| Q[Set Metadata to nil]
    P -->|No| R[Keep Metadata]
    
    R --> S[(Database)]
    Q --> S
    
    S --> T[Frontend API]
    T --> U[IconImage Component]
    U --> V{Icon URL exists?}
    V -->|Yes| W[Display Image]
    V -->|No| X[Display Fallback Icon]
```
</details>


<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Ftemplate_service.go%3A1247%0ARe-parsing%20compose%20file%20to%20extract%20icon%20on%20every%20call%20to%20%60GetTemplateContentWithParsedData%60%20%28called%20when%20viewing%20template%20details%29%20is%20wasteful%20for%20local%20templates%20since%20icon%20is%20already%20in%20database%20metadata.%20Consider%20checking%20if%20%60composeTemplate.Metadata%3F.IconURL%60%20is%20already%20set%20for%20local%20templates%20and%20skip%20re-resolution.%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<sub>Last reviewed commit: adace3b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->