### PR TITLE
feat: persistient volume backup mount

### DIFF
--- a/backend/internal/services/volume_service.go
+++ b/backend/internal/services/volume_service.go
@@ -46,6 +46,26 @@ type VolumeService struct {
 
 const volumeHelperImage = "busybox:stable-musl"
 
+type backupStorageMode string
+
+const (
+	// backupStorageModeArcaneMount means backup helpers mirror an existing Arcane
+	// container mount at /backups. This intentionally covers any mount the Arcane
+	// container already has at /backups, not exclusively bind mounts.
+	backupStorageModeArcaneMount backupStorageMode = "arcane_mount"
+	// backupStorageModeNamedVolumeFallback means no suitable Arcane container
+	// mount was found, so Arcane's dedicated named backup volume is used.
+	backupStorageModeNamedVolumeFallback backupStorageMode = "named_volume_fallback"
+)
+
+const backupMountMissingWarning = "No volume is mounted at /backups in the Arcane container. Backups will only live inside Docker unless you mount a host path."
+
+type backupStorageMountInternal struct {
+	mode           backupStorageMode
+	mount          mount.Mount
+	requiresEnsure bool
+}
+
 func NewVolumeService(db *database.DB, dockerService *DockerClientService, eventService *EventService, settingsService *SettingsService, containerService *ContainerService, imageService *ImageService, backupVolumeName string) *VolumeService {
 	slog.Debug("volume service: new")
 	if strings.TrimSpace(backupVolumeName) == "" {
@@ -341,41 +361,17 @@ func (s *VolumeService) DownloadFile(ctx context.Context, volumeName, filePath s
 	}
 
 	targetPath := path.Join("/volume", sanitizedPath)
-	copyResult, err := dockerClient.CopyFromContainer(ctx, containerID, client.CopyFromContainerOptions{
-		SourcePath: targetPath,
-	})
-	if err != nil {
-		cleanup()
-		return nil, 0, fmt.Errorf("failed to download: %w", err)
-	}
-	reader := copyResult.Content
-
-	tr := tar.NewReader(reader)
-	hdr, err := tr.Next()
-	if err != nil {
-		_ = reader.Close()
-		cleanup()
-		return nil, 0, fmt.Errorf("failed to read tar stream: %w", err)
-	}
-	if hdr.FileInfo().IsDir() {
-		_ = reader.Close()
-		cleanup()
-		return nil, 0, fmt.Errorf("path is a directory")
-	}
-	size := hdr.Size
-
-	return &cleanupReadCloser{
-		Reader:  tr,
-		Closer:  reader,
-		cleanup: cleanup,
-	}, size, nil
+	return s.downloadFileFromContainerInternal(ctx, dockerClient, containerID, targetPath, cleanup)
 }
 
-func (s *VolumeService) getHelperImageInternal(ctx context.Context) (string, error) {
+func (s *VolumeService) getHelperImageInternal(ctx context.Context, dockerClient *client.Client) (string, error) {
 	slog.DebugContext(ctx, "volume service: resolve helper image")
-	dockerClient, err := s.dockerService.GetClient()
-	if err != nil {
-		return "", fmt.Errorf("failed to get docker client: %w", err)
+	var err error
+	if dockerClient == nil {
+		dockerClient, err = s.dockerService.GetClient()
+		if err != nil {
+			return "", fmt.Errorf("failed to get docker client: %w", err)
+		}
 	}
 
 	if _, err := dockerClient.ImageInspect(ctx, volumeHelperImage); err == nil {
@@ -422,6 +418,86 @@ func (s *VolumeService) resolveArcaneHelperImageInternal(ctx context.Context, do
 	return "", "", false
 }
 
+func resolveBackupStorageMountFromMountsInternal(mounts []container.MountPoint, target string, readOnly bool) (backupStorageMountInternal, bool) {
+	mirroredMount := docker.MountForDestination(mounts, "/backups", target)
+	if mirroredMount == nil {
+		return backupStorageMountInternal{}, false
+	}
+	// MountForDestination only returns non-nil for bind and named volume mounts.
+
+	if !readOnly && mirroredMount.ReadOnly {
+		slog.Warn("volume service: requested writable backup mount but source is read-only; writes may fail")
+	}
+	mirroredMount.ReadOnly = readOnly
+
+	return backupStorageMountInternal{
+		mode:  backupStorageModeArcaneMount,
+		mount: *mirroredMount,
+	}, true
+}
+
+func (s *VolumeService) resolveBackupStorageMountInternal(ctx context.Context, dockerClient *client.Client, target string, readOnly bool) (backupStorageMountInternal, error) {
+	if dockerClient != nil {
+		containerID := s.getArcaneContainerIDInternal(ctx, dockerClient)
+		if containerID != "" {
+			inspect, err := dockerClient.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+			if err != nil {
+				slog.WarnContext(ctx, "volume service: failed to inspect arcane container for backup mount resolution, falling back to named volume", "container_id", containerID, "error", err.Error())
+			} else if resolved, ok := resolveBackupStorageMountFromMountsInternal(inspect.Container.Mounts, target, readOnly); ok {
+				return resolved, nil
+			}
+		}
+	}
+
+	return backupStorageMountInternal{
+		mode: backupStorageModeNamedVolumeFallback,
+		mount: mount.Mount{
+			Type:     mount.TypeVolume,
+			Source:   s.backupVolumeName,
+			Target:   target,
+			ReadOnly: readOnly,
+		},
+		requiresEnsure: true,
+	}, nil
+}
+
+func (s *VolumeService) resolveUsableBackupStorageMountInternal(ctx context.Context, dockerClient *client.Client, target string, readOnly bool) (backupStorageMountInternal, error) {
+	backupStorage, err := s.resolveBackupStorageMountInternal(ctx, dockerClient, target, readOnly)
+	if err != nil {
+		return backupStorageMountInternal{}, err
+	}
+	if backupStorage.requiresEnsure {
+		if err := s.ensureBackupVolumeInternal(ctx); err != nil {
+			return backupStorageMountInternal{}, err
+		}
+	}
+	return backupStorage, nil
+}
+
+func backupMountWarningForStorageInternal(storage backupStorageMountInternal) string {
+	if storage.mode == backupStorageModeArcaneMount {
+		return ""
+	}
+	return backupMountMissingWarning
+}
+
+func backupMountWarningFromArcaneMountsInternal(mounts []container.MountPoint) string {
+	backupStorage, ok := resolveBackupStorageMountFromMountsInternal(mounts, "/backups", true)
+	if ok {
+		return backupMountWarningForStorageInternal(backupStorage)
+	}
+
+	// Backward compatibility: historically either /backups or /restores mount
+	// suppressed the warning. Preserve that user-visible behavior.
+	for _, m := range mounts {
+		if m.Destination == "/restores" {
+			return ""
+		}
+	}
+
+	return backupMountMissingWarning
+}
+
 func (s *VolumeService) BackupMountWarning(ctx context.Context) string {
 	dockerClient, err := s.dockerService.GetClient()
 	if err != nil {
@@ -430,6 +506,7 @@ func (s *VolumeService) BackupMountWarning(ctx context.Context) string {
 
 	containerID := s.getArcaneContainerIDInternal(ctx, dockerClient)
 	if containerID == "" {
+		// Cannot determine Arcane mount status (e.g. running outside Docker); suppress warning.
 		return ""
 	}
 
@@ -438,22 +515,7 @@ func (s *VolumeService) BackupMountWarning(ctx context.Context) string {
 		return ""
 	}
 
-	hasBackups := false
-	hasRestores := false
-	for _, mount := range inspect.Container.Mounts {
-		if mount.Destination == "/backups" {
-			hasBackups = true
-		}
-		if mount.Destination == "/restores" {
-			hasRestores = true
-		}
-	}
-
-	if hasBackups || hasRestores {
-		return ""
-	}
-
-	return "No volume is mounted at /backups or /restores in the Arcane container. Backups/restores will only live inside Docker unless you mount a host path."
+	return backupMountWarningFromArcaneMountsInternal(inspect.Container.Mounts)
 }
 
 func (s *VolumeService) getArcaneContainerIDInternal(ctx context.Context, dockerClient *client.Client) string {
@@ -478,6 +540,67 @@ func (s *VolumeService) getArcaneContainerIDInternal(ctx context.Context, docker
 	}
 
 	return containers.Items[0].ID
+}
+
+func (s *VolumeService) createBackupTempContainerWithMountInternal(ctx context.Context, dockerClient *client.Client, backupMount mount.Mount) (string, func(), error) {
+	var err error
+	if dockerClient == nil {
+		dockerClient, err = s.dockerService.GetClient()
+		if err != nil {
+			return "", nil, err
+		}
+	}
+
+	helperImage, err := s.getHelperImageInternal(ctx, dockerClient)
+	if err != nil {
+		return "", nil, err
+	}
+
+	config := &container.Config{
+		Image:           helperImage,
+		Cmd:             []string{"sleep", "infinity"},
+		NetworkDisabled: true,
+		Labels:          buildVolumeHelperLabelsInternal(),
+	}
+
+	hostConfig := s.buildHelperHostConfigInternal(helperImage, nil, []mount.Mount{backupMount})
+
+	resp, err := dockerClient.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Config:     config,
+		HostConfig: hostConfig,
+	})
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create backup temp container: %w", err)
+	}
+
+	if _, err := dockerClient.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{}); err != nil {
+		_, _ = dockerClient.ContainerRemove(ctx, resp.ID, volumeHelperRemoveOptionsInternal())
+		return "", nil, fmt.Errorf("failed to start backup temp container: %w", err)
+	}
+
+	cleanup := func() {
+		_, _ = dockerClient.ContainerRemove(ctx, resp.ID, volumeHelperRemoveOptionsInternal())
+	}
+
+	return resp.ID, cleanup, nil
+}
+
+func (s *VolumeService) createBackupTempContainerInternal(ctx context.Context, dockerClient *client.Client, target string, readOnly bool) (string, func(), error) {
+	slog.DebugContext(ctx, "volume service: create backup temp container", "target", target, "read_only", readOnly)
+	var err error
+	if dockerClient == nil {
+		dockerClient, err = s.dockerService.GetClient()
+		if err != nil {
+			return "", nil, err
+		}
+	}
+
+	backupStorage, err := s.resolveUsableBackupStorageMountInternal(ctx, dockerClient, target, readOnly)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return s.createBackupTempContainerWithMountInternal(ctx, dockerClient, backupStorage.mount)
 }
 
 type cleanupReadCloser struct {
@@ -523,9 +646,10 @@ func (s *VolumeService) isArcaneFallbackHelperImageInternal(helperImage string) 
 	return !strings.EqualFold(strings.TrimSpace(helperImage), volumeHelperImage)
 }
 
-func (s *VolumeService) buildHelperHostConfigInternal(helperImage string, binds []string) *container.HostConfig {
+func (s *VolumeService) buildHelperHostConfigInternal(helperImage string, binds []string, mounts []mount.Mount) *container.HostConfig {
 	hostConfig := &container.HostConfig{
 		Binds:      binds,
+		Mounts:     mounts,
 		AutoRemove: true,
 	}
 
@@ -557,7 +681,7 @@ func (s *VolumeService) createTempContainerInternal(ctx context.Context, volumeN
 		}
 	}
 
-	helperImage, err := s.getHelperImageInternal(ctx)
+	helperImage, err := s.getHelperImageInternal(ctx, dockerClient)
 	if err != nil {
 		return "", nil, err
 	}
@@ -576,7 +700,7 @@ func (s *VolumeService) createTempContainerInternal(ctx context.Context, volumeN
 			}
 			return ""
 		}()),
-	})
+	}, nil)
 
 	resp, err := dockerClient.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Config:     config,
@@ -886,19 +1010,23 @@ func (s *VolumeService) ensureBackupVolumeInternal(ctx context.Context) error {
 
 func (s *VolumeService) CreateBackup(ctx context.Context, volumeName string, user models.User) (*models.VolumeBackup, error) {
 	slog.DebugContext(ctx, "volume service: create backup", "volume", volumeName, "user", user.ID)
-	if err := s.ensureBackupVolumeInternal(ctx); err != nil {
-		return nil, err
-	}
-
 	dockerClient, err := s.dockerService.GetClient()
 	if err != nil {
 		return nil, err
 	}
 
 	backupID := fmt.Sprintf("%s-%d-%s", volumeName, time.Now().UnixNano(), uuid.NewString()[:8])
-	filename := fmt.Sprintf("%s.tar.gz", backupID)
+	filename, err := s.backupArchiveFilenameInternal(backupID)
+	if err != nil {
+		return nil, err
+	}
 
-	helperImage, err := s.getHelperImageInternal(ctx)
+	helperImage, err := s.getHelperImageInternal(ctx, dockerClient)
+	if err != nil {
+		return nil, err
+	}
+
+	backupStorage, err := s.resolveUsableBackupStorageMountInternal(ctx, dockerClient, "/backups", false)
 	if err != nil {
 		return nil, err
 	}
@@ -911,8 +1039,7 @@ func (s *VolumeService) CreateBackup(ctx context.Context, volumeName string, use
 
 	hostConfig := s.buildHelperHostConfigInternal(helperImage, []string{
 		fmt.Sprintf("%s:/volume:ro", volumeName),
-		fmt.Sprintf("%s:/backups", s.backupVolumeName),
-	})
+	}, []mount.Mount{backupStorage.mount})
 
 	resp, err := dockerClient.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Config:     config,
@@ -939,7 +1066,11 @@ func (s *VolumeService) CreateBackup(ctx context.Context, volumeName string, use
 		}
 	}
 
-	tempContainerID, cleanup, err := s.createTempContainerInternal(ctx, s.backupVolumeName, true)
+	sizeCheckMount := backupStorage.mount
+	sizeCheckMount.Target = "/volume"
+	sizeCheckMount.ReadOnly = true
+
+	tempContainerID, cleanup, err := s.createBackupTempContainerWithMountInternal(ctx, dockerClient, sizeCheckMount)
 	if err != nil {
 		return nil, err
 	}
@@ -1070,13 +1201,15 @@ func (s *VolumeService) DeleteBackup(ctx context.Context, backupID string, user 
 	}
 
 	// Now delete the actual file - best effort since DB record is already gone
-	containerID, cleanup, err := s.createTempContainerInternal(ctx, s.backupVolumeName, false)
+	containerID, cleanup, err := s.createBackupTempContainerInternal(ctx, nil, "/volume", false)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to create container for backup file cleanup", "backup_id", backupID, "error", err.Error())
 	} else {
 		defer cleanup()
-		filename := fmt.Sprintf("%s.tar.gz", backupID)
-		if _, _, err = s.execInContainerInternal(ctx, containerID, []string{"rm", "-f", path.Join("/volume", filename)}); err != nil {
+		filename, filenameErr := s.backupArchiveFilenameInternal(backupID)
+		if filenameErr != nil {
+			slog.WarnContext(ctx, "failed to sanitize backup id for file cleanup", "backup_id", backupID, "error", filenameErr.Error())
+		} else if _, _, err = s.execInContainerInternal(ctx, containerID, []string{"rm", "-f", path.Join("/volume", filename)}); err != nil {
 			slog.WarnContext(ctx, "failed to delete backup file (orphan file may remain)", "backup_id", backupID, "error", err.Error())
 		}
 	}
@@ -1126,9 +1259,17 @@ func (s *VolumeService) RestoreBackup(ctx context.Context, volumeName, backupID 
 		return err
 	}
 
-	filename := fmt.Sprintf("%s.tar.gz", backupID)
+	filename, err := s.backupArchiveFilenameInternal(backupID)
+	if err != nil {
+		return err
+	}
 
-	helperImage, err := s.getHelperImageInternal(ctx)
+	helperImage, err := s.getHelperImageInternal(ctx, dockerClient)
+	if err != nil {
+		return err
+	}
+
+	backupStorage, err := s.resolveUsableBackupStorageMountInternal(ctx, dockerClient, "/backups", true)
 	if err != nil {
 		return err
 	}
@@ -1145,8 +1286,7 @@ func (s *VolumeService) RestoreBackup(ctx context.Context, volumeName, backupID 
 
 	hostConfig := s.buildHelperHostConfigInternal(helperImage, []string{
 		fmt.Sprintf("%s:/volume", volumeName),
-		fmt.Sprintf("%s:/backups:ro", s.backupVolumeName),
-	})
+	}, []mount.Mount{backupStorage.mount})
 
 	resp, err := dockerClient.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Config:     config,
@@ -1205,6 +1345,26 @@ func (s *VolumeService) sanitizeBackupPathInternal(input string) (string, error)
 	return cleaned, nil
 }
 
+func (s *VolumeService) sanitizeBackupIDInternal(backupID string) (string, error) {
+	cleaned, err := s.sanitizeBackupPathInternal(backupID)
+	if err != nil {
+		return "", fmt.Errorf("invalid backup id: %w", err)
+	}
+	if strings.Contains(cleaned, "/") {
+		return "", fmt.Errorf("invalid backup id: path separators not allowed")
+	}
+	return cleaned, nil
+}
+
+func (s *VolumeService) backupArchiveFilenameInternal(backupID string) (string, error) {
+	sanitizedBackupID, err := s.sanitizeBackupIDInternal(backupID)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s.tar.gz", sanitizedBackupID), nil
+}
+
 // sanitizeBrowsePath validates and cleans a path for file browser operations.
 // It ensures the path stays within the volume boundary.
 func (s *VolumeService) sanitizeBrowsePathInternal(input string) (string, error) {
@@ -1230,11 +1390,11 @@ func (s *VolumeService) sanitizeBrowsePathInternal(input string) (string, error)
 
 func (s *VolumeService) BackupHasPath(ctx context.Context, backupID string, filePath string) (bool, error) {
 	slog.DebugContext(ctx, "volume service: backup has path", "backup_id", backupID, "path", filePath)
-	if err := s.ensureBackupVolumeInternal(ctx); err != nil {
+	cleaned, err := s.sanitizeBackupPathInternal(filePath)
+	if err != nil {
 		return false, err
 	}
-
-	cleaned, err := s.sanitizeBackupPathInternal(filePath)
+	filename, err := s.backupArchiveFilenameInternal(backupID)
 	if err != nil {
 		return false, err
 	}
@@ -1244,13 +1404,13 @@ func (s *VolumeService) BackupHasPath(ctx context.Context, backupID string, file
 		return false, err
 	}
 
-	containerID, cleanup, err := s.createTempContainerInternal(ctx, s.backupVolumeName, true)
+	containerID, cleanup, err := s.createBackupTempContainerInternal(ctx, nil, "/volume", true)
 	if err != nil {
 		return false, err
 	}
 	defer cleanup()
 
-	archivePath := path.Join("/volume", fmt.Sprintf("%s.tar.gz", backupID))
+	archivePath := path.Join("/volume", filename)
 	cmd := []string{"tar", "-tzf", archivePath}
 	stdout, stderr, err := s.execInContainerInternal(ctx, containerID, cmd)
 	if err != nil {
@@ -1276,7 +1436,8 @@ func (s *VolumeService) BackupHasPath(ctx context.Context, backupID string, file
 
 func (s *VolumeService) ListBackupFiles(ctx context.Context, backupID string) ([]string, error) {
 	slog.DebugContext(ctx, "volume service: list backup files", "backup_id", backupID)
-	if err := s.ensureBackupVolumeInternal(ctx); err != nil {
+	filename, err := s.backupArchiveFilenameInternal(backupID)
+	if err != nil {
 		return nil, err
 	}
 
@@ -1285,13 +1446,13 @@ func (s *VolumeService) ListBackupFiles(ctx context.Context, backupID string) ([
 		return nil, err
 	}
 
-	containerID, cleanup, err := s.createTempContainerInternal(ctx, s.backupVolumeName, true)
+	containerID, cleanup, err := s.createBackupTempContainerInternal(ctx, nil, "/volume", true)
 	if err != nil {
 		return nil, err
 	}
 	defer cleanup()
 
-	archivePath := path.Join("/volume", fmt.Sprintf("%s.tar.gz", backupID))
+	archivePath := path.Join("/volume", filename)
 	cmd := []string{"tar", "-tzf", archivePath}
 	stdout, _, err := s.execInContainerInternal(ctx, containerID, cmd)
 	if err != nil {
@@ -1324,6 +1485,10 @@ func (s *VolumeService) RestoreBackupFiles(ctx context.Context, volumeName, back
 	slog.DebugContext(ctx, "volume service: restore backup files", "volume", volumeName, "backup_id", backupID, "paths_count", len(paths), "user", user.ID)
 	if len(paths) == 0 {
 		return fmt.Errorf("no paths provided")
+	}
+	filename, err := s.backupArchiveFilenameInternal(backupID)
+	if err != nil {
+		return err
 	}
 
 	var backup models.VolumeBackup
@@ -1363,7 +1528,12 @@ func (s *VolumeService) RestoreBackupFiles(ctx context.Context, volumeName, back
 		return err
 	}
 
-	helperImage, err := s.getHelperImageInternal(ctx)
+	helperImage, err := s.getHelperImageInternal(ctx, dockerClient)
+	if err != nil {
+		return err
+	}
+
+	backupStorage, err := s.resolveUsableBackupStorageMountInternal(ctx, dockerClient, "/backups", true)
 	if err != nil {
 		return err
 	}
@@ -1377,8 +1547,7 @@ func (s *VolumeService) RestoreBackupFiles(ctx context.Context, volumeName, back
 
 	hostConfig := s.buildHelperHostConfigInternal(helperImage, []string{
 		fmt.Sprintf("%s:/volume", volumeName),
-		fmt.Sprintf("%s:/backups:ro", s.backupVolumeName),
-	})
+	}, []mount.Mount{backupStorage.mount})
 
 	resp, err := dockerClient.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Config:     config,
@@ -1398,7 +1567,6 @@ func (s *VolumeService) RestoreBackupFiles(ctx context.Context, volumeName, back
 	}
 	defer cleanup()
 
-	filename := fmt.Sprintf("%s.tar.gz", backupID)
 	cmd := append([]string{"tar", "-xzf", path.Join("/backups", filename), "-C", "/volume", "--"}, tarPaths...)
 	_, stderr, err := s.execInContainerInternal(ctx, resp.ID, cmd)
 	if err != nil {
@@ -1427,8 +1595,21 @@ func (s *VolumeService) RestoreBackupFiles(ctx context.Context, volumeName, back
 
 func (s *VolumeService) DownloadBackup(ctx context.Context, backupID string, user *models.User) (io.ReadCloser, int64, error) {
 	slog.DebugContext(ctx, "volume service: download backup", "backup_id", backupID)
-	filename := fmt.Sprintf("%s.tar.gz", backupID)
-	reader, size, err := s.DownloadFile(ctx, s.backupVolumeName, filename)
+	filename, err := s.backupArchiveFilenameInternal(backupID)
+	if err != nil {
+		return nil, 0, err
+	}
+	dockerClient, err := s.dockerService.GetClient()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	containerID, cleanup, err := s.createBackupTempContainerInternal(ctx, dockerClient, "/volume", true)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	reader, size, err := s.downloadFileFromContainerInternal(ctx, dockerClient, containerID, path.Join("/volume", filename), cleanup)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1886,4 +2067,40 @@ func (s *VolumeService) ListVolumesPaginated(ctx context.Context, params paginat
 	paginationResp := pagination.BuildResponseFromFilterResult(result, params)
 
 	return result.Items, paginationResp, counts, nil
+}
+
+func (s *VolumeService) downloadFileFromContainerInternal(
+	ctx context.Context,
+	dockerClient *client.Client,
+	containerID string,
+	containerPath string,
+	cleanup func(),
+) (io.ReadCloser, int64, error) {
+	copyResult, err := dockerClient.CopyFromContainer(ctx, containerID, client.CopyFromContainerOptions{
+		SourcePath: containerPath,
+	})
+	if err != nil {
+		cleanup()
+		return nil, 0, fmt.Errorf("failed to download: %w", err)
+	}
+	reader := copyResult.Content
+
+	tr := tar.NewReader(reader)
+	hdr, err := tr.Next()
+	if err != nil {
+		_ = reader.Close()
+		cleanup()
+		return nil, 0, fmt.Errorf("failed to read tar stream: %w", err)
+	}
+	if hdr.FileInfo().IsDir() {
+		_ = reader.Close()
+		cleanup()
+		return nil, 0, fmt.Errorf("path is a directory")
+	}
+
+	return &cleanupReadCloser{
+		Reader:  tr,
+		Closer:  reader,
+		cleanup: cleanup,
+	}, hdr.Size, nil
 }

--- a/backend/internal/services/volume_service_test.go
+++ b/backend/internal/services/volume_service_test.go
@@ -1,10 +1,13 @@
 package services
 
 import (
+	"context"
 	"testing"
 
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
+	volumetypes "github.com/getarcaneapp/arcane/types/volume"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/volume"
 	"github.com/stretchr/testify/require"
 )
@@ -108,6 +111,224 @@ func TestEnrichVolumesWithUsageDataInternal(t *testing.T) {
 			got := svc.enrichVolumesWithUsageDataInternal(tt.volumes, tt.usageVolumes)
 			require.Len(t, got, tt.wantLen)
 			tt.assertions(t, got)
+		})
+	}
+}
+
+func TestIsInternalVolumeInternal(t *testing.T) {
+	svc := &VolumeService{backupVolumeName: "arcane-backups"}
+
+	require.True(t, svc.isInternalVolumeInternal(volumetypes.Volume{Name: "arcane-backups"}))
+	require.False(t, svc.isInternalVolumeInternal(volumetypes.Volume{Name: "user-volume"}))
+}
+
+func TestResolveBackupStorageMountFromMountsInternal(t *testing.T) {
+	tests := []struct {
+		name         string
+		mounts       []container.MountPoint
+		target       string
+		readOnly     bool
+		wantResolved bool
+		wantMode     backupStorageMode
+		wantType     mount.Type
+		wantSource   string
+		wantTarget   string
+		wantReadOnly bool
+		wantEnsure   bool
+	}{
+		{
+			name: "mirrors bind mount",
+			mounts: []container.MountPoint{
+				{Type: mount.TypeBind, Source: "/host/backups", Destination: "/backups"},
+			},
+			target:       "/volume",
+			readOnly:     true,
+			wantResolved: true,
+			wantMode:     backupStorageModeArcaneMount,
+			wantType:     mount.TypeBind,
+			wantSource:   "/host/backups",
+			wantTarget:   "/volume",
+			wantReadOnly: true,
+		},
+		{
+			name: "writable request against read-only bind mount still resolves",
+			mounts: []container.MountPoint{
+				{Type: mount.TypeBind, Source: "/host/backups", Destination: "/backups", RW: false},
+			},
+			target:       "/volume",
+			readOnly:     false,
+			wantResolved: true,
+			wantMode:     backupStorageModeArcaneMount,
+			wantType:     mount.TypeBind,
+			wantSource:   "/host/backups",
+			wantTarget:   "/volume",
+			wantReadOnly: false,
+		},
+		{
+			name: "mirrors named volume",
+			mounts: []container.MountPoint{
+				{Type: mount.TypeVolume, Name: "arcane-backups", Destination: "/backups"},
+			},
+			target:       "/backups",
+			readOnly:     false,
+			wantResolved: true,
+			wantMode:     backupStorageModeArcaneMount,
+			wantType:     mount.TypeVolume,
+			wantSource:   "arcane-backups",
+			wantTarget:   "/backups",
+			wantReadOnly: false,
+		},
+		{
+			name: "ignores unsupported mount types",
+			mounts: []container.MountPoint{
+				{Type: mount.TypeTmpfs, Destination: "/backups"},
+			},
+			target:       "/backups",
+			readOnly:     true,
+			wantResolved: false,
+		},
+		{
+			name:         "returns unresolved when mount is absent",
+			target:       "/backups",
+			readOnly:     true,
+			wantResolved: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := resolveBackupStorageMountFromMountsInternal(tt.mounts, tt.target, tt.readOnly)
+			require.Equal(t, tt.wantResolved, ok)
+			if !tt.wantResolved {
+				return
+			}
+
+			require.Equal(t, tt.wantMode, got.mode)
+			require.Equal(t, tt.wantType, got.mount.Type)
+			require.Equal(t, tt.wantSource, got.mount.Source)
+			require.Equal(t, tt.wantTarget, got.mount.Target)
+			require.Equal(t, tt.wantReadOnly, got.mount.ReadOnly)
+			require.Equal(t, tt.wantEnsure, got.requiresEnsure)
+		})
+	}
+}
+
+func TestResolveBackupStorageMountInternalFallsBackToNamedVolume(t *testing.T) {
+	svc := &VolumeService{backupVolumeName: "arcane-backups"}
+
+	got, err := svc.resolveBackupStorageMountInternal(context.Background(), nil, "/backups", true)
+	require.NoError(t, err)
+	require.Equal(t, backupStorageModeNamedVolumeFallback, got.mode)
+	require.Equal(t, mount.TypeVolume, got.mount.Type)
+	require.Equal(t, "arcane-backups", got.mount.Source)
+	require.Equal(t, "/backups", got.mount.Target)
+	require.True(t, got.mount.ReadOnly)
+	require.True(t, got.requiresEnsure)
+}
+
+func TestBackupMountWarningForStorageInternal(t *testing.T) {
+	require.Empty(t, backupMountWarningForStorageInternal(backupStorageMountInternal{mode: backupStorageModeArcaneMount}))
+	require.Equal(t, backupMountMissingWarning, backupMountWarningForStorageInternal(backupStorageMountInternal{mode: backupStorageModeNamedVolumeFallback}))
+}
+
+func TestBackupMountWarningFromArcaneMountsInternal(t *testing.T) {
+	tests := []struct {
+		name   string
+		mounts []container.MountPoint
+		want   string
+	}{
+		{
+			name: "bind mount at backups suppresses warning",
+			mounts: []container.MountPoint{
+				{Type: mount.TypeBind, Source: "/host/backups", Destination: "/backups"},
+			},
+			want: "",
+		},
+		{
+			name: "named volume at backups suppresses warning",
+			mounts: []container.MountPoint{
+				{Type: mount.TypeVolume, Name: "arcane-backups", Destination: "/backups"},
+			},
+			want: "",
+		},
+		{
+			name: "bind mount at restores suppresses warning",
+			mounts: []container.MountPoint{
+				{Type: mount.TypeBind, Source: "/host/restores", Destination: "/restores"},
+			},
+			want: "",
+		},
+		{
+			name: "unsupported restores mount still suppresses warning for compatibility",
+			mounts: []container.MountPoint{
+				{Type: mount.TypeTmpfs, Destination: "/restores"},
+			},
+			want: "",
+		},
+		{
+			name: "missing backups mount warns",
+			mounts: []container.MountPoint{
+				{Type: mount.TypeBind, Source: "/host/other", Destination: "/other"},
+			},
+			want: backupMountMissingWarning,
+		},
+		{
+			name: "unsupported backups mount type warns",
+			mounts: []container.MountPoint{
+				{Type: mount.TypeTmpfs, Destination: "/backups"},
+			},
+			want: backupMountMissingWarning,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, backupMountWarningFromArcaneMountsInternal(tt.mounts))
+		})
+	}
+}
+
+func TestBackupArchiveFilenameInternal(t *testing.T) {
+	svc := &VolumeService{}
+
+	tests := []struct {
+		name     string
+		backupID string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "valid backup id",
+			backupID: "volume-123-abc",
+			want:     "volume-123-abc.tar.gz",
+		},
+		{
+			name:     "trims surrounding whitespace",
+			backupID: "  volume-123-abc  ",
+			want:     "volume-123-abc.tar.gz",
+		},
+		{
+			name:     "rejects traversal attempts",
+			backupID: "../../bin/busybox",
+			wantErr:  true,
+		},
+		{
+			name:     "rejects path separators",
+			backupID: "nested/path",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := svc.backupArchiveFilenameInternal(tt.backupID)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/backend/internal/utils/docker/mount_utils_test.go
+++ b/backend/internal/utils/docker/mount_utils_test.go
@@ -1,0 +1,83 @@
+package docker
+
+import (
+	"testing"
+
+	containertypes "github.com/moby/moby/api/types/container"
+	mounttypes "github.com/moby/moby/api/types/mount"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMountForDestination(t *testing.T) {
+	tests := []struct {
+		name       string
+		mounts     []containertypes.MountPoint
+		dest       string
+		target     string
+		wantNil    bool
+		wantType   mounttypes.Type
+		wantSource string
+		wantTarget string
+		wantRO     bool
+	}{
+		{
+			name: "returns bind mount",
+			mounts: []containertypes.MountPoint{
+				{Type: mounttypes.TypeBind, Source: "/host/backups", Destination: "/backups", RW: true},
+			},
+			dest:       "/backups",
+			target:     "/volume",
+			wantType:   mounttypes.TypeBind,
+			wantSource: "/host/backups",
+			wantTarget: "/volume",
+			wantRO:     false,
+		},
+		{
+			name: "returns named volume mount",
+			mounts: []containertypes.MountPoint{
+				{Type: mounttypes.TypeVolume, Name: "arcane-backups", Destination: "/backups", RW: false},
+			},
+			dest:       "/backups",
+			target:     "/restores",
+			wantType:   mounttypes.TypeVolume,
+			wantSource: "arcane-backups",
+			wantTarget: "/restores",
+			wantRO:     true,
+		},
+		{
+			name: "defaults target to destination",
+			mounts: []containertypes.MountPoint{
+				{Type: mounttypes.TypeBind, Source: "/host/backups", Destination: "/backups", RW: true},
+			},
+			dest:       "/backups",
+			wantType:   mounttypes.TypeBind,
+			wantSource: "/host/backups",
+			wantTarget: "/backups",
+			wantRO:     false,
+		},
+		{
+			name: "ignores unsupported mount types",
+			mounts: []containertypes.MountPoint{
+				{Type: mounttypes.TypeTmpfs, Destination: "/backups"},
+			},
+			dest:    "/backups",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MountForDestination(tt.mounts, tt.dest, tt.target)
+			if tt.wantNil {
+				require.Nil(t, got)
+				return
+			}
+
+			require.NotNil(t, got)
+			require.Equal(t, tt.wantType, got.Type)
+			require.Equal(t, tt.wantSource, got.Source)
+			require.Equal(t, tt.wantTarget, got.Target)
+			require.Equal(t, tt.wantRO, got.ReadOnly)
+		})
+	}
+}


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1642

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements persistent volume backup mount support by teaching the backup/restore pipeline to mirror the Arcane container's own `/backups` mount (bind or named volume) into every helper container it spawns, rather than always falling back to an internal named volume.

Key changes:
- New `resolveBackupStorageMountInternal` / `resolveUsableBackupStorageMountInternal` flow: inspects the Arcane container at runtime, mirrors its `/backups` mount into helper containers; falls back to the named `backupVolumeName` volume when running outside Docker or when the container has no usable `/backups` mount.
- `backupArchiveFilenameInternal` + `sanitizeBackupIDInternal` introduced to sanitize user-supplied `backupID` values before constructing container paths — addresses path-traversal concerns in `DownloadBackup`, `DeleteBackup`, `BackupHasPath`, `ListBackupFiles`, and `RestoreBackupFiles`.
- `buildHelperHostConfigInternal` extended with a `mounts []mount.Mount` parameter so Docker typed-mount specs (bind mounts, named volumes) can be passed alongside legacy bind strings.
- **Behavioral change**: The `/restores` mount check has been removed from `BackupMountWarning`, which is a user-visible regression for anyone who previously relied on mounting only `/restores` to suppress the warning.
- **Naming clarity**: The mode `backupStorageModeArcaneMount` intentionally covers both host bind mounts and named volumes at `/backups`, which may create confusion about whether backups are externally persisted.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Mergeable with caution — the core mount-mirroring logic is sound and well-tested, but the silent removal of the `/restores` warning check is a user-visible behavioral regression that should be explicitly acknowledged in release notes.
- The implementation is solid and path-traversal vulnerabilities are properly mitigated through sanitization. The main risk is the undocumented behavioral change in `BackupMountWarning`: users who previously silenced the warning by mounting only `/restores` will now see persistent warnings after upgrade, which could cause confusion. The `backupStorageModeArcaneMount` naming ambiguity is a clarity concern but does not cause runtime issues. These are not blocking issues but should be communicated to users.
- backend/internal/services/volume_service.go — specifically the `BackupMountWarning` behavioral change and the `backupStorageModeArcaneMount` classification logic.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CreateBackup / RestoreBackup / DownloadBackup / DeleteBackup / etc.] --> B[resolveUsableBackupStorageMountInternal]
    B --> C[resolveBackupStorageMountInternal]
    C --> D{dockerClient != nil?}
    D -- No --> F[Named Volume Fallback]
    D -- Yes --> E[getArcaneContainerIDInternal]
    E --> G{containerID found?}
    G -- No --> F
    G -- Yes --> H[ContainerInspect]
    H --> I{Inspect OK?}
    I -- No --> F[Named Volume Fallback<br/>requiresEnsure=true<br/>mode=named_volume_fallback]
    I -- Yes --> J[resolveBackupStorageMountFromMountsInternal]
    J --> K[MountForDestination<br/>mounts, /backups, target]
    K --> L{Mount found?<br/>TypeVolume or TypeBind?}
    L -- No --> F
    L -- Yes --> M[Mirror mount<br/>mode=arcane_mount<br/>requiresEnsure=false]
    M --> N[createBackupTempContainerWithMountInternal]
    F --> O{requiresEnsure?}
    O -- Yes --> P[ensureBackupVolumeInternal]
    P --> N
    O -- No --> N
    N --> Q[Helper container with<br/>backupMount at target path]
```
</details>


<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Finternal%2Fservices%2Fvolume_service.go%3A488-506%0A**%60%2Frestores%60%20mount%20no%20longer%20suppresses%20the%20warning**%0A%0AThe%20%60BackupMountWarning%60%20function%20only%20checks%20for%20a%20%60%2Fbackups%60%20mount%20%28via%20%60resolveBackupStorageMountFromMountsInternal%60%20on%20line%20480%29%2C%20whereas%20the%20previous%20implementation%20also%20accepted%20%60%2Frestores%60%20mounts%20as%20valid%20to%20suppress%20the%20warning.%0A%0AAny%20user%20who%20previously%20silenced%20this%20warning%20by%20mounting%20a%20host%20path%20at%20%60%2Frestores%60%20%28without%20%60%2Fbackups%60%29%20will%20now%20see%20a%20persistent%2C%20unexpected%20warning%20after%20this%20update.%20This%20is%20a%20user-visible%20behavioral%20regression.%0A%0AIf%20dropping%20%60%2Frestores%60%20support%20is%20intentional%2C%20this%20change%20should%20be%20documented%20in%20migration%20notes.%20If%20%60%2Frestores%60%20should%20still%20suppress%20the%20warning%2C%20extend%20the%20check%20to%20include%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Finternal%2Fservices%2Fvolume_service.go%3A49-56%0A**Named%20Docker%20volumes%20classified%20as%20%60backupStorageModeArcaneMount%60**%0A%0AWhen%20the%20Arcane%20container%20has%20a%20named%20volume%20%28e.g.%20%60arcane-backups%60%29%20mounted%20at%20%60%2Fbackups%60%2C%20%60resolveBackupStorageMountFromMountsInternal%60%20returns%20mode%20%60backupStorageModeArcaneMount%60.%20The%20mode%20name%20implies%20a%20persistent%20host%20bind%20mount%2C%20but%20it%20also%20applies%20to%20internal%20named%20volumes.%0A%0AThis%20means%20%60backupMountWarningForStorageInternal%60%20suppresses%20the%20warning%20whenever%20ANY%20mount%20exists%20at%20%60%2Fbackups%60%E2%80%94whether%20host-persisted%20or%20just%20Docker's%20default%20volume%E2%80%94which%20may%20mislead%20users%20into%20thinking%20their%20backups%20persist%20externally%20when%20they%20do%20not.%0A%0AConsider%20documenting%20that%20%60backupStorageModeArcaneMount%60%20intentionally%20covers%20%22any%20mount%20the%20Arcane%20container%20already%20has%20at%20%60%2Fbackups%60%22%2C%20not%20exclusively%20bind%20mounts%2C%20to%20prevent%20future%20misunderstandings.%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<sub>Last reviewed commit: b4f53a0</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - GoLang Best Practices

---
description: 'Instructions for writing Go code following idiomatic Go pra... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->