### PR TITLE
feat: add jwt refresh interval variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,8 @@ PGID=1000
 # IMPORTANT: Generate unique values for production!
 ENCRYPTION_KEY=your-32-char-encryption-key-here
 JWT_SECRET=your-super-secret-jwt-key-change-this
+# JWT refresh token expiry duration (default: 168h = 7 days). Accepts Go duration format (e.g., 72h, 720h, 8760h).
+# JWT_REFRESH_EXPIRY=168h
 
 # Database Configuration
 DATABASE_URL=file:data/arcane.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(2500)&_txlock=immediate

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -27,16 +27,17 @@ const (
 // Fields with `options:"file"` support Docker secrets via the _FILE suffix.
 // Available options: file, toLower, trimTrailingSlash
 type Config struct {
-	AppUrl        string         `env:"APP_URL" default:"http://localhost:3552"`
-	DatabaseURL   string         `env:"DATABASE_URL" default:"file:data/arcane.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(2500)&_txlock=immediate" options:"file"`
-	Port          string         `env:"PORT" default:"3552"`
-	Listen        string         `env:"LISTEN" default:""`
-	TLSEnabled    bool           `env:"TLS_ENABLED" default:"false"`
-	TLSCertFile   string         `env:"TLS_CERT_FILE" default:""`
-	TLSKeyFile    string         `env:"TLS_KEY_FILE" default:""`
-	Environment   AppEnvironment `env:"ENVIRONMENT" default:"production"`
-	JWTSecret     string         `env:"JWT_SECRET" default:"default-jwt-secret-change-me" options:"file"` //nolint:gosec // configuration field name is part of stable config API
-	EncryptionKey string         `env:"ENCRYPTION_KEY" default:"arcane-dev-key-32-characters!!!" options:"file"`
+	AppUrl           string         `env:"APP_URL" default:"http://localhost:3552"`
+	DatabaseURL      string         `env:"DATABASE_URL" default:"file:data/arcane.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(2500)&_txlock=immediate" options:"file"`
+	Port             string         `env:"PORT" default:"3552"`
+	Listen           string         `env:"LISTEN" default:""`
+	TLSEnabled       bool           `env:"TLS_ENABLED" default:"false"`
+	TLSCertFile      string         `env:"TLS_CERT_FILE" default:""`
+	TLSKeyFile       string         `env:"TLS_KEY_FILE" default:""`
+	Environment      AppEnvironment `env:"ENVIRONMENT" default:"production"`
+	JWTSecret        string         `env:"JWT_SECRET" default:"default-jwt-secret-change-me" options:"file"` //nolint:gosec // configuration field name is part of stable config API
+	JWTRefreshExpiry time.Duration  `env:"JWT_REFRESH_EXPIRY" default:"168h"`
+	EncryptionKey    string         `env:"ENCRYPTION_KEY" default:"arcane-dev-key-32-characters!!!" options:"file"`
 
 	OidcEnabled                bool   `env:"OIDC_ENABLED" default:"false"`
 	OidcClientID               string `env:"OIDC_CLIENT_ID" default:"" options:"file"`
@@ -123,7 +124,7 @@ func loadFromEnv(cfg *Config) {
 			envValue = defaultValue
 		}
 
-		setFieldValue(field, envValue)
+		setFieldValueInternal(field, fieldType, envValue)
 	})
 }
 
@@ -241,8 +242,8 @@ func resolveFileBasedEnvVariable(field reflect.Value, fieldType reflect.StructFi
 	}
 }
 
-// setFieldValue sets a reflect.Value from a string based on the field's type.
-func setFieldValue(field reflect.Value, value string) {
+// setFieldValueInternal sets a reflect.Value from a string based on the field's type.
+func setFieldValueInternal(field reflect.Value, fieldType reflect.StructField, value string) {
 	if !field.CanSet() {
 		return
 	}
@@ -270,6 +271,37 @@ func setFieldValue(field reflect.Value, value string) {
 	if field.Kind() == reflect.Int {
 		if i, err := strconv.Atoi(value); err == nil {
 			field.SetInt(int64(i))
+		}
+		return
+	}
+
+	if field.Type() == reflect.TypeFor[time.Duration]() {
+		applyDurationDefault := func(reason string) {
+			envTag := fieldType.Tag.Get("env")
+			defaultValue := fieldType.Tag.Get("default")
+
+			if fallback, fallbackErr := time.ParseDuration(defaultValue); fallbackErr == nil {
+				slog.Warn(reason+", using tagged default",
+					"field", envTag,
+					"value", value,
+					"default", defaultValue)
+				field.SetInt(int64(fallback))
+			} else {
+				slog.Warn(reason+", and invalid tagged default",
+					"field", envTag,
+					"value", value,
+					"default", defaultValue)
+			}
+		}
+
+		if d, err := time.ParseDuration(value); err == nil {
+			if d > 0 {
+				field.SetInt(int64(d))
+			} else {
+				applyDurationDefault("Non-positive duration for config field")
+			}
+		} else {
+			applyDurationDefault("Invalid duration for config field")
 		}
 		return
 	}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -3,7 +3,9 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/getarcaneapp/arcane/backend/internal/common"
 	"github.com/stretchr/testify/assert"
@@ -351,6 +353,69 @@ func TestConfig_GetManagerBaseURL(t *testing.T) {
 		}
 		assert.Equal(t, "https://manager.example.com/arcane", cfg.GetManagerBaseURL())
 	})
+}
+
+func TestConfig_JWTRefreshExpiry(t *testing.T) {
+	origJWTRefreshExpiry := os.Getenv("JWT_REFRESH_EXPIRY")
+	defer restoreEnv("JWT_REFRESH_EXPIRY", origJWTRefreshExpiry)
+
+	t.Run("defaults to 7 days when not set", func(t *testing.T) {
+		unsetEnv(t, "JWT_REFRESH_EXPIRY")
+
+		cfg := Load()
+		assert.Equal(t, 7*24*time.Hour, cfg.JWTRefreshExpiry)
+	})
+
+	t.Run("parses custom duration from env var", func(t *testing.T) {
+		setEnv(t, "JWT_REFRESH_EXPIRY", "48h")
+
+		cfg := Load()
+		assert.Equal(t, 48*time.Hour, cfg.JWTRefreshExpiry)
+	})
+
+	t.Run("supports compound duration format", func(t *testing.T) {
+		setEnv(t, "JWT_REFRESH_EXPIRY", "24h30m")
+
+		cfg := Load()
+		assert.Equal(t, 24*time.Hour+30*time.Minute, cfg.JWTRefreshExpiry)
+	})
+
+	t.Run("falls back to default on invalid duration", func(t *testing.T) {
+		setEnv(t, "JWT_REFRESH_EXPIRY", "notaduration")
+
+		cfg := Load()
+		assert.Equal(t, 168*time.Hour, cfg.JWTRefreshExpiry)
+	})
+
+	t.Run("falls back to default on zero duration", func(t *testing.T) {
+		setEnv(t, "JWT_REFRESH_EXPIRY", "0s")
+
+		cfg := Load()
+		assert.Equal(t, 168*time.Hour, cfg.JWTRefreshExpiry)
+	})
+
+	t.Run("falls back to default on negative duration", func(t *testing.T) {
+		setEnv(t, "JWT_REFRESH_EXPIRY", "-1h")
+
+		cfg := Load()
+		assert.Equal(t, 168*time.Hour, cfg.JWTRefreshExpiry)
+	})
+}
+
+func TestSetFieldValueInternal_DurationUsesFieldTagDefault(t *testing.T) {
+	type durationConfig struct {
+		SessionTimeout time.Duration `env:"SESSION_TIMEOUT" default:"2h"`
+	}
+
+	cfg := &durationConfig{}
+	v := reflect.ValueOf(cfg).Elem()
+	field := v.FieldByName("SessionTimeout")
+	fieldType, ok := v.Type().FieldByName("SessionTimeout")
+	require.True(t, ok)
+
+	setFieldValueInternal(field, fieldType, "invalid-duration")
+
+	assert.Equal(t, 2*time.Hour, cfg.SessionTimeout)
 }
 
 func restoreEnv(key, value string) {

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -64,7 +64,7 @@ func NewAuthService(userService *UserService, settingsService *SettingsService, 
 		settingsService: settingsService,
 		eventService:    eventService,
 		jwtSecret:       crypto.CheckOrGenerateJwtSecret(jwtSecret),
-		refreshExpiry:   7 * 24 * time.Hour,
+		refreshExpiry:   cfg.JWTRefreshExpiry,
 		config:          cfg,
 	}
 }


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1950

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds JWT refresh token expiry duration configurability via the `JWT_REFRESH_EXPIRY` environment variable, replacing the previously hardcoded `7 * 24 * time.Hour` value.

**Key Implementation Details:**
- Adds `JWTRefreshExpiry time.Duration` to Config struct with `default:"168h"` tag
- Extends `setFieldValueInternal` with robust `time.Duration` handling: validates parsed values, rejects non-positive durations, logs warnings with the invalid supplied value, and falls back to the field's own struct-tag default
- Uses a reusable `applyDurationDefault` closure to avoid duplication across error branches and to support future `time.Duration` config fields without hardcoding
- Wires `cfg.JWTRefreshExpiry` into `NewAuthService`, cleanly replacing the hardcoded literal
- Adds comprehensive test coverage: 6 subtests for default/custom/compound/invalid/zero/negative cases, plus a unit test verifying generic tag-based fallback
- Documents the option in `.env.example` with clear guidance on accepted Go duration format

All edge cases are properly handled and tested. The fallback logic uses the field's own struct tag rather than any hardcoded value, making the implementation safe for future `time.Duration` config additions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge. The change is well-bounded, backward-compatible, and all edge cases are covered by tests.
- The implementation is clean and idiomatic. All six edge cases (default, custom, compound, invalid, zero, negative) are explicitly tested. The fallback logic uses the struct-tag default rather than any hardcoded value, making it safe for future `time.Duration` config additions. The rename to `setFieldValueInternal` is consistently applied across definition and both call sites. No regressions to existing field parsing (string, bool, uint32, int, custom types) are introduced.
- No files require special attention.
</details>

<sub>Last reviewed commit: e29e95d</sub>

<!-- /greptile_comment -->