### PR TITLE
fix: inconsistient behavior with pull and redeploy button via project table

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/getarcaneapp/arcane/types v1.15.3
 	github.com/go-viper/mapstructure/v2 v2.5.0
+	github.com/mattn/go-runewidth v0.0.20
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -37,7 +38,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.20 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect

--- a/frontend/src/routes/(app)/projects/projects-table.actions.ts
+++ b/frontend/src/routes/(app)/projects/projects-table.actions.ts
@@ -1,0 +1,266 @@
+import { openConfirmDialog } from '$lib/components/confirm-dialog';
+import { m } from '$lib/paraglide/messages';
+import { deployOptionsStore } from '$lib/stores/deploy-options.store.svelte';
+import { gitOpsSyncService } from '$lib/services/gitops-sync-service';
+import { projectService } from '$lib/services/project-service';
+import type { SearchPaginationSortRequest } from '$lib/types/pagination.type';
+import { handleApiResultWithCallbacks } from '$lib/utils/api.util';
+import { tryCatch } from '$lib/utils/try-catch';
+import { toast } from 'svelte-sonner';
+import type { ActionStatus } from './projects-table.helpers';
+
+type BulkLoadingState = {
+	up: boolean;
+	down: boolean;
+	redeploy: boolean;
+};
+
+type ActionDeps = {
+	getRequestOptions: () => SearchPaginationSortRequest;
+	refreshProjects: (options?: SearchPaginationSortRequest) => Promise<void>;
+	setSelectedIds: (next: string[]) => void;
+	actionStatus: Record<string, ActionStatus>;
+	isBulkLoading: BulkLoadingState;
+	getEnvId: () => string | undefined;
+};
+
+type ProjectActionKind = 'start' | 'stop' | 'restart' | 'redeploy';
+
+type ProjectActionConfig = {
+	status: ActionStatus;
+	run: (id: string) => Promise<unknown>;
+	success: () => string;
+	failure: () => string;
+};
+
+type BulkActionConfig = {
+	title: (count: number) => string;
+	message: (count: number) => string;
+	label: string;
+	loadingKey: keyof BulkLoadingState;
+	run: (id: string) => Promise<unknown>;
+	success: (count: number) => string;
+	partial: (success: number, total: number, failed: number) => string;
+	failure: () => string;
+	destructive?: boolean;
+};
+
+type DestroyConfirmResult = {
+	checkboxes?: {
+		volumes?: boolean;
+		files?: boolean;
+	};
+	volumes?: boolean;
+	files?: boolean;
+};
+
+type ProjectActions = {
+	performProjectAction: (action: ProjectActionKind, id: string) => Promise<void>;
+	handleDestroyProject: (id: string) => Promise<void>;
+	handleSyncFromGit: (projectId: string, gitOpsSyncId: string) => Promise<void>;
+	handleBulkUp: (ids: string[]) => Promise<void>;
+	handleBulkDown: (ids: string[]) => Promise<void>;
+	handleBulkRedeploy: (ids: string[]) => Promise<void>;
+};
+
+const projectActionConfigs: Record<ProjectActionKind, ProjectActionConfig> = {
+	start: {
+		status: 'starting',
+		run: (id) => projectService.deployProject(id, deployOptionsStore.getRequestOptions()),
+		success: () => m.compose_start_success(),
+		failure: () => m.compose_start_failed()
+	},
+	stop: {
+		status: 'stopping',
+		run: (id) => projectService.downProject(id),
+		success: () => m.compose_stop_success(),
+		failure: () => m.compose_stop_failed()
+	},
+	restart: {
+		status: 'restarting',
+		run: (id) => projectService.restartProject(id),
+		success: () => m.compose_restart_success(),
+		failure: () => m.compose_restart_failed()
+	},
+	redeploy: {
+		status: 'redeploying',
+		run: (id) => projectService.redeployProject(id),
+		success: () => m.compose_pull_success(),
+		failure: () => m.compose_pull_failed()
+	}
+};
+
+export function createProjectActions({
+	getRequestOptions,
+	refreshProjects,
+	setSelectedIds,
+	actionStatus,
+	isBulkLoading,
+	getEnvId
+}: ActionDeps): ProjectActions {
+	async function performProjectAction(action: ProjectActionKind, id: string): Promise<void> {
+		const config = projectActionConfigs[action];
+		actionStatus[id] = config.status;
+
+		try {
+			await handleApiResultWithCallbacks({
+				result: await tryCatch(config.run(id)),
+				message: config.failure(),
+				setLoadingState: (value) => {
+					actionStatus[id] = value ? config.status : '';
+				},
+				onSuccess: async () => {
+					toast.success(config.success());
+					await refreshProjects();
+				}
+			});
+		} catch (error) {
+			toast.error(m.common_action_failed());
+			actionStatus[id] = '';
+		}
+	}
+
+	async function handleDestroyProject(id: string): Promise<void> {
+		openConfirmDialog({
+			title: m.common_confirm_removal_title(),
+			message: m.compose_confirm_removal_message(),
+			checkboxes: [
+				{
+					id: 'volumes',
+					label: m.confirm_remove_volumes_warning(),
+					initialState: false
+				},
+				{
+					id: 'files',
+					label: m.confirm_remove_project_files(),
+					initialState: false
+				}
+			],
+			confirm: {
+				label: m.compose_destroy(),
+				destructive: true,
+				action: async (result: DestroyConfirmResult) => {
+					const removeVolumes = !!(result?.checkboxes?.volumes ?? result?.volumes);
+					const removeFiles = !!(result?.checkboxes?.files ?? result?.files);
+					actionStatus[id] = 'destroying';
+
+					await handleApiResultWithCallbacks({
+						result: await tryCatch(projectService.destroyProject(id, removeVolumes, removeFiles)),
+						message: m.compose_destroy_failed(),
+						setLoadingState: (value) => {
+							actionStatus[id] = value ? 'destroying' : '';
+						},
+						onSuccess: async () => {
+							toast.success(m.compose_destroy_success());
+							await refreshProjects();
+						}
+					});
+				}
+			}
+		});
+	}
+
+	async function handleSyncFromGit(projectId: string, gitOpsSyncId: string): Promise<void> {
+		const envId = getEnvId();
+		if (!envId) return;
+
+		actionStatus[projectId] = 'syncing';
+		const result = await tryCatch(gitOpsSyncService.performSync(envId, gitOpsSyncId));
+
+		await handleApiResultWithCallbacks({
+			result,
+			message: m.git_sync_failed(),
+			setLoadingState: (value) => {
+				actionStatus[projectId] = value ? 'syncing' : '';
+			},
+			onSuccess: async () => {
+				toast.success(m.git_sync_success());
+				await refreshProjects();
+			}
+		});
+	}
+
+	async function runBulkAction(ids: string[], config: BulkActionConfig): Promise<void> {
+		if (!ids || ids.length === 0) return;
+
+		openConfirmDialog({
+			title: config.title(ids.length),
+			message: config.message(ids.length),
+			confirm: {
+				label: config.label,
+				destructive: config.destructive ?? false,
+				action: async () => {
+					isBulkLoading[config.loadingKey] = true;
+
+					try {
+						const results = await Promise.allSettled(ids.map((id) => config.run(id)));
+
+						const successCount = results.filter((result) => result.status === 'fulfilled').length;
+						const failureCount = results.length - successCount;
+
+						if (successCount === ids.length) {
+							toast.success(config.success(successCount));
+						} else if (successCount > 0) {
+							toast.warning(config.partial(successCount, ids.length, failureCount));
+						} else {
+							toast.error(config.failure());
+						}
+
+						await refreshProjects(getRequestOptions());
+						setSelectedIds([]);
+					} finally {
+						isBulkLoading[config.loadingKey] = false;
+					}
+				}
+			}
+		});
+	}
+
+	async function handleBulkUp(ids: string[]): Promise<void> {
+		await runBulkAction(ids, {
+			title: (count) => m.projects_bulk_up_confirm_title({ count }),
+			message: (count) => m.projects_bulk_up_confirm_message({ count }),
+			label: m.common_up(),
+			loadingKey: 'up',
+			run: (id) => projectService.deployProject(id, deployOptionsStore.getRequestOptions()),
+			success: (count) => m.projects_bulk_up_success({ count }),
+			partial: (success, total, failed) => m.projects_bulk_up_partial({ success, total, failed }),
+			failure: () => m.compose_start_failed()
+		});
+	}
+
+	async function handleBulkDown(ids: string[]): Promise<void> {
+		await runBulkAction(ids, {
+			title: (count) => m.projects_bulk_down_confirm_title({ count }),
+			message: (count) => m.projects_bulk_down_confirm_message({ count }),
+			label: m.common_down(),
+			loadingKey: 'down',
+			run: (id) => projectService.downProject(id),
+			success: (count) => m.projects_bulk_down_success({ count }),
+			partial: (success, total, failed) => m.projects_bulk_down_partial({ success, total, failed }),
+			failure: () => m.compose_stop_failed()
+		});
+	}
+
+	async function handleBulkRedeploy(ids: string[]): Promise<void> {
+		await runBulkAction(ids, {
+			title: (count) => m.projects_bulk_redeploy_confirm_title({ count }),
+			message: (count) => m.projects_bulk_redeploy_confirm_message({ count }),
+			label: m.compose_pull_redeploy(),
+			loadingKey: 'redeploy',
+			run: (id) => projectService.redeployProject(id),
+			success: (count) => m.projects_bulk_redeploy_success({ count }),
+			partial: (success, total, failed) => m.projects_bulk_redeploy_partial({ success, total, failed }),
+			failure: () => m.compose_pull_failed()
+		});
+	}
+
+	return {
+		performProjectAction,
+		handleDestroyProject,
+		handleSyncFromGit,
+		handleBulkUp,
+		handleBulkDown,
+		handleBulkRedeploy
+	};
+}

--- a/frontend/src/routes/(app)/projects/projects-table.helpers.ts
+++ b/frontend/src/routes/(app)/projects/projects-table.helpers.ts
@@ -1,0 +1,1 @@
+export type ActionStatus = 'starting' | 'stopping' | 'restarting' | 'redeploying' | 'destroying' | 'syncing' | '';

--- a/frontend/src/routes/(app)/projects/projects-table.svelte
+++ b/frontend/src/routes/(app)/projects/projects-table.svelte
@@ -6,11 +6,7 @@
 	import { EditIcon, StartIcon, RestartIcon, StopIcon, TrashIcon, RedeployIcon, EllipsisIcon } from '$lib/icons';
 	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import { goto } from '$app/navigation';
-	import { toast } from 'svelte-sonner';
-	import { openConfirmDialog } from '$lib/components/confirm-dialog';
 	import StatusBadge from '$lib/components/badges/status-badge.svelte';
-	import { handleApiResultWithCallbacks } from '$lib/utils/api.util';
-	import { tryCatch } from '$lib/utils/try-catch';
 	import type { Paginated, SearchPaginationSortRequest } from '$lib/types/pagination.type';
 	import { getStatusVariant } from '$lib/utils/status.utils';
 	import { capitalizeFirstLetter } from '$lib/utils/string.utils';
@@ -19,11 +15,11 @@
 	import { UniversalMobileCard } from '$lib/components/arcane-table';
 	import { m } from '$lib/paraglide/messages';
 	import { projectService } from '$lib/services/project-service';
-	import { deployOptionsStore } from '$lib/stores/deploy-options.store.svelte';
-	import { gitOpsSyncService } from '$lib/services/gitops-sync-service';
 	import { FolderOpenIcon, LayersIcon, CalendarIcon, ProjectsIcon, GitBranchIcon, RefreshIcon } from '$lib/icons';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import IconImage from '$lib/components/icon-image.svelte';
+	import type { ActionStatus } from './projects-table.helpers';
+	import { createProjectActions } from './projects-table.actions';
 
 	let {
 		projects = $bindable(),
@@ -37,16 +33,7 @@
 		onRefreshData?: (options: SearchPaginationSortRequest) => Promise<void>;
 	} = $props();
 
-	let isLoading = $state({
-		start: false,
-		stop: false,
-		restart: false,
-		remove: false,
-		destroy: false,
-		pull: false,
-		updating: false,
-		syncing: false
-	});
+	let actionStatus = $state<Record<string, ActionStatus>>({});
 
 	let isBulkLoading = $state({
 		up: false,
@@ -66,211 +53,23 @@
 		return project.status.toLowerCase() === 'unknown' && project.statusReason ? project.statusReason : undefined;
 	}
 
-	async function performProjectAction(action: string, id: string) {
-		isLoading[action as keyof typeof isLoading] = true;
+	let mobileFieldVisibility = $state<Record<string, boolean>>({});
+	const envId = $derived(environmentStore.selected?.id);
 
-		try {
-			if (action === 'start') {
-				handleApiResultWithCallbacks({
-					result: await tryCatch(projectService.deployProject(id, deployOptionsStore.getRequestOptions())),
-					message: m.compose_start_failed(),
-					setLoadingState: (value) => (isLoading.start = value),
-					onSuccess: async () => {
-						toast.success(m.compose_start_success());
-						await refreshProjects();
-					}
-				});
-			} else if (action === 'stop') {
-				handleApiResultWithCallbacks({
-					result: await tryCatch(projectService.downProject(id)),
-					message: m.compose_stop_failed(),
-					setLoadingState: (value) => (isLoading.stop = value),
-					onSuccess: async () => {
-						toast.success(m.compose_stop_success());
-						await refreshProjects();
-					}
-				});
-			} else if (action === 'restart') {
-				handleApiResultWithCallbacks({
-					result: await tryCatch(projectService.restartProject(id)),
-					message: m.compose_restart_failed(),
-					setLoadingState: (value) => (isLoading.restart = value),
-					onSuccess: async () => {
-						toast.success(m.compose_restart_success());
-						await refreshProjects();
-					}
-				});
-			} else if (action === 'redeploy') {
-				handleApiResultWithCallbacks({
-					result: await tryCatch(projectService.redeployProject(id)),
-					message: m.compose_pull_failed(),
-					setLoadingState: (value) => (isLoading.pull = value),
-					onSuccess: async () => {
-						toast.success(m.compose_pull_success());
-						await refreshProjects();
-					}
-				});
-			} else if (action === 'destroy') {
-				openConfirmDialog({
-					title: m.common_confirm_removal_title(),
-					message: m.compose_confirm_removal_message(),
-					checkboxes: [
-						{
-							id: 'volumes',
-							label: m.confirm_remove_volumes_warning(),
-							initialState: false
-						},
-						{
-							id: 'files',
-							label: m.confirm_remove_project_files(),
-							initialState: false
-						}
-					],
-					confirm: {
-						label: m.compose_destroy(),
-						destructive: true,
-						action: async (result: any) => {
-							const removeVolumes = !!(result?.checkboxes?.volumes ?? result?.volumes);
-							const removeFiles = !!(result?.checkboxes?.files ?? result?.files);
-
-							handleApiResultWithCallbacks({
-								result: await tryCatch(projectService.destroyProject(id, removeVolumes, removeFiles)),
-								message: m.compose_destroy_failed(),
-								setLoadingState: (value) => (isLoading.destroy = value),
-								onSuccess: async () => {
-									toast.success(m.compose_destroy_success());
-									await refreshProjects();
-								}
-							});
-						}
-					}
-				});
-			}
-		} catch (error) {
-			toast.error(m.common_action_failed());
-		}
-	}
-
-	async function handleSyncFromGit(gitOpsSyncId: string) {
-		if (!envId) return;
-		isLoading.syncing = true;
-		const result = await tryCatch(gitOpsSyncService.performSync(envId, gitOpsSyncId));
-		handleApiResultWithCallbacks({
-			result,
-			message: m.git_sync_failed(),
-			setLoadingState: (value) => (isLoading.syncing = value),
-			onSuccess: async () => {
-				toast.success(m.git_sync_success());
-				await refreshProjects();
-			}
+	const { performProjectAction, handleDestroyProject, handleSyncFromGit, handleBulkUp, handleBulkDown, handleBulkRedeploy } =
+		createProjectActions({
+			getRequestOptions: () => requestOptions,
+			refreshProjects,
+			setSelectedIds: (next) => {
+				selectedIds = next;
+			},
+			actionStatus,
+			isBulkLoading,
+			getEnvId: () => envId
 		});
-	}
-
-	async function handleBulkUp(ids: string[]) {
-		if (!ids || ids.length === 0) return;
-
-		openConfirmDialog({
-			title: m.projects_bulk_up_confirm_title({ count: ids.length }),
-			message: m.projects_bulk_up_confirm_message({ count: ids.length }),
-			confirm: {
-				label: m.common_up(),
-				destructive: false,
-				action: async () => {
-					isBulkLoading.up = true;
-
-					const deployOptions = deployOptionsStore.getRequestOptions();
-					const results = await Promise.allSettled(ids.map((id) => projectService.deployProject(id, deployOptions)));
-
-					const successCount = results.filter((r) => r.status === 'fulfilled').length;
-					const failureCount = results.length - successCount;
-
-					isBulkLoading.up = false;
-
-					if (successCount === ids.length) {
-						toast.success(m.projects_bulk_up_success({ count: successCount }));
-					} else if (successCount > 0) {
-						toast.warning(m.projects_bulk_up_partial({ success: successCount, total: ids.length, failed: failureCount }));
-					} else {
-						toast.error(m.compose_start_failed());
-					}
-
-					await refreshProjects();
-					selectedIds = [];
-				}
-			}
-		});
-	}
-
-	async function handleBulkDown(ids: string[]) {
-		if (!ids || ids.length === 0) return;
-
-		openConfirmDialog({
-			title: m.projects_bulk_down_confirm_title({ count: ids.length }),
-			message: m.projects_bulk_down_confirm_message({ count: ids.length }),
-			confirm: {
-				label: m.common_down(),
-				destructive: false,
-				action: async () => {
-					isBulkLoading.down = true;
-
-					const results = await Promise.allSettled(ids.map((id) => projectService.downProject(id)));
-
-					const successCount = results.filter((r) => r.status === 'fulfilled').length;
-					const failureCount = results.length - successCount;
-
-					isBulkLoading.down = false;
-
-					if (successCount === ids.length) {
-						toast.success(m.projects_bulk_down_success({ count: successCount }));
-					} else if (successCount > 0) {
-						toast.warning(m.projects_bulk_down_partial({ success: successCount, total: ids.length, failed: failureCount }));
-					} else {
-						toast.error(m.compose_stop_failed());
-					}
-
-					await refreshProjects();
-					selectedIds = [];
-				}
-			}
-		});
-	}
-
-	async function handleBulkRedeploy(ids: string[]) {
-		if (!ids || ids.length === 0) return;
-
-		openConfirmDialog({
-			title: m.projects_bulk_redeploy_confirm_title({ count: ids.length }),
-			message: m.projects_bulk_redeploy_confirm_message({ count: ids.length }),
-			confirm: {
-				label: m.compose_pull_redeploy(),
-				destructive: false,
-				action: async () => {
-					isBulkLoading.redeploy = true;
-
-					const results = await Promise.allSettled(ids.map((id) => projectService.redeployProject(id)));
-
-					const successCount = results.filter((r) => r.status === 'fulfilled').length;
-					const failureCount = results.length - successCount;
-
-					isBulkLoading.redeploy = false;
-
-					if (successCount === ids.length) {
-						toast.success(m.projects_bulk_redeploy_success({ count: successCount }));
-					} else if (successCount > 0) {
-						toast.warning(m.projects_bulk_redeploy_partial({ success: successCount, total: ids.length, failed: failureCount }));
-					} else {
-						toast.error(m.compose_pull_failed());
-					}
-
-					await refreshProjects();
-					selectedIds = [];
-				}
-			}
-		});
-	}
 
 	const isAnyLoading = $derived(
-		Object.values(isLoading).some((loading) => loading) || Object.values(isBulkLoading).some((loading) => loading)
+		Object.values(actionStatus).some((status) => status !== '') || Object.values(isBulkLoading).some((loading) => loading)
 	);
 
 	const columns = [
@@ -319,9 +118,6 @@
 			icon: RedeployIcon
 		}
 	]);
-
-	let mobileFieldVisibility = $state<Record<string, boolean>>({});
-	const envId = $derived(environmentStore.selected?.id);
 </script>
 
 {#snippet NameCell({ item }: { item: Project })}
@@ -429,6 +225,7 @@
 {/snippet}
 
 {#snippet RowActions({ item }: { item: Project })}
+	{@const status = actionStatus[item.id]}
 	<DropdownMenu.Root>
 		<DropdownMenu.Trigger>
 			{#snippet child({ props })}
@@ -447,10 +244,10 @@
 
 				{#if item.gitOpsManagedBy}
 					<DropdownMenu.Item
-						onclick={() => handleSyncFromGit(item.gitOpsManagedBy!)}
-						disabled={isLoading.syncing || isAnyLoading}
+						onclick={() => handleSyncFromGit(item.id, item.gitOpsManagedBy!)}
+						disabled={status === 'syncing' || isAnyLoading}
 					>
-						{#if isLoading.syncing}
+						{#if status === 'syncing'}
 							<Spinner class="size-4" />
 						{:else}
 							<RefreshIcon class="size-4" />
@@ -462,8 +259,11 @@
 				<DropdownMenu.Separator />
 
 				{#if item.status !== 'running'}
-					<DropdownMenu.Item onclick={() => performProjectAction('start', item.id)} disabled={isLoading.start || isAnyLoading}>
-						{#if isLoading.start}
+					<DropdownMenu.Item
+						onclick={() => performProjectAction('start', item.id)}
+						disabled={status === 'starting' || isAnyLoading}
+					>
+						{#if status === 'starting'}
 							<Spinner class="size-4" />
 						{:else}
 							<StartIcon class="size-4" />
@@ -471,8 +271,11 @@
 						{m.common_up()}
 					</DropdownMenu.Item>
 				{:else}
-					<DropdownMenu.Item onclick={() => performProjectAction('stop', item.id)} disabled={isLoading.stop || isAnyLoading}>
-						{#if isLoading.stop}
+					<DropdownMenu.Item
+						onclick={() => performProjectAction('stop', item.id)}
+						disabled={status === 'stopping' || isAnyLoading}
+					>
+						{#if status === 'stopping'}
 							<Spinner class="size-4" />
 						{:else}
 							<StopIcon class="size-4" />
@@ -482,9 +285,9 @@
 
 					<DropdownMenu.Item
 						onclick={() => performProjectAction('restart', item.id)}
-						disabled={isLoading.restart || isAnyLoading}
+						disabled={status === 'restarting' || isAnyLoading}
 					>
-						{#if isLoading.restart}
+						{#if status === 'restarting'}
 							<Spinner class="size-4" />
 						{:else}
 							<RestartIcon class="size-4" />
@@ -493,8 +296,11 @@
 					</DropdownMenu.Item>
 				{/if}
 
-				<DropdownMenu.Item onclick={() => performProjectAction('redeploy', item.id)} disabled={isLoading.pull || isAnyLoading}>
-					{#if isLoading.pull}
+				<DropdownMenu.Item
+					onclick={() => performProjectAction('redeploy', item.id)}
+					disabled={status === 'redeploying' || isAnyLoading}
+				>
+					{#if status === 'redeploying'}
 						<Spinner class="size-4" />
 					{:else}
 						<RedeployIcon class="size-4" />
@@ -506,10 +312,10 @@
 
 				<DropdownMenu.Item
 					variant="destructive"
-					onclick={() => performProjectAction('destroy', item.id)}
-					disabled={isLoading.remove || isAnyLoading}
+					onclick={() => handleDestroyProject(item.id)}
+					disabled={status === 'destroying' || isAnyLoading}
 				>
-					{#if isLoading.remove}
+					{#if status === 'destroying'}
 						<Spinner class="size-4" />
 					{:else}
 						<TrashIcon class="size-4" />


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1794

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the inconsistent loading/disabled-button behavior in the project table by replacing the shared `isLoading` state object (which applied a single spinner and disabled state across **all** rows when any one action was running) with a per-project `actionStatus` record keyed by project ID. Action logic has been extracted into a new `createProjectActions` factory (`projects-table.actions.ts`) and a shared type file (`projects-table.helpers.ts`), keeping the Svelte component focused on presentation.

**Key changes:**
- `projects-table.svelte`: Swaps `let isLoading = $state({...})` for `let actionStatus = $state<Record<string, ActionStatus>>({})`, so spinners and disabled states are now scoped to the specific row being acted on. Bulk loading state is unchanged.
- `projects-table.actions.ts`: New file housing `performProjectAction`, `handleDestroyProject`, `handleSyncFromGit`, and the three bulk-action handlers. The bulk-action `runBulkAction` now correctly uses a `try/finally` block, ensuring `isBulkLoading` is always cleared — an improvement over the original code.
- **Issue**: In `performProjectAction` (line 86) and `handleSyncFromGit` (line 152), `handleApiResultWithCallbacks` is an `async` function but is called without `await`. This makes the surrounding `try/catch` dead code and leaves async errors unguarded.
- `cli/go.mod`: Promotes `github.com/mattn/go-runewidth` from indirect to direct — appears unrelated to the frontend change.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- The core fix is correct and well-structured, but the missing `await` on `handleApiResultWithCallbacks` in two places creates dead error-handling code that should be addressed before merging.
- The per-project loading state refactor correctly solves the reported bug, and the bulk-action `finally` cleanup is an improvement. The missing `await` on the async utility in `performProjectAction` and `handleSyncFromGit` means the `catch` blocks are unreachable — errors from those async flows would not surface the intended error toast, and the intended `actionStatus` reset in the `catch` would never fire. In practice `handleApiResultWithCallbacks` guards its own errors internally, so there is no observable regression today, but the pattern is fragile and misleading.
- `frontend/src/routes/(app)/projects/projects-table.actions.ts` — the two missing `await` calls on `handleApiResultWithCallbacks`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/routes/(app)/projects/projects-table.actions.ts | New file extracting all project action logic; contains two instances where `handleApiResultWithCallbacks` (an async function) is called without `await`, making the surrounding `try/catch` unreachable dead code and risking unhandled promise rejections. |
| frontend/src/routes/(app)/projects/projects-table.helpers.ts | Simple new file exporting the `ActionStatus` union type; correct and safe. |
| frontend/src/routes/(app)/projects/projects-table.svelte | Refactored to use per-project `actionStatus` keyed by project ID instead of a shared global loading state, correctly fixing the inconsistent spinner/disabled-button behavior across rows; delegates action logic to the new `createProjectActions` factory. |
| cli/go.mod | Promotes `github.com/mattn/go-runewidth` from an indirect to a direct dependency; unrelated to the frontend fix (discussed in a previous review thread). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Svelte as projects-table.svelte
    participant Actions as createProjectActions
    participant API as projectService / gitOpsSyncService
    participant UI as Toast / Dialog

    User->>Svelte: Click action button (e.g. Redeploy)
    Svelte->>Actions: performProjectAction('redeploy', id)
    Actions->>Actions: actionStatus[id] = 'redeploying'
    Actions->>API: tryCatch(config.run(id))
    API-->>Actions: Result<T, Error>
    Actions->>Actions: handleApiResultWithCallbacks(result) [NOT awaited]
    Actions-->>Svelte: returns (loading still shown via actionStatus)
    Note over Actions: async continues in background
    Actions->>UI: setLoadingState(true) → actionStatus[id] = 'redeploying'
    alt Success
        Actions->>UI: toast.success(...)
        Actions->>Svelte: refreshProjects()
    else Error
        Actions->>UI: toast.error(message)
    end
    Actions->>Actions: finally: setLoadingState(false) → actionStatus[id] = ''
    Svelte->>Svelte: isAnyLoading re-derived → buttons re-enabled

    User->>Svelte: Click Bulk Up (multiple projects)
    Svelte->>Actions: handleBulkUp(ids)
    Actions->>UI: openConfirmDialog(...)
    User->>UI: Confirm
    UI->>Actions: action callback
    Actions->>Actions: isBulkLoading.up = true
    Actions->>API: Promise.allSettled(ids.map deployProject)
    API-->>Actions: results[]
    Actions->>UI: toast (success / partial / error)
    Actions->>Svelte: refreshProjects()
    Actions->>Svelte: setSelectedIds([])
    Actions->>Actions: finally: isBulkLoading.up = false
```
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fprojects%2Fprojects-table.actions.ts%3A83-96%0A**%60handleApiResultWithCallbacks%60%20not%20awaited%20%E2%80%94%20%60catch%60%20block%20is%20unreachable**%0A%0A%60handleApiResultWithCallbacks%60%20is%20declared%20%60async%60%20%28returning%20%60Promise%3Cvoid%3E%60%29%2C%20but%20the%20call%20on%20line%2086%20is%20not%20%60await%60-ed.%20Because%20of%20this%3A%0A%0A1.%20The%20%60try%2Fcatch%60%20block%20only%20guards%20synchronous%20throws.%20Since%20%60tryCatch%28%29%60%20never%20throws%20and%20%60handleApiResultWithCallbacks%60%20does%20not%20throw%20synchronously%2C%20the%20%60catch%60%20block%20on%20line%2093%20is%20**unreachable%20dead%20code**%20%E2%80%94%20%60actionStatus%5Bid%5D%20%3D%20''%60%20on%20line%2095%20will%20never%20execute%20through%20this%20path.%0A2.%20Any%20unhandled%20rejection%20inside%20the%20detached%20promise%20would%20propagate%20as%20an%20unhandled%20rejection%2C%20bypassing%20the%20intended%20error%20toast.%0A%0AThe%20same%20pattern%20appears%20in%20%60handleSyncFromGit%60%20%28line%20152%29.%0A%0A%60%60%60suggestion%0A%09%09try%20%7B%0A%09%09%09await%20handleApiResultWithCallbacks%28%7B%0A%09%09%09%09result%3A%20await%20tryCatch%28config.run%28id%29%29%2C%0A%09%09%09%09message%3A%20config.failure%28%29%2C%0A%09%09%09%09setLoadingState%3A%20%28value%29%20%3D%3E%20%7B%0A%09%09%09%09%09actionStatus%5Bid%5D%20%3D%20value%20%3F%20config.status%20%3A%20''%3B%0A%09%09%09%09%7D%2C%0A%09%09%09%09onSuccess%3A%20async%20%28%29%20%3D%3E%20%7B%0A%09%09%09%09%09toast.success%28config.success%28%29%29%3B%0A%09%09%09%09%09await%20refreshProjects%28%29%3B%0A%09%09%09%09%7D%0A%09%09%09%7D%29%3B%0A%09%09%7D%20catch%20%28error%29%20%7B%0A%09%09%09toast.error%28m.common_action_failed%28%29%29%3B%0A%09%09%09actionStatus%5Bid%5D%20%3D%20''%3B%0A%09%09%7D%0A%60%60%60%0A%0A**Context%20Used%3A**%20Rule%20from%20%60dashboard%60%20-%20JavaScript%2FTypeScript%20Best%20Practices%0A%0AUse%20const%2Flet%20instead%20of%20var%20for%20variable%20declarations%0APrefer%20...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D68c6ab5b-40de-4e3c-a803-95d60efb41a6%29%29%0A%0A%23%23%23%20Issue%202%20of%202%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fprojects%2Fprojects-table.actions.ts%3A147-161%0A**%60handleApiResultWithCallbacks%60%20not%20awaited%20in%20%60handleSyncFromGit%60**%0A%0ASame%20issue%20as%20in%20%60performProjectAction%60%3A%20%60handleApiResultWithCallbacks%60%20is%20%60async%60%20but%20is%20not%20awaited%20here.%20The%20loading%20state%20is%20cleared%20correctly%20through%20%60setLoadingState%28false%29%60%20in%20the%20utility's%20own%20%60finally%60%20block%2C%20but%20any%20error%20thrown%20asynchronously%20inside%20it%20will%20produce%20an%20unhandled%20promise%20rejection%20rather%20than%20being%20caught%20at%20the%20call%20site.%0A%0A%60%60%60suggestion%0A%09async%20function%20handleSyncFromGit%28projectId%3A%20string%2C%20gitOpsSyncId%3A%20string%29%3A%20Promise%3Cvoid%3E%20%7B%0A%09%09const%20envId%20%3D%20getEnvId%28%29%3B%0A%09%09if%20%28!envId%29%20return%3B%0A%0A%09%09actionStatus%5BprojectId%5D%20%3D%20'syncing'%3B%0A%09%09const%20result%20%3D%20await%20tryCatch%28gitOpsSyncService.performSync%28envId%2C%20gitOpsSyncId%29%29%3B%0A%0A%09%09await%20handleApiResultWithCallbacks%28%7B%0A%09%09%09result%2C%0A%09%09%09message%3A%20m.git_sync_failed%28%29%2C%0A%09%09%09setLoadingState%3A%20%28value%29%20%3D%3E%20%7B%0A%09%09%09%09actionStatus%5BprojectId%5D%20%3D%20value%20%3F%20'syncing'%20%3A%20''%3B%0A%09%09%09%7D%2C%0A%09%09%09onSuccess%3A%20async%20%28%29%20%3D%3E%20%7B%0A%09%09%09%09toast.success%28m.git_sync_success%28%29%29%3B%0A%09%09%09%09await%20refreshProjects%28%29%3B%0A%09%09%09%7D%0A%09%09%7D%29%3B%0A%09%7D%0A%60%60%60%0A%0A**Context%20Used%3A**%20Rule%20from%20%60dashboard%60%20-%20JavaScript%2FTypeScript%20Best%20Practices%0A%0AUse%20const%2Flet%20instead%20of%20var%20for%20variable%20declarations%0APrefer%20...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D68c6ab5b-40de-4e3c-a803-95d60efb41a6%29%29%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<sub>Last reviewed commit: 6afcff5</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule from `dashboard` - JavaScript/TypeScript Best Practices

Use const/let instead of var for variable declarations
Prefer ... ([source](https://app.greptile.com/review/custom-context?memory=68c6ab5b-40de-4e3c-a803-95d60efb41a6))

<!-- /greptile_comment -->