### PR TITLE
perf: share websocket streams, cache settings reads, and parallelize auto-heal inspections

### DIFF
--- a/backend/internal/api/ws_handler.go
+++ b/backend/internal/api/ws_handler.go
@@ -37,6 +37,7 @@ import (
 
 const (
 	gpuCacheDuration = 30 * time.Second
+	cgroupCacheTTL   = 30 * time.Second
 )
 
 // amdGPUSysfsPath is the base path for AMD GPU sysfs entries
@@ -156,9 +157,32 @@ type WebSocketHandler struct {
 	wsUpgrader        websocket.Upgrader
 	wsMetrics         *WebSocketMetrics
 	activeConnections sync.Map
+	logStreamsMu      sync.Mutex
+	logStreams        map[string]*wsLogStream
 	cpuCache          struct {
 		sync.RWMutex
 		value     float64
+		timestamp time.Time
+	}
+	systemStaticInfo struct {
+		once     sync.Once
+		cpuCount int
+		hostname string
+	}
+	systemStatsSampler struct {
+		stateMu     sync.RWMutex
+		latest      systemtypes.SystemStats
+		timestamp   time.Time
+		lifecycleMu sync.Mutex
+		clients     int
+		cancel      context.CancelFunc
+		ready       chan struct{}
+		running     bool
+	}
+	cgroupCache struct {
+		sync.RWMutex
+		value     *docker.CgroupLimits
+		detected  bool
 		timestamp time.Time
 	}
 	diskUsagePathCache struct {
@@ -177,13 +201,22 @@ type WebSocketHandler struct {
 	detectionMutex       sync.Mutex
 	gpuMonitoringEnabled bool
 	gpuType              string
+	projectLogStreamer   func(ctx context.Context, projectID string, logsChan chan<- string, follow bool, tail, since string, timestamps bool) error
+	containerLogStreamer func(ctx context.Context, containerID string, logsChan chan<- string, follow bool, tail, since string, timestamps bool) error
+	systemStatsCollector func(ctx context.Context) systemtypes.SystemStats
+	cpuUsageReader       func(interval time.Duration) (float64, bool)
+	cgroupLimitsDetector func() (*docker.CgroupLimits, error)
 }
 
 type wsLogStream struct {
-	hub    *ws.Hub
-	cancel context.CancelFunc
-	format string
-	seq    atomic.Uint64
+	hub             *ws.Hub
+	cancel          context.CancelFunc
+	firstSubscriber chan struct{}
+	format          string
+	key             string
+	refs            int
+	done            bool
+	seq             atomic.Uint64
 }
 
 func getContextUserIDInternal(c *gin.Context) string {
@@ -206,6 +239,98 @@ func buildWSConnectionInfoInternal(c *gin.Context, kind, resourceID string) syst
 	}
 }
 
+func buildLogStreamKeyInternal(envID, kind, resourceID, format string, batched, follow bool, tail, since string, timestamps bool) string {
+	return strings.Join([]string{
+		envID,
+		kind,
+		resourceID,
+		format,
+		strconv.FormatBool(batched),
+		strconv.FormatBool(follow),
+		tail,
+		since,
+		strconv.FormatBool(timestamps),
+	}, "|")
+}
+
+func (h *WebSocketHandler) streamProjectLogsInternal(ctx context.Context, projectID string, logsChan chan<- string, follow bool, tail, since string, timestamps bool) error {
+	if h.projectLogStreamer != nil {
+		return h.projectLogStreamer(ctx, projectID, logsChan, follow, tail, since, timestamps)
+	}
+	return h.projectService.StreamProjectLogs(ctx, projectID, logsChan, follow, tail, since, timestamps)
+}
+
+func (h *WebSocketHandler) streamContainerLogsInternal(ctx context.Context, containerID string, logsChan chan<- string, follow bool, tail, since string, timestamps bool) error {
+	if h.containerLogStreamer != nil {
+		return h.containerLogStreamer(ctx, containerID, logsChan, follow, tail, since, timestamps)
+	}
+	return h.containerService.StreamLogs(ctx, containerID, logsChan, follow, tail, since, timestamps)
+}
+
+func (h *WebSocketHandler) getOrCreateLogStreamInternal(key string, create func(onEmpty func(*wsLogStream)) *wsLogStream) *wsLogStream {
+	h.logStreamsMu.Lock()
+	defer h.logStreamsMu.Unlock()
+
+	if stream, ok := h.logStreams[key]; ok {
+		if !stream.done {
+			stream.refs++
+			return stream
+		}
+	}
+
+	stream := create(func(stream *wsLogStream) {
+		h.markLogStreamDoneInternal(key, stream)
+	})
+	stream.key = key
+	stream.refs = 1
+	h.logStreams[key] = stream
+	return stream
+}
+
+func takeLogStreamCancelInternal(stream *wsLogStream) context.CancelFunc {
+	cancel := stream.cancel
+	stream.cancel = nil
+	return cancel
+}
+
+func (h *WebSocketHandler) releaseLogStreamInternal(key string, stream *wsLogStream) {
+	var cancel context.CancelFunc
+
+	h.logStreamsMu.Lock()
+	if stream.refs > 0 {
+		stream.refs--
+	}
+	if stream.refs == 0 {
+		if current, ok := h.logStreams[key]; ok && current == stream {
+			delete(h.logStreams, key)
+		}
+		cancel = takeLogStreamCancelInternal(stream)
+	}
+	h.logStreamsMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (h *WebSocketHandler) markLogStreamDoneInternal(key string, stream *wsLogStream) {
+	var cancel context.CancelFunc
+
+	h.logStreamsMu.Lock()
+	stream.done = true
+	if stream.refs == 0 {
+		if current, ok := h.logStreams[key]; ok && current == stream {
+			delete(h.logStreams, key)
+		}
+		cancel = takeLogStreamCancelInternal(stream)
+	}
+	h.logStreamsMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+}
+
 func NewWebSocketHandler(
 	group *gin.RouterGroup,
 	projectService *services.ProjectService,
@@ -219,6 +344,7 @@ func NewWebSocketHandler(
 		containerService:     containerService,
 		systemService:        systemService,
 		wsMetrics:            defaultWebSocketMetrics,
+		logStreams:           make(map[string]*wsLogStream),
 		gpuMonitoringEnabled: cfg.GPUMonitoringEnabled,
 		gpuType:              cfg.GPUType,
 		wsUpgrader: websocket.Upgrader{
@@ -228,7 +354,6 @@ func NewWebSocketHandler(
 			EnableCompression: true,
 		},
 	}
-
 	wsGroup := group.Group("/environments/:id/ws")
 	wsGroup.Use(authMiddleware.WithAdminNotRequired().Add())
 	{
@@ -283,101 +408,162 @@ func (h *WebSocketHandler) ProjectLogs(c *gin.Context) {
 		return
 	}
 
-	connID := h.wsMetrics.RegisterConnection(buildWSConnectionInfoInternal(c, systemtypes.WSKindProjectLogs, projectID))
-	hub := h.startProjectLogHub(projectID, format, batched, follow, tail, since, timestamps, func() {
-		h.wsMetrics.UnregisterConnection(connID)
+	streamKey := buildLogStreamKeyInternal(c.Param("id"), systemtypes.WSKindProjectLogs, projectID, format, batched, follow, tail, since, timestamps)
+	stream := h.getOrCreateLogStreamInternal(streamKey, func(onEmpty func(*wsLogStream)) *wsLogStream {
+		return h.startProjectLogHub(streamKey, projectID, format, batched, follow, tail, since, timestamps, onEmpty)
 	})
+	connID := h.wsMetrics.RegisterConnection(buildWSConnectionInfoInternal(c, systemtypes.WSKindProjectLogs, projectID))
 	// WebSocket connections use context.Background() because they are long-lived and should not
 	// be tied to the HTTP request context. Cleanup is handled via the hub's OnEmpty callback
 	// which triggers when all clients disconnect.
-	ws.ServeClient(context.Background(), hub, conn)
+	ws.ServeClientWithOnRemove(context.Background(), stream.hub, conn, func() {
+		h.wsMetrics.UnregisterConnection(connID)
+		h.releaseLogStreamInternal(streamKey, stream)
+	})
 }
 
-func (h *WebSocketHandler) startProjectLogHub(projectID, format string, batched, follow bool, tail, since string, timestamps bool, onEmptyHook func()) *ws.Hub {
+func newWSLogStreamInternal(key, format string) (*wsLogStream, context.Context) {
 	ls := &wsLogStream{
-		hub:    ws.NewHub(1024),
-		format: format,
+		hub:             ws.NewHub(1024),
+		firstSubscriber: make(chan struct{}),
+		format:          format,
+		key:             key,
 	}
+	ls.hub.SetOnFirstClient(func() {
+		close(ls.firstSubscriber)
+	})
 
 	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel is intentionally retained and invoked by the hub OnEmpty callback.
 	ls.cancel = cancel
 
-	ls.hub.SetOnEmpty(func() {
-		if onEmptyHook != nil {
-			onEmptyHook()
-		}
-		slog.Debug("client disconnected, cleaning up project log hub", "projectID", projectID)
-		cancel()
-	})
-
 	go ls.hub.Run(ctx)
 
+	return ls, ctx
+}
+
+func (h *WebSocketHandler) startProjectLogSourceInternal(ctx context.Context, key, projectID, format string, follow bool, tail, since string, timestamps bool, ls *wsLogStream) <-chan string {
 	lines := make(chan string, 256)
-	go func(ctx context.Context) {
+
+	go func() {
 		defer close(lines)
-		if err := h.projectService.StreamProjectLogs(ctx, projectID, lines, follow, tail, since, timestamps); err != nil {
+		if !waitForLogStreamSubscriberInternal(ctx, ls.firstSubscriber) {
+			return
+		}
+
+		if err := h.streamProjectLogsInternal(ctx, projectID, lines, follow, tail, since, timestamps); err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return
 			}
 
-			slog.Warn("project log stream failed", "projectID", projectID, "error", err)
-
-			if format == "json" {
-				msg := ws.LogMessage{
-					Seq:       ls.seq.Add(1),
-					Level:     "error",
-					Message:   "Failed to stream project logs: " + err.Error(),
-					Service:   "arcane",
-					Timestamp: ws.NowRFC3339(),
-				}
-				if b, merr := json.Marshal(msg); merr == nil {
-					ls.hub.Broadcast(b)
-				}
-				return
-			}
-
-			ls.hub.Broadcast([]byte("Failed to stream project logs: " + err.Error()))
+			h.broadcastProjectLogStreamErrorInternal(projectID, format, err, ls)
+			h.markLogStreamDoneInternal(key, ls)
+			return
 		}
-	}(ctx)
+
+		if ctx.Err() == nil {
+			h.markLogStreamDoneInternal(key, ls)
+		}
+	}()
+
+	return lines
+}
+
+func waitForLogStreamSubscriberInternal(ctx context.Context, firstSubscriber <-chan struct{}) bool {
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-firstSubscriber:
+			return true
+		}
+	}
+}
+
+func (h *WebSocketHandler) broadcastProjectLogStreamErrorInternal(projectID, format string, err error, ls *wsLogStream) {
+	slog.Warn("project log stream failed", "projectID", projectID, "error", err)
 
 	if format == "json" {
-		msgs := make(chan ws.LogMessage, 256)
-		go func() {
-			defer close(msgs)
-			for line := range lines {
-				level, service, msg, ts := ws.NormalizeProjectLine(line)
-				seq := ls.seq.Add(1)
-				timestamp := ts
-				if timestamp == "" {
-					timestamp = ws.NowRFC3339()
-				}
-				msgs <- ws.LogMessage{
-					Seq:       seq,
-					Level:     level,
-					Message:   msg,
-					Service:   service,
-					Timestamp: timestamp,
-				}
-			}
-		}()
-		if batched {
-			go ws.ForwardLogJSONBatched(ctx, ls.hub, msgs, 50, 400*time.Millisecond)
-		} else {
-			go ws.ForwardLogJSON(ctx, ls.hub, msgs)
+		msg := ws.LogMessage{
+			Seq:       ls.seq.Add(1),
+			Level:     "error",
+			Message:   "Failed to stream project logs: " + err.Error(),
+			Service:   "arcane",
+			Timestamp: ws.NowRFC3339(),
 		}
-	} else {
-		cleanChan := make(chan string, 256)
-		go func() {
-			defer close(cleanChan)
-			for line := range lines {
-				_, _, msg, _ := ws.NormalizeProjectLine(line)
-				cleanChan <- msg
-			}
-		}()
-		go ws.ForwardLines(ctx, ls.hub, cleanChan)
+		if b, marshalErr := json.Marshal(msg); marshalErr == nil {
+			ls.hub.Broadcast(b)
+		}
+		return
 	}
 
-	return ls.hub
+	ls.hub.Broadcast([]byte("Failed to stream project logs: " + err.Error()))
+}
+
+func startProjectLogForwardersInternal(ctx context.Context, format string, batched bool, lines <-chan string, ls *wsLogStream) {
+	if format == "json" {
+		startProjectJSONForwarderInternal(ctx, batched, lines, ls)
+		return
+	}
+
+	startProjectTextForwarderInternal(ctx, lines, ls)
+}
+
+func startProjectJSONForwarderInternal(ctx context.Context, batched bool, lines <-chan string, ls *wsLogStream) {
+	msgs := make(chan ws.LogMessage, 256)
+	go func() {
+		defer close(msgs)
+		for line := range lines {
+			level, service, msg, ts := ws.NormalizeProjectLine(line)
+			seq := ls.seq.Add(1)
+			timestamp := ts
+			if timestamp == "" {
+				timestamp = ws.NowRFC3339()
+			}
+			msgs <- ws.LogMessage{
+				Seq:       seq,
+				Level:     level,
+				Message:   msg,
+				Service:   service,
+				Timestamp: timestamp,
+			}
+		}
+	}()
+
+	if batched {
+		go ws.ForwardLogJSONBatched(ctx, ls.hub, msgs, 50, 400*time.Millisecond)
+		return
+	}
+
+	go ws.ForwardLogJSON(ctx, ls.hub, msgs)
+}
+
+func startProjectTextForwarderInternal(ctx context.Context, lines <-chan string, ls *wsLogStream) {
+	cleanChan := make(chan string, 256)
+	go func() {
+		defer close(cleanChan)
+		for line := range lines {
+			_, _, msg, _ := ws.NormalizeProjectLine(line)
+			cleanChan <- msg
+		}
+	}()
+
+	go ws.ForwardLines(ctx, ls.hub, cleanChan)
+}
+
+func (h *WebSocketHandler) startProjectLogHub(key, projectID, format string, batched, follow bool, tail, since string, timestamps bool, onEmptyHook func(*wsLogStream)) *wsLogStream {
+	ls, ctx := newWSLogStreamInternal(key, format)
+
+	ls.hub.SetOnEmpty(func() {
+		if onEmptyHook != nil {
+			onEmptyHook(ls)
+		}
+		slog.Debug("client disconnected, cleaning up project log hub", "projectID", projectID)
+	})
+
+	lines := h.startProjectLogSourceInternal(ctx, key, projectID, format, follow, tail, since, timestamps, ls)
+	startProjectLogForwardersInternal(ctx, format, batched, lines, ls)
+
+	return ls
 }
 
 // ============================================================================
@@ -423,45 +609,49 @@ func (h *WebSocketHandler) ContainerLogs(c *gin.Context) {
 		return
 	}
 
-	connID := h.wsMetrics.RegisterConnection(buildWSConnectionInfoInternal(c, systemtypes.WSKindContainerLogs, containerID))
-	hub := h.startContainerLogHub(containerID, format, batched, follow, tail, since, timestamps, func() {
-		h.wsMetrics.UnregisterConnection(connID)
+	streamKey := buildLogStreamKeyInternal(c.Param("id"), systemtypes.WSKindContainerLogs, containerID, format, batched, follow, tail, since, timestamps)
+	stream := h.getOrCreateLogStreamInternal(streamKey, func(onEmpty func(*wsLogStream)) *wsLogStream {
+		return h.startContainerLogHub(streamKey, containerID, format, batched, follow, tail, since, timestamps, onEmpty)
 	})
+	connID := h.wsMetrics.RegisterConnection(buildWSConnectionInfoInternal(c, systemtypes.WSKindContainerLogs, containerID))
 	// WebSocket connections use context.Background() because they are long-lived and should not
 	// be tied to the HTTP request context. Cleanup is handled via the hub's OnEmpty callback
 	// which triggers when all clients disconnect.
-	ws.ServeClient(context.Background(), hub, conn)
+	ws.ServeClientWithOnRemove(context.Background(), stream.hub, conn, func() {
+		h.wsMetrics.UnregisterConnection(connID)
+		h.releaseLogStreamInternal(streamKey, stream)
+	})
 }
 
-func (h *WebSocketHandler) startContainerLogHub(containerID, format string, batched, follow bool, tail, since string, timestamps bool, onEmptyHook func()) *ws.Hub {
-	ls := &wsLogStream{
-		hub:    ws.NewHub(1024),
-		format: format,
-	}
-
-	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel is intentionally retained and invoked by the hub OnEmpty callback.
-	ls.cancel = cancel
+func (h *WebSocketHandler) startContainerLogHub(key, containerID, format string, batched, follow bool, tail, since string, timestamps bool, onEmptyHook func(*wsLogStream)) *wsLogStream {
+	ls, ctx := newWSLogStreamInternal(key, format)
 
 	ls.hub.SetOnEmpty(func() {
 		if onEmptyHook != nil {
-			onEmptyHook()
+			onEmptyHook(ls)
 		}
 		slog.Debug("client disconnected, cleaning up container log hub", "containerID", containerID)
-		cancel()
 	})
-
-	go ls.hub.Run(ctx)
 
 	lines := make(chan string, 256)
 	go func(ctx context.Context) {
 		defer close(lines)
-		if err := h.containerService.StreamLogs(ctx, containerID, lines, follow, tail, since, timestamps); err != nil {
+		if !waitForLogStreamSubscriberInternal(ctx, ls.firstSubscriber) {
+			return
+		}
+
+		if err := h.streamContainerLogsInternal(ctx, containerID, lines, follow, tail, since, timestamps); err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return
 			}
 
-			slog.Warn("container log stream failed", "containerID", containerID, "error", err)
-			broadcastContainerLogStreamErrorInternal(ls, err)
+			h.broadcastContainerLogStreamErrorInternal(containerID, format, err, ls)
+			h.markLogStreamDoneInternal(key, ls)
+			return
+		}
+
+		if ctx.Err() == nil {
+			h.markLogStreamDoneInternal(key, ls)
 		}
 	}(ctx)
 
@@ -493,29 +683,27 @@ func (h *WebSocketHandler) startContainerLogHub(containerID, format string, batc
 		go ws.ForwardLines(ctx, ls.hub, lines)
 	}
 
-	return ls.hub
+	return ls
 }
 
-func broadcastContainerLogStreamErrorInternal(stream *wsLogStream, err error) {
-	if stream == nil || stream.hub == nil || err == nil {
-		return
-	}
+func (h *WebSocketHandler) broadcastContainerLogStreamErrorInternal(containerID, format string, err error, ls *wsLogStream) {
+	slog.Warn("container log stream failed", "containerID", containerID, "error", err)
 
-	message := "Failed to stream container logs: " + err.Error()
-	if stream.format == "json" {
+	if format == "json" {
 		msg := ws.LogMessage{
-			Seq:       stream.seq.Add(1),
+			Seq:       ls.seq.Add(1),
 			Level:     "error",
-			Message:   message,
+			Message:   "Failed to stream container logs: " + err.Error(),
+			Service:   "arcane",
 			Timestamp: ws.NowRFC3339(),
 		}
 		if b, marshalErr := json.Marshal(msg); marshalErr == nil {
-			stream.hub.Broadcast(b)
+			ls.hub.Broadcast(b)
 		}
 		return
 	}
 
-	stream.hub.Broadcast([]byte(message))
+	ls.hub.Broadcast([]byte("Failed to stream container logs: " + err.Error()))
 }
 
 // ContainerStats streams container stats over WebSocket.
@@ -740,23 +928,115 @@ func (h *WebSocketHandler) releaseRateLimit(clientIP string, count *int32) {
 	}
 }
 
-// startCPUSampler starts a background goroutine that samples CPU usage.
-func (h *WebSocketHandler) startCPUSampler(ctx context.Context, ticker *time.Ticker) {
-	go func(ctx context.Context) {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				if vals, err := cpu.Percent(0, false); err == nil && len(vals) > 0 {
-					h.cpuCache.Lock()
-					h.cpuCache.value = vals[0]
-					h.cpuCache.timestamp = time.Now()
-					h.cpuCache.Unlock()
-				}
-			}
+func (h *WebSocketHandler) acquireSystemStatsSamplerInternal(ctx context.Context) bool {
+	h.systemStatsSampler.lifecycleMu.Lock()
+
+	h.systemStatsSampler.clients++
+	if h.systemStatsSampler.running {
+		ready := h.systemStatsSampler.ready
+		h.systemStatsSampler.lifecycleMu.Unlock()
+		return waitForSystemStatsSamplerReadyInternal(ctx, ready)
+	}
+
+	samplerCtx, cancel := context.WithCancel(context.WithoutCancel(ctx)) //nolint:gosec // cancel is intentionally retained in sampler state and invoked when the last subscriber disconnects.
+	ready := make(chan struct{})
+	h.systemStatsSampler.cancel = cancel
+	h.systemStatsSampler.ready = ready
+	h.systemStatsSampler.running = true
+	h.systemStatsSampler.lifecycleMu.Unlock()
+
+	go func() {
+		closeReady := sync.OnceFunc(func() {
+			close(ready)
+		})
+		if !h.initializeCPUCacheCtx(samplerCtx) {
+			closeReady()
+			return
 		}
-	}(ctx)
+		if samplerCtx.Err() != nil {
+			closeReady()
+			return
+		}
+
+		h.storeSystemStatsSnapshotInternal(h.collectSystemStatsSnapshotInternal(samplerCtx))
+		closeReady()
+		if samplerCtx.Err() != nil {
+			return
+		}
+
+		h.runSystemStatsSamplerInternal(samplerCtx)
+	}()
+
+	return waitForSystemStatsSamplerReadyInternal(ctx, ready)
+}
+
+func waitForSystemStatsSamplerReadyInternal(ctx context.Context, ready <-chan struct{}) bool {
+	if ready == nil {
+		return true
+	}
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-ready:
+		return ctx.Err() == nil
+	}
+}
+
+func (h *WebSocketHandler) releaseSystemStatsSamplerInternal() {
+	var cancel context.CancelFunc
+
+	h.systemStatsSampler.lifecycleMu.Lock()
+	if h.systemStatsSampler.clients > 0 {
+		h.systemStatsSampler.clients--
+	}
+	if h.systemStatsSampler.clients == 0 && h.systemStatsSampler.running {
+		cancel = h.systemStatsSampler.cancel
+		h.systemStatsSampler.cancel = nil
+		h.systemStatsSampler.ready = nil
+		h.systemStatsSampler.running = false
+	}
+	h.systemStatsSampler.lifecycleMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (h *WebSocketHandler) runSystemStatsSamplerInternal(ctx context.Context) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			h.updateCPUCacheInternal(0)
+			h.storeSystemStatsSnapshotInternal(h.collectSystemStatsSnapshotInternal(ctx))
+		}
+	}
+}
+
+func (h *WebSocketHandler) storeSystemStatsSnapshotInternal(stats systemtypes.SystemStats) {
+	h.systemStatsSampler.stateMu.Lock()
+	h.systemStatsSampler.latest = stats
+	h.systemStatsSampler.timestamp = time.Now()
+	h.systemStatsSampler.stateMu.Unlock()
+}
+
+func (h *WebSocketHandler) latestSystemStatsSnapshotInternal() systemtypes.SystemStats {
+	h.systemStatsSampler.stateMu.RLock()
+	stats := h.systemStatsSampler.latest
+	h.systemStatsSampler.stateMu.RUnlock()
+	return stats
+}
+
+func (h *WebSocketHandler) collectSystemStatsSnapshotInternal(ctx context.Context) systemtypes.SystemStats {
+	if h.systemStatsCollector != nil {
+		return h.systemStatsCollector(ctx)
+	}
+	return h.collectSystemStats(ctx)
 }
 
 // collectSystemStats gathers all system statistics.
@@ -789,11 +1069,26 @@ func (h *WebSocketHandler) collectSystemStats(ctx context.Context) systemtypes.S
 
 // getCPUCount returns the number of CPUs.
 func (h *WebSocketHandler) getCPUCount() int {
-	cpuCount, err := cpu.Counts(true)
-	if err != nil {
-		return runtime.NumCPU()
-	}
-	return cpuCount
+	h.initSystemStaticInfoInternal()
+	return h.systemStaticInfo.cpuCount
+}
+
+func (h *WebSocketHandler) initSystemStaticInfoInternal() {
+	h.systemStaticInfo.once.Do(func() {
+		cpuCount, err := cpu.Counts(true)
+		if err != nil {
+			cpuCount = runtime.NumCPU()
+		}
+
+		hostInfo, _ := host.Info()
+		hostname := ""
+		if hostInfo != nil {
+			hostname = hostInfo.Hostname
+		}
+
+		h.systemStaticInfo.cpuCount = cpuCount
+		h.systemStaticInfo.hostname = hostname
+	})
 }
 
 // getMemoryInfo returns memory usage and total.
@@ -807,8 +1102,8 @@ func (h *WebSocketHandler) getMemoryInfo() (uint64, uint64) {
 
 // applyCgroupLimits applies cgroup limits when running in a container.
 func (h *WebSocketHandler) applyCgroupLimits(cpuCount int, memUsed, memTotal uint64) (int, uint64, uint64) {
-	cgroupLimits, err := docker.DetectCgroupLimits()
-	if err != nil {
+	cgroupLimits := h.getCachedCgroupLimitsInternal()
+	if cgroupLimits == nil {
 		return cpuCount, memUsed, memTotal
 	}
 
@@ -844,11 +1139,8 @@ func (h *WebSocketHandler) getDiskInfo(ctx context.Context) (uint64, uint64) {
 
 // getHostname returns the system hostname.
 func (h *WebSocketHandler) getHostname() string {
-	hostInfo, _ := host.Info()
-	if hostInfo == nil {
-		return ""
-	}
-	return hostInfo.Hostname
+	h.initSystemStaticInfoInternal()
+	return h.systemStaticInfo.hostname
 }
 
 // getGPUInfo returns GPU statistics if monitoring is enabled.
@@ -863,14 +1155,100 @@ func (h *WebSocketHandler) getGPUInfo(ctx context.Context) ([]systemtypes.GPUSta
 	return gpuData, len(gpuData)
 }
 
-// initializeCPUCache performs initial CPU sampling.
-func (h *WebSocketHandler) initializeCPUCache() {
-	if vals, err := cpu.Percent(time.Second, false); err == nil && len(vals) > 0 {
-		h.cpuCache.Lock()
-		h.cpuCache.value = vals[0]
-		h.cpuCache.timestamp = time.Now()
-		h.cpuCache.Unlock()
+// initializeCPUCacheCtx performs initial CPU sampling and returns early if the sampler is canceled.
+func (h *WebSocketHandler) initializeCPUCacheCtx(ctx context.Context) bool {
+	result := make(chan float64, 1)
+
+	go func() {
+		if val, ok := h.readCPUUsageInternal(time.Second); ok {
+			result <- val
+		}
+		close(result)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case val, ok := <-result:
+		if !ok || ctx.Err() != nil {
+			return false
+		}
+		h.storeCPUCacheValueInternal(val)
+		return true
 	}
+}
+
+func (h *WebSocketHandler) updateCPUCacheInternal(interval time.Duration) {
+	if val, ok := h.readCPUUsageInternal(interval); ok {
+		h.storeCPUCacheValueInternal(val)
+	}
+}
+
+func (h *WebSocketHandler) readCPUUsageInternal(interval time.Duration) (float64, bool) {
+	if h.cpuUsageReader != nil {
+		return h.cpuUsageReader(interval)
+	}
+
+	return defaultReadCPUUsageInternal(interval)
+}
+
+var defaultReadCPUUsageInternal = func(interval time.Duration) (float64, bool) {
+	if vals, err := cpu.Percent(interval, false); err == nil && len(vals) > 0 {
+		return vals[0], true
+	}
+
+	return 0, false
+}
+
+func (h *WebSocketHandler) storeCPUCacheValueInternal(value float64) {
+	h.cpuCache.Lock()
+	h.cpuCache.value = value
+	h.cpuCache.timestamp = time.Now()
+	h.cpuCache.Unlock()
+}
+
+func (h *WebSocketHandler) getCachedCgroupLimitsInternal() *docker.CgroupLimits {
+	h.cgroupCache.RLock()
+	value := h.cgroupCache.value
+	detected := h.cgroupCache.detected
+	fresh := time.Since(h.cgroupCache.timestamp) < cgroupCacheTTL
+	h.cgroupCache.RUnlock()
+	if fresh {
+		if detected {
+			return value
+		}
+		return nil
+	}
+
+	h.cgroupCache.Lock()
+	defer h.cgroupCache.Unlock()
+
+	if time.Since(h.cgroupCache.timestamp) < cgroupCacheTTL {
+		if h.cgroupCache.detected {
+			return h.cgroupCache.value
+		}
+		return nil
+	}
+
+	detect := h.cgroupLimitsDetector
+	if detect == nil {
+		detect = docker.DetectCgroupLimits
+	}
+
+	limits, err := detect()
+	h.cgroupCache.timestamp = time.Now()
+	if err != nil {
+		h.cgroupCache.value = nil
+		h.cgroupCache.detected = false
+	} else {
+		h.cgroupCache.value = limits
+		h.cgroupCache.detected = true
+	}
+	if !h.cgroupCache.detected {
+		return nil
+	}
+
+	return h.cgroupCache.value
 }
 
 // SystemStats streams system stats over WebSocket.
@@ -924,23 +1302,21 @@ func (h *WebSocketHandler) SystemStats(c *gin.Context) {
 	pingTicker := time.NewTicker(statsPingPeriod)
 	defer pingTicker.Stop()
 
-	cpuUpdateTicker := time.NewTicker(1 * time.Second)
-	defer cpuUpdateTicker.Stop()
-
 	ctx, cancel := context.WithCancel(c.Request.Context())
 	defer cancel()
+	if !h.acquireSystemStatsSamplerInternal(ctx) {
+		h.releaseSystemStatsSamplerInternal()
+		return
+	}
+	defer h.releaseSystemStatsSamplerInternal()
 
 	go h.readSystemStatsPumpInternal(ctx, cancel, conn)
 
-	h.startCPUSampler(ctx, cpuUpdateTicker)
-
 	send := func() error {
-		stats := h.collectSystemStats(ctx)
+		stats := h.latestSystemStatsSnapshotInternal()
 		_ = conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 		return conn.WriteJSON(stats)
 	}
-
-	h.initializeCPUCache()
 
 	if err := send(); err != nil {
 		return

--- a/backend/internal/api/ws_handler_test.go
+++ b/backend/internal/api/ws_handler_test.go
@@ -1,15 +1,21 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	docker "github.com/getarcaneapp/arcane/backend/pkg/dockerutil"
 	ws "github.com/getarcaneapp/arcane/backend/pkg/libarcane/ws"
+	systemtypes "github.com/getarcaneapp/arcane/types/system"
+	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +35,8 @@ func TestBroadcastContainerLogStreamErrorInternal_JSON(t *testing.T) {
 		format: "json",
 	}
 
-	broadcastContainerLogStreamErrorInternal(stream, errors.New("boom"))
+	handler := newTestWebSocketHandler()
+	handler.broadcastContainerLogStreamErrorInternal("container-1", "json", errors.New("boom"), stream)
 
 	_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	_, payload, err := clientConn.ReadMessage()
@@ -58,7 +65,8 @@ func TestBroadcastContainerLogStreamErrorInternal_Text(t *testing.T) {
 		format: "text",
 	}
 
-	broadcastContainerLogStreamErrorInternal(stream, errors.New("boom"))
+	handler := newTestWebSocketHandler()
+	handler.broadcastContainerLogStreamErrorInternal("container-1", "text", errors.New("boom"), stream)
 
 	_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	_, payload, err := clientConn.ReadMessage()
@@ -93,4 +101,524 @@ func newTestWSPairInternal(t *testing.T) (clientConn *websocket.Conn, serverConn
 		_ = serverConn.Close()
 		server.Close()
 	}
+}
+
+func newTestWebSocketHandler() *WebSocketHandler {
+	return &WebSocketHandler{
+		wsMetrics:  NewWebSocketMetrics(),
+		logStreams: make(map[string]*wsLogStream),
+		wsUpgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool { return true },
+		},
+	}
+}
+
+func dialWebSocket(t *testing.T, serverURL, path string) *websocket.Conn {
+	t.Helper()
+
+	wsURL := "ws" + strings.TrimPrefix(serverURL, "http") + path
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+
+	return conn
+}
+
+func TestWebSocketHandler_ProjectLogs_SharedStreamPerTarget(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := newTestWebSocketHandler()
+	var starts atomic.Int32
+	var cancels atomic.Int32
+
+	handler.projectLogStreamer = func(ctx context.Context, projectID string, logsChan chan<- string, follow bool, tail, since string, timestamps bool) error {
+		starts.Add(1)
+		ticker := time.NewTicker(20 * time.Millisecond)
+		defer ticker.Stop()
+		defer cancels.Add(1)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-ticker.C:
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case logsChan <- "api | shared project log":
+				}
+			}
+		}
+	}
+
+	router := gin.New()
+	router.GET("/api/environments/:id/ws/projects/:projectId/logs", handler.ProjectLogs)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	conn1 := dialWebSocket(t, server.URL, "/api/environments/0/ws/projects/project-1/logs")
+	conn2 := dialWebSocket(t, server.URL, "/api/environments/0/ws/projects/project-1/logs")
+
+	_ = conn1.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, _, err := conn1.ReadMessage()
+	require.NoError(t, err)
+
+	_ = conn2.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, _, err = conn2.ReadMessage()
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return starts.Load() == 1
+	}, 2*time.Second, 20*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		handler.logStreamsMu.Lock()
+		defer handler.logStreamsMu.Unlock()
+		return len(handler.logStreams) == 1
+	}, time.Second, 20*time.Millisecond)
+
+	require.NoError(t, conn1.Close())
+
+	require.Eventually(t, func() bool {
+		handler.logStreamsMu.Lock()
+		defer handler.logStreamsMu.Unlock()
+		return len(handler.logStreams) == 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	handler.logStreamsMu.Lock()
+	activeAfterFirstClose := len(handler.logStreams)
+	handler.logStreamsMu.Unlock()
+	require.Equal(t, 1, activeAfterFirstClose)
+	require.Equal(t, int32(0), cancels.Load())
+
+	require.NoError(t, conn2.Close())
+
+	require.Eventually(t, func() bool {
+		handler.logStreamsMu.Lock()
+		defer handler.logStreamsMu.Unlock()
+		return len(handler.logStreams) == 0
+	}, 2*time.Second, 20*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return cancels.Load() == 1
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestWebSocketHandler_ProjectLogs_CompletedSourceStartsFreshStream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := newTestWebSocketHandler()
+	var starts atomic.Int32
+	firstDone := make(chan struct{})
+
+	handler.projectLogStreamer = func(ctx context.Context, projectID string, logsChan chan<- string, follow bool, tail, since string, timestamps bool) error {
+		call := starts.Add(1)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case logsChan <- "api | finite project log":
+		}
+		if call == 1 {
+			close(firstDone)
+		}
+		return nil
+	}
+
+	router := gin.New()
+	router.GET("/api/environments/:id/ws/projects/:projectId/logs", handler.ProjectLogs)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	path := "/api/environments/0/ws/projects/project-1/logs?follow=false"
+	conn1 := dialWebSocket(t, server.URL, path)
+	defer conn1.Close()
+
+	_ = conn1.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg1, err := conn1.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, "finite project log", string(msg1))
+
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first finite log stream did not complete")
+	}
+
+	conn2 := dialWebSocket(t, server.URL, path)
+	defer conn2.Close()
+
+	_ = conn2.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg2, err := conn2.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, "finite project log", string(msg2))
+
+	require.Eventually(t, func() bool {
+		return starts.Load() == 2
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestWebSocketHandler_ContainerLogs_BroadcastsStreamErrors(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := newTestWebSocketHandler()
+	handler.containerLogStreamer = func(ctx context.Context, containerID string, logsChan chan<- string, follow bool, tail, since string, timestamps bool) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case logsChan <- "api | container log":
+		}
+		return errors.New("stream failed")
+	}
+
+	router := gin.New()
+	router.GET("/api/environments/:id/ws/containers/:containerId/logs", handler.ContainerLogs)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	conn := dialWebSocket(t, server.URL, "/api/environments/0/ws/containers/container-1/logs")
+	defer conn.Close()
+
+	var got []string
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	require.NoError(t, err)
+	got = append(got, string(msg))
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err = conn.ReadMessage()
+	require.NoError(t, err)
+	got = append(got, string(msg))
+
+	require.ElementsMatch(t, []string{
+		"api | container log",
+		"Failed to stream container logs: stream failed",
+	}, got)
+}
+
+func TestWebSocketHandler_ContainerLogs_ErrorStartsFreshStreamForNewSubscribers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := newTestWebSocketHandler()
+	var starts atomic.Int32
+	handler.containerLogStreamer = func(ctx context.Context, containerID string, logsChan chan<- string, follow bool, tail, since string, timestamps bool) error {
+		starts.Add(1)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case logsChan <- "api | container log":
+		}
+		return errors.New("stream failed")
+	}
+
+	router := gin.New()
+	router.GET("/api/environments/:id/ws/containers/:containerId/logs", handler.ContainerLogs)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	path := "/api/environments/0/ws/containers/container-1/logs"
+	conn1 := dialWebSocket(t, server.URL, path)
+	defer conn1.Close()
+
+	got1 := make([]string, 0, 2)
+	for range 2 {
+		_ = conn1.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, msg, err := conn1.ReadMessage()
+		require.NoError(t, err)
+		got1 = append(got1, string(msg))
+	}
+	require.ElementsMatch(t, []string{
+		"api | container log",
+		"Failed to stream container logs: stream failed",
+	}, got1)
+
+	conn2 := dialWebSocket(t, server.URL, path)
+	defer conn2.Close()
+
+	got2 := make([]string, 0, 2)
+	for range 2 {
+		_ = conn2.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, msg, err := conn2.ReadMessage()
+		require.NoError(t, err)
+		got2 = append(got2, string(msg))
+	}
+	require.ElementsMatch(t, []string{
+		"api | container log",
+		"Failed to stream container logs: stream failed",
+	}, got2)
+
+	require.Eventually(t, func() bool {
+		return starts.Load() == 2
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestWebSocketHandler_SystemStats_UsesSharedSampler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := newTestWebSocketHandler()
+	var collects atomic.Int32
+
+	handler.systemStatsCollector = func(ctx context.Context) systemtypes.SystemStats {
+		n := collects.Add(1)
+		return systemtypes.SystemStats{
+			CPUUsage: float64(n),
+		}
+	}
+
+	router := gin.New()
+	router.GET("/api/environments/:id/ws/system/stats", handler.SystemStats)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	conn1 := dialWebSocket(t, server.URL, "/api/environments/0/ws/system/stats?interval=1")
+	conn2 := dialWebSocket(t, server.URL, "/api/environments/0/ws/system/stats?interval=1")
+
+	_ = conn1.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, _, err := conn1.ReadMessage()
+	require.NoError(t, err)
+
+	_ = conn2.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, _, err = conn2.ReadMessage()
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return collects.Load() >= 1
+	}, 2*time.Second, 50*time.Millisecond)
+
+	require.NoError(t, conn1.Close())
+	require.NoError(t, conn2.Close())
+
+	require.Eventually(t, func() bool {
+		handler.systemStatsSampler.lifecycleMu.Lock()
+		defer handler.systemStatsSampler.lifecycleMu.Unlock()
+		return !handler.systemStatsSampler.running && handler.systemStatsSampler.clients == 0
+	}, 2*time.Second, 20*time.Millisecond)
+
+	stoppedAt := collects.Load()
+	require.Never(t, func() bool {
+		return collects.Load() != stoppedAt
+	}, 1200*time.Millisecond, 100*time.Millisecond)
+}
+
+func TestWebSocketHandler_AcquireSystemStatsSampler_WaitsForInitialSnapshot(t *testing.T) {
+	handler := newTestWebSocketHandler()
+	handler.systemStatsCollector = func(ctx context.Context) systemtypes.SystemStats {
+		return systemtypes.SystemStats{CPUUsage: 42}
+	}
+
+	firstDone := make(chan struct{})
+	go func() {
+		handler.acquireSystemStatsSamplerInternal(context.Background())
+		close(firstDone)
+	}()
+
+	require.Eventually(t, func() bool {
+		handler.systemStatsSampler.lifecycleMu.Lock()
+		defer handler.systemStatsSampler.lifecycleMu.Unlock()
+		return handler.systemStatsSampler.running && handler.systemStatsSampler.ready != nil
+	}, 500*time.Millisecond, 10*time.Millisecond)
+
+	secondDone := make(chan struct{})
+	go func() {
+		handler.acquireSystemStatsSamplerInternal(context.Background())
+		close(secondDone)
+	}()
+
+	require.Never(t, func() bool {
+		select {
+		case <-secondDone:
+			return true
+		default:
+			return false
+		}
+	}, 200*time.Millisecond, 20*time.Millisecond)
+
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first sampler acquisition did not finish")
+	}
+
+	select {
+	case <-secondDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second sampler acquisition did not wait for readiness")
+	}
+
+	stats := handler.latestSystemStatsSnapshotInternal()
+	require.Equal(t, 42.0, stats.CPUUsage)
+
+	handler.releaseSystemStatsSamplerInternal()
+	handler.releaseSystemStatsSamplerInternal()
+
+	require.Eventually(t, func() bool {
+		handler.systemStatsSampler.lifecycleMu.Lock()
+		defer handler.systemStatsSampler.lifecycleMu.Unlock()
+		return !handler.systemStatsSampler.running && handler.systemStatsSampler.clients == 0 && handler.systemStatsSampler.ready == nil
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestWebSocketHandler_AcquireSystemStatsSampler_StopsWaitingWhenCallerCancels(t *testing.T) {
+	handler := newTestWebSocketHandler()
+
+	readyToCancel := make(chan struct{})
+	handler.systemStatsCollector = func(ctx context.Context) systemtypes.SystemStats {
+		return systemtypes.SystemStats{CPUUsage: 42}
+	}
+
+	handler.cpuUsageReader = func(interval time.Duration) (float64, bool) {
+		close(readyToCancel)
+		time.Sleep(200 * time.Millisecond)
+		return 42, true
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan bool, 1)
+	go func() {
+		done <- handler.acquireSystemStatsSamplerInternal(ctx)
+	}()
+
+	select {
+	case <-readyToCancel:
+	case <-time.After(time.Second):
+		t.Fatal("sampler did not start CPU initialization")
+	}
+
+	cancel()
+
+	select {
+	case ok := <-done:
+		require.False(t, ok)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("sampler acquisition did not stop waiting after cancellation")
+	}
+
+	handler.releaseSystemStatsSamplerInternal()
+
+	require.Eventually(t, func() bool {
+		handler.systemStatsSampler.lifecycleMu.Lock()
+		defer handler.systemStatsSampler.lifecycleMu.Unlock()
+		return !handler.systemStatsSampler.running && handler.systemStatsSampler.clients == 0
+	}, time.Second, 20*time.Millisecond)
+}
+
+func TestWebSocketHandler_LogStream_ReplacesDoneStreamAndCleansStaleRefs(t *testing.T) {
+	handler := newTestWebSocketHandler()
+	key := "env|project|resource|text|false|true|100||false"
+
+	var staleCancels atomic.Int32
+	stale := &wsLogStream{
+		hub:    ws.NewHub(1),
+		cancel: func() { staleCancels.Add(1) },
+		refs:   2,
+		done:   true,
+	}
+	handler.logStreams[key] = stale
+
+	var freshCancels atomic.Int32
+	fresh := handler.getOrCreateLogStreamInternal(key, func(onEmpty func(*wsLogStream)) *wsLogStream {
+		return &wsLogStream{
+			hub:    ws.NewHub(1),
+			cancel: func() { freshCancels.Add(1) },
+		}
+	})
+
+	require.NotSame(t, stale, fresh)
+	handler.logStreamsMu.Lock()
+	require.Same(t, fresh, handler.logStreams[key])
+	handler.logStreamsMu.Unlock()
+
+	handler.markLogStreamDoneInternal(key, stale)
+	handler.logStreamsMu.Lock()
+	require.Same(t, fresh, handler.logStreams[key])
+	handler.logStreamsMu.Unlock()
+
+	handler.releaseLogStreamInternal(key, stale)
+	require.Equal(t, 1, stale.refs)
+	handler.logStreamsMu.Lock()
+	require.Same(t, fresh, handler.logStreams[key])
+	handler.logStreamsMu.Unlock()
+
+	handler.releaseLogStreamInternal(key, stale)
+	require.Equal(t, int32(1), staleCancels.Load())
+	handler.logStreamsMu.Lock()
+	require.Same(t, fresh, handler.logStreams[key])
+	handler.logStreamsMu.Unlock()
+
+	handler.releaseLogStreamInternal(key, fresh)
+	require.Equal(t, int32(1), freshCancels.Load())
+	handler.logStreamsMu.Lock()
+	_, ok := handler.logStreams[key]
+	handler.logStreamsMu.Unlock()
+	require.False(t, ok)
+}
+
+func TestWebSocketHandler_LogStream_CancelsOnlyOnce(t *testing.T) {
+	handler := newTestWebSocketHandler()
+	key := "env|project|resource|text|false|true|100||false"
+
+	var cancels atomic.Int32
+	stream := &wsLogStream{
+		hub:    ws.NewHub(1),
+		cancel: func() { cancels.Add(1) },
+		refs:   1,
+	}
+	handler.logStreams[key] = stream
+
+	handler.markLogStreamDoneInternal(key, stream)
+	handler.releaseLogStreamInternal(key, stream)
+	handler.markLogStreamDoneInternal(key, stream)
+
+	require.Equal(t, int32(1), cancels.Load())
+}
+
+func TestWebSocketHandler_GetCachedCgroupLimitsInternal_DeduplicatesRefresh(t *testing.T) {
+	handler := newTestWebSocketHandler()
+	handler.cgroupCache.timestamp = time.Now().Add(-2 * cgroupCacheTTL)
+
+	var calls atomic.Int32
+	start := make(chan struct{})
+	release := make(chan struct{})
+	handler.cgroupLimitsDetector = func() (*docker.CgroupLimits, error) {
+		calls.Add(1)
+		close(start)
+		<-release
+		return &docker.CgroupLimits{CPUCount: 2}, nil
+	}
+
+	const goroutines = 8
+	results := make(chan *docker.CgroupLimits, goroutines)
+	ready := make(chan struct{})
+	var entered sync.WaitGroup
+	entered.Add(goroutines)
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Go(func() {
+			<-ready
+			entered.Done()
+			results <- handler.getCachedCgroupLimitsInternal()
+		})
+	}
+
+	close(ready)
+	entered.Wait()
+
+	select {
+	case <-start:
+	case <-time.After(2 * time.Second):
+		t.Fatal("detector was not called")
+	}
+
+	require.Equal(t, int32(1), calls.Load())
+
+	close(release)
+	wg.Wait()
+	close(results)
+
+	for result := range results {
+		require.NotNil(t, result)
+		require.Equal(t, 2, result.CPUCount)
+	}
+	require.Equal(t, int32(1), calls.Load())
 }

--- a/backend/internal/models/settings.go
+++ b/backend/internal/models/settings.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -19,6 +19,21 @@ const (
 type SettingVariable struct {
 	Key   string `gorm:"primaryKey"`
 	Value string
+}
+
+type settingFieldMeta struct {
+	index       int
+	key         string
+	attrs       string
+	isPublic    bool
+	isSensitive bool
+	isLocal     bool
+}
+
+var settingsFieldCache struct {
+	once    sync.Once
+	ordered []settingFieldMeta
+	byKey   map[string]settingFieldMeta
 }
 
 // IsTrue returns true if the value is a truthy string
@@ -154,29 +169,63 @@ func (SettingVariable) TableName() string {
 	return "settings"
 }
 
-func (s *Settings) ToSettingVariableSlice(showAll bool, redactSensitiveValues bool) []SettingVariable {
-	cfgValue := reflect.ValueOf(s).Elem()
-	cfgType := cfgValue.Type()
+func buildSettingsFieldCacheInternal() {
+	rt := reflect.TypeFor[Settings]()
+	ordered := make([]settingFieldMeta, 0, rt.NumField())
+	byKey := make(map[string]settingFieldMeta, rt.NumField())
 
-	var res []SettingVariable
-
-	for i := 0; i < cfgType.NumField(); i++ {
-		field := cfgType.Field(i)
-
+	for i := 0; i < rt.NumField(); i++ {
+		field := rt.Field(i)
 		key, attrs, _ := strings.Cut(field.Tag.Get("key"), ",")
 		if key == "" {
 			continue
 		}
 
-		if !showAll && !strings.Contains(attrs, "public") {
+		meta := settingFieldMeta{
+			index:       i,
+			key:         key,
+			attrs:       attrs,
+			isPublic:    strings.Contains(attrs, "public"),
+			isSensitive: strings.Contains(attrs, "sensitive"),
+			isLocal:     strings.Contains(attrs, "local"),
+		}
+		ordered = append(ordered, meta)
+		byKey[key] = meta
+	}
+
+	settingsFieldCache.ordered = ordered
+	settingsFieldCache.byKey = byKey
+}
+
+func getSettingsFieldCacheInternal() ([]settingFieldMeta, map[string]settingFieldMeta) {
+	settingsFieldCache.once.Do(buildSettingsFieldCacheInternal)
+	return settingsFieldCache.ordered, settingsFieldCache.byKey
+}
+
+func (s *Settings) Clone() *Settings {
+	if s == nil {
+		return &Settings{}
+	}
+
+	clone := *s
+	return &clone
+}
+
+func (s *Settings) ToSettingVariableSlice(showAll bool, redactSensitiveValues bool) []SettingVariable {
+	cfgValue := reflect.ValueOf(s).Elem()
+	fields, _ := getSettingsFieldCacheInternal()
+
+	res := make([]SettingVariable, 0, len(fields))
+	for _, field := range fields {
+		if !showAll && !field.isPublic {
 			continue
 		}
 
-		value := cfgValue.Field(i).FieldByName("Value").String()
-		value = redactSettingValue(key, value, attrs, redactSensitiveValues)
+		value := cfgValue.Field(field.index).FieldByName("Value").String()
+		value = redactSettingValue(field.key, value, field.attrs, redactSensitiveValues)
 
 		settingVariable := SettingVariable{
-			Key:   key,
+			Key:   field.key,
 			Value: value,
 		}
 		res = append(res, settingVariable)
@@ -187,65 +236,47 @@ func (s *Settings) ToSettingVariableSlice(showAll bool, redactSensitiveValues bo
 
 func (s *Settings) FieldByKey(key string) (defaultValue string, isPublic bool, isSensitive bool, err error) {
 	rv := reflect.ValueOf(s).Elem()
-	rt := rv.Type()
+	_, byKey := getSettingsFieldCacheInternal()
 
-	for i := 0; i < rt.NumField(); i++ {
-		tagValue := strings.Split(rt.Field(i).Tag.Get("key"), ",")
-		keyFromTag := tagValue[0]
-		isPublic = slices.Contains(tagValue, "public")
-		isSensitive = slices.Contains(tagValue, "sensitive")
-
-		if keyFromTag != key {
-			continue
-		}
-
-		valueField := rv.Field(i).FieldByName("Value")
-		return valueField.String(), isPublic, isSensitive, nil
+	field, ok := byKey[key]
+	if !ok {
+		return "", false, false, SettingKeyNotFoundError{field: key}
 	}
 
-	return "", false, false, SettingKeyNotFoundError{field: key}
+	valueField := rv.Field(field.index).FieldByName("Value")
+	return valueField.String(), field.isPublic, field.isSensitive, nil
 }
 
 func (s *Settings) IsLocalSetting(key string) bool {
-	rt := reflect.TypeFor[Settings]()
-
-	for field := range rt.Fields() {
-		tagValue := strings.Split(field.Tag.Get("key"), ",")
-		keyFromTag := tagValue[0]
-
-		if keyFromTag == key {
-			return slices.Contains(tagValue, "local")
-		}
+	_, byKey := getSettingsFieldCacheInternal()
+	field, ok := byKey[key]
+	if !ok {
+		return false
 	}
 
-	return false
+	return field.isLocal
 }
 
 func (s *Settings) UpdateField(key string, value string, noSensitive bool) error {
 	rv := reflect.ValueOf(s).Elem()
-	rt := rv.Type()
+	_, byKey := getSettingsFieldCacheInternal()
 
-	for i := 0; i < rt.NumField(); i++ {
-		tagValue, attrs, _ := strings.Cut(rt.Field(i).Tag.Get("key"), ",")
-		if tagValue != key {
-			continue
-		}
-
-		// If the field is sensitive and noSensitive is true, we skip that
-		if noSensitive && strings.Contains(attrs, "sensitive") {
-			return SettingSensitiveForbiddenError{field: key}
-		}
-
-		valueField := rv.Field(i).FieldByName("Value")
-		if !valueField.CanSet() {
-			return fmt.Errorf("field Value in SettingVariable is not settable for config key '%s'", key)
-		}
-
-		valueField.SetString(value)
-		return nil
+	field, ok := byKey[key]
+	if !ok {
+		return SettingKeyNotFoundError{field: key}
 	}
 
-	return SettingKeyNotFoundError{field: key}
+	if noSensitive && field.isSensitive {
+		return SettingSensitiveForbiddenError{field: key}
+	}
+
+	valueField := rv.Field(field.index).FieldByName("Value")
+	if !valueField.CanSet() {
+		return fmt.Errorf("field Value in SettingVariable is not settable for config key '%s'", key)
+	}
+
+	valueField.SetString(value)
+	return nil
 }
 
 // helper keeps redaction logic in one place; behavior unchanged

--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -57,10 +57,6 @@ func NewSettingsService(ctx context.Context, db *database.DB) (*SettingsService,
 		return nil, fmt.Errorf("failed to setup instance ID: %w", err)
 	}
 
-	if err = svc.LoadDatabaseSettings(ctx); err != nil {
-		return nil, fmt.Errorf("failed to reload settings after instance ID setup: %w", err)
-	}
-
 	return svc, nil
 }
 
@@ -80,6 +76,14 @@ func (s *SettingsService) LoadDatabaseSettings(ctx context.Context) (err error) 
 	}
 
 	s.config.Store(dst)
+
+	return nil
+}
+
+func (s *SettingsService) refreshSettingsCacheInternal(ctx context.Context) error {
+	if err := s.LoadDatabaseSettings(ctx); err != nil {
+		return fmt.Errorf("failed to refresh settings cache: %w", err)
+	}
 
 	return nil
 }
@@ -326,28 +330,8 @@ func (s *SettingsService) isEnvOverrideActiveInternal(key string) bool {
 }
 
 func (s *SettingsService) GetSettings(ctx context.Context) (*models.Settings, error) {
-	var settingVars []models.SettingVariable
-	err := s.db.WithContext(ctx).Find(&settingVars).Error
-	if err != nil {
-		return nil, err
-	}
-
-	settings := &models.Settings{}
-
-	for _, sv := range settingVars {
-		if err := settings.UpdateField(sv.Key, sv.Value, false); err != nil {
-			var notFoundErr models.SettingKeyNotFoundError
-			if !errors.As(err, &notFoundErr) {
-				return nil, fmt.Errorf("failed to load setting %s: %w", sv.Key, err)
-			}
-		}
-	}
-
-	// Apply environment variable overrides for fields tagged with "envOverride".
-	// This keeps behavior consistent with the cached settings path (LoadDatabaseSettingsInternal)
-	// and allows env vars like OIDC_MERGE_ACCOUNTS to affect runtime behavior.
+	settings := s.GetSettingsConfig().Clone()
 	s.applyEnvOverrides(ctx, settings)
-
 	return settings, nil
 }
 
@@ -459,6 +443,14 @@ func (s *SettingsService) migrateOidcKeyNames(ctx context.Context) error {
 }
 
 func (s *SettingsService) UpdateSetting(ctx context.Context, key, value string) error {
+	if err := s.updateSettingValueNoRefreshInternal(ctx, key, value); err != nil {
+		return err
+	}
+
+	return s.refreshSettingsCacheInternal(ctx)
+}
+
+func (s *SettingsService) updateSettingValueNoRefreshInternal(ctx context.Context, key, value string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		settingVar := &models.SettingVariable{
 			Key:   key,
@@ -470,10 +462,8 @@ func (s *SettingsService) UpdateSetting(ctx context.Context, key, value string) 
 
 func (s *SettingsService) UpdateSettings(ctx context.Context, updates settings.Update) ([]models.SettingVariable, error) {
 	defaultCfg := s.getDefaultSettings()
-	cfg, err := s.GetSettings(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load current settings: %w", err)
-	}
+	cfg := s.GetSettingsConfig().Clone()
+	s.applyEnvOverrides(ctx, cfg)
 
 	valuesToUpdate, changedPolling, changedAutoUpdate, changedScheduledPrune, changedVulnerabilityScan, changedAutoHeal, changedTimeouts, err := s.prepareUpdateValues(updates, cfg, defaultCfg)
 	if err != nil {
@@ -488,13 +478,10 @@ func (s *SettingsService) UpdateSettings(ctx context.Context, updates settings.U
 		return nil, err
 	}
 
-	// Reload and store settings BEFORE calling callbacks so they read updated values
-	settings, err := s.GetSettings(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve updated settings: %w", err)
+	if err := s.refreshSettingsCacheInternal(ctx); err != nil {
+		return nil, err
 	}
-
-	s.config.Store(settings)
+	settings := s.GetSettingsConfig()
 
 	// Now call callbacks after in-memory config is updated
 	if changedPolling && s.OnImagePollingSettingsChanged != nil {
@@ -667,7 +654,7 @@ func (s *SettingsService) handleOidcConfigUpdate(ctx context.Context, updates se
 			return fmt.Errorf("failed to marshal merged OIDC config: %w", err)
 		}
 
-		if err := s.UpdateSetting(ctx, "authOidcConfig", string(mergedBytes)); err != nil {
+		if err := s.updateSettingValueNoRefreshInternal(ctx, "authOidcConfig", string(mergedBytes)); err != nil {
 			return fmt.Errorf("failed to update authOidcConfig: %w", err)
 		}
 	}
@@ -688,7 +675,7 @@ func (s *SettingsService) handleOidcConfigUpdate(ctx context.Context, updates se
 			}
 		}
 
-		if err := s.UpdateSetting(ctx, "oidcClientSecret", secret); err != nil {
+		if err := s.updateSettingValueNoRefreshInternal(ctx, "oidcClientSecret", secret); err != nil {
 			return fmt.Errorf("failed to update oidcClientSecret: %w", err)
 		}
 	}
@@ -916,34 +903,15 @@ func (s *SettingsService) GetStringSetting(ctx context.Context, key, defaultValu
 }
 
 func (s *SettingsService) SetBoolSetting(ctx context.Context, key string, value bool) error {
-	if err := s.UpdateSetting(ctx, key, fmt.Sprintf("%t", value)); err != nil {
-		return err
-	}
-	// Rebuild a fresh snapshot instead of mutating current pointer (avoids races)
-	if err := s.LoadDatabaseSettings(ctx); err != nil {
-		return fmt.Errorf("failed to refresh settings cache: %w", err)
-	}
-	return nil
+	return s.UpdateSetting(ctx, key, fmt.Sprintf("%t", value))
 }
 
 func (s *SettingsService) SetIntSetting(ctx context.Context, key string, value int) error {
-	if err := s.UpdateSetting(ctx, key, fmt.Sprintf("%d", value)); err != nil {
-		return err
-	}
-	if err := s.LoadDatabaseSettings(ctx); err != nil {
-		return fmt.Errorf("failed to refresh settings cache: %w", err)
-	}
-	return nil
+	return s.UpdateSetting(ctx, key, fmt.Sprintf("%d", value))
 }
 
 func (s *SettingsService) SetStringSetting(ctx context.Context, key, value string) error {
-	if err := s.UpdateSetting(ctx, key, value); err != nil {
-		return err
-	}
-	if err := s.LoadDatabaseSettings(ctx); err != nil {
-		return fmt.Errorf("failed to refresh settings cache: %w", err)
-	}
-	return nil
+	return s.UpdateSetting(ctx, key, value)
 }
 
 func (s *SettingsService) EnsureEncryptionKey(ctx context.Context) (string, error) {
@@ -1041,10 +1009,6 @@ func (s *SettingsService) NormalizeProjectsDirectory(ctx context.Context, projec
 			return fmt.Errorf("failed to update projectsDirectory: %w", err)
 		}
 
-		if err := s.LoadDatabaseSettings(ctx); err != nil {
-			return fmt.Errorf("failed to reload settings after normalization: %w", err)
-		}
-
 		slog.InfoContext(ctx, "Successfully normalized projects directory")
 	} else {
 		slog.DebugContext(ctx, "Projects directory already normalized or custom, skipping", "value", projectsDirSetting.Value)
@@ -1089,10 +1053,6 @@ func (s *SettingsService) NormalizeBuildsDirectory(ctx context.Context) error {
 
 		if err := s.UpdateSetting(ctx, buildsKey, absPath); err != nil {
 			return fmt.Errorf("failed to update buildsDirectory: %w", err)
-		}
-
-		if err := s.LoadDatabaseSettings(ctx); err != nil {
-			return fmt.Errorf("failed to reload settings after normalization: %w", err)
 		}
 
 		slog.InfoContext(ctx, "Successfully normalized builds directory")

--- a/backend/internal/services/settings_service_test.go
+++ b/backend/internal/services/settings_service_test.go
@@ -91,6 +91,22 @@ func TestSettingsService_GetSettings_UnknownKeysIgnored(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSettingsService_GetSettings_UsesCachedSnapshotWithoutDatabase(t *testing.T) {
+	ctx := context.Background()
+	db := setupSettingsTestDB(t)
+	svc, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	require.NoError(t, svc.SetStringSetting(ctx, "baseServerUrl", "http://cached"))
+
+	// GetSettings should clone the in-memory snapshot and not touch the database.
+	svc.db = nil
+
+	settings, err := svc.GetSettings(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "http://cached", settings.BaseServerURL.Value)
+}
+
 func TestSettingsService_PruneUnknownSettings_RemovesStaleKeys(t *testing.T) {
 	ctx := context.Background()
 	db := setupSettingsTestDB(t)
@@ -295,6 +311,51 @@ func TestSettingsService_UpdateSetting(t *testing.T) {
 	require.Equal(t, "all", sv.Value)
 }
 
+func TestSettingsService_UpdateSetting_RefreshesCachedSnapshot(t *testing.T) {
+	ctx := context.Background()
+	db := setupSettingsTestDB(t)
+	svc, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	require.Equal(t, "http://localhost", svc.GetSettingsConfig().BaseServerURL.Value)
+	require.NoError(t, svc.UpdateSetting(ctx, "baseServerUrl", "https://arcane.test"))
+
+	require.Equal(t, "https://arcane.test", svc.GetSettingsConfig().BaseServerURL.Value)
+
+	settings, err := svc.GetSettings(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "https://arcane.test", settings.BaseServerURL.Value)
+}
+
+func BenchmarkSettingsService_GetSettings(b *testing.B) {
+	ctx := context.Background()
+	db, err := gorm.Open(glsqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.SettingVariable{}); err != nil {
+		b.Fatal(err)
+	}
+	settingsDB := &database.DB{DB: db}
+	svc, err := NewSettingsService(ctx, settingsDB)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		settings, err := svc.GetSettings(ctx)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if settings == nil {
+			b.Fatal("settings should not be nil")
+		}
+	}
+}
+
 func TestSettingsService_EnsureEncryptionKey(t *testing.T) {
 	ctx := context.Background()
 	db := setupSettingsTestDB(t)
@@ -420,6 +481,31 @@ func TestSettingsService_UpdateSettings_RefreshesCache(t *testing.T) {
 		}
 	}
 	require.True(t, found, "projectsDirectory setting not found in cached list")
+}
+
+func TestSettingsService_UpdateSettings_ReturnsEnvOverriddenValues(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "tcp://env-docker:2375")
+
+	ctx := context.Background()
+	db := setupSettingsTestDB(t)
+	svc, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+	require.NoError(t, svc.EnsureDefaultSettings(ctx))
+
+	newDir := "custom/projects2"
+	settingsList, err := svc.UpdateSettings(ctx, settings.Update{
+		ProjectsDirectory: &newDir,
+	})
+	require.NoError(t, err)
+
+	found := false
+	for _, sv := range settingsList {
+		if sv.Key == "dockerHost" {
+			found = true
+			require.Equal(t, "tcp://env-docker:2375", sv.Value)
+		}
+	}
+	require.True(t, found, "dockerHost setting not found in update response")
 }
 
 func TestSettingsService_UpdateSettings_TimeoutCallbackIncludesTrivyScanTimeout(t *testing.T) {

--- a/backend/pkg/libarcane/ws/client.go
+++ b/backend/pkg/libarcane/ws/client.go
@@ -22,9 +22,10 @@ const (
 
 // Client represents a single WebSocket connection.
 type Client struct {
-	conn *websocket.Conn
-	send chan []byte
-	once sync.Once
+	conn     *websocket.Conn
+	send     chan []byte
+	once     sync.Once
+	onRemove func()
 }
 
 func NewClient(conn *websocket.Conn, sendBuffer int) *Client {
@@ -39,7 +40,12 @@ func NewClient(conn *websocket.Conn, sendBuffer int) *Client {
 // ServeClient registers the client with the hub and starts read/write pumps.
 // Caller is responsible for creating/closing the websocket.Conn.
 func ServeClient(ctx context.Context, hub *Hub, conn *websocket.Conn) {
+	ServeClientWithOnRemove(ctx, hub, conn, nil)
+}
+
+func ServeClientWithOnRemove(ctx context.Context, hub *Hub, conn *websocket.Conn, onRemove func()) {
 	c := NewClient(conn, clientSendBuffer)
+	c.onRemove = onRemove
 	hub.register <- c
 
 	go c.writePump(ctx, hub)
@@ -48,6 +54,9 @@ func ServeClient(ctx context.Context, hub *Hub, conn *websocket.Conn) {
 
 func (c *Client) safeRemove(hub *Hub) {
 	c.once.Do(func() {
+		if c.onRemove != nil {
+			c.onRemove()
+		}
 		hub.remove(c)
 	})
 }

--- a/backend/pkg/libarcane/ws/hub.go
+++ b/backend/pkg/libarcane/ws/hub.go
@@ -12,6 +12,7 @@ type Hub struct {
 	register   chan *Client
 	unregister chan *Client
 	broadcast  chan []byte
+	onFirst    func()
 	onEmpty    func()
 }
 
@@ -22,6 +23,12 @@ func NewHub(buffer int) *Hub {
 		unregister: make(chan *Client),
 		broadcast:  make(chan []byte, buffer),
 	}
+}
+
+func (h *Hub) SetOnFirstClient(fn func()) {
+	h.mu.Lock()
+	h.onFirst = fn
+	h.mu.Unlock()
 }
 
 func (h *Hub) SetOnEmpty(fn func()) {
@@ -38,9 +45,17 @@ func (h *Hub) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case c := <-h.register:
+			var onFirst func()
 			h.mu.Lock()
 			h.clients[c] = struct{}{}
+			if len(h.clients) == 1 && h.onFirst != nil {
+				onFirst = h.onFirst
+				h.onFirst = nil
+			}
 			h.mu.Unlock()
+			if onFirst != nil {
+				onFirst()
+			}
 		case c := <-h.unregister:
 			// remove() handles the onEmpty callback when the last client disconnects.
 			h.remove(c)

--- a/backend/pkg/libarcane/ws/hub_client_count_test.go
+++ b/backend/pkg/libarcane/ws/hub_client_count_test.go
@@ -1,9 +1,0 @@
-package ws
-
-// ClientCount is test-only and intentionally compiled from *_test.go to avoid
-// deadcode in production builds.
-func (h *Hub) ClientCount() int {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	return len(h.clients)
-}

--- a/backend/pkg/libarcane/ws/hub_test.go
+++ b/backend/pkg/libarcane/ws/hub_test.go
@@ -207,6 +207,32 @@ func TestHub_OnEmptyCallback(t *testing.T) {
 	require.Eventually(t, called.Load, time.Second, 5*time.Millisecond, "onEmpty callback was not called")
 }
 
+func TestHub_OnFirstClientCallback(t *testing.T) {
+	h := NewHub(10)
+	ctx := t.Context()
+	go h.Run(ctx)
+
+	var callCount atomic.Int32
+	h.SetOnFirstClient(func() {
+		callCount.Add(1)
+	})
+
+	_, sc1, cleanup1 := newTestWSPair(t)
+	defer cleanup1()
+	_, sc2, cleanup2 := newTestWSPair(t)
+	defer cleanup2()
+
+	h.register <- NewClient(sc1, 16)
+	h.register <- NewClient(sc2, 16)
+
+	require.Eventually(t, func() bool {
+		return h.ClientCount() == 2
+	}, time.Second, 5*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return callCount.Load() == 1
+	}, time.Second, 5*time.Millisecond)
+}
+
 func TestHub_OnEmptyCalledOnlyOnce(t *testing.T) {
 	h := NewHub(10)
 	ctx := t.Context()

--- a/backend/pkg/libarcane/ws/hub_test_helper_test.go
+++ b/backend/pkg/libarcane/ws/hub_test_helper_test.go
@@ -1,0 +1,7 @@
+package ws
+
+func (h *Hub) ClientCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.clients)
+}

--- a/backend/pkg/scheduler/auto_heal_job.go
+++ b/backend/pkg/scheduler/auto_heal_job.go
@@ -13,9 +13,11 @@ import (
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/robfig/cron/v3"
+	"golang.org/x/sync/errgroup"
 )
 
 const AutoHealJobName = "auto-heal"
+const autoHealInspectConcurrency = 4
 
 // restartRecord tracks restart timestamps for a single container.
 type restartRecord struct {
@@ -30,6 +32,11 @@ type AutoHealJob struct {
 
 	mu       sync.Mutex
 	restarts map[string]*restartRecord
+
+	getDockerClient  func() (*client.Client, error)
+	listContainers   func(ctx context.Context, dockerClient *client.Client) ([]container.Summary, error)
+	inspectContainer func(ctx context.Context, dockerClient *client.Client, containerID string) (container.InspectResponse, error)
+	restartContainer func(ctx context.Context, dockerClient *client.Client, containerID string) error
 }
 
 func NewAutoHealJob(
@@ -73,78 +80,107 @@ func (j *AutoHealJob) Run(ctx context.Context) {
 		return
 	}
 
-	dockerClient, err := j.dockerClientService.GetClient(ctx)
+	dockerClient, err := j.getDockerClientInternal(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "auto-heal failed to get Docker client", "error", err)
 		return
 	}
 
-	containerList, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: false})
+	containerList, err := j.listContainersInternal(ctx, dockerClient)
 	if err != nil {
 		slog.ErrorContext(ctx, "auto-heal failed to list containers", "error", err)
 		return
 	}
-	containers := containerList.Items
+	containers := containerList
 
 	excludedContainers := j.parseExcludedContainers(ctx)
 	maxRestarts := j.settingsService.GetIntSetting(ctx, "autoHealMaxRestarts", 5)
 	restartWindowMinutes := j.settingsService.GetIntSetting(ctx, "autoHealRestartWindow", 30)
 	restartWindow := time.Duration(restartWindowMinutes) * time.Minute
 
+	candidates := j.filterCandidatesInternal(containers, excludedContainers)
+
+	g, groupCtx := errgroup.WithContext(ctx)
+	g.SetLimit(autoHealInspectConcurrency)
+
+	for _, candidate := range candidates {
+		g.Go(func() error {
+			j.processCandidateInternal(groupCtx, dockerClient, candidate, maxRestarts, restartWindow, restartWindowMinutes)
+			return nil
+		})
+	}
+
+	_ = g.Wait()
+}
+
+func (j *AutoHealJob) filterCandidatesInternal(containers []container.Summary, excludedContainers map[string]struct{}) []container.Summary {
+	candidates := make([]container.Summary, 0, len(containers))
 	for _, c := range containers {
-		// Skip Arcane internal containers
 		if libarcane.IsInternalContainer(c.Labels) {
 			continue
 		}
 
 		containerName := j.getContainerName(c.Names)
-
-		// Skip excluded containers
 		if j.isExcluded(containerName, excludedContainers) {
 			continue
 		}
 
-		// Inspect to get health status
-		inspect, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, c.ID, client.ContainerInspectOptions{})
-		if err != nil {
-			slog.WarnContext(ctx, "auto-heal failed to inspect container", "container", containerName, "error", err)
-			continue
-		}
-		containerInspect := inspect.Container
+		candidates = append(candidates, c)
+	}
 
-		// Skip if no healthcheck configured or not unhealthy
-		if containerInspect.State == nil || containerInspect.State.Health == nil {
-			continue
-		}
-		if containerInspect.State.Health.Status != container.Unhealthy {
-			continue
-		}
+	return candidates
+}
 
-		// Check restart-loop protection
-		if !j.canRestart(c.ID, maxRestarts, restartWindow) {
-			slog.WarnContext(ctx, "auto-heal restart-loop protection: skipping container",
-				"container", containerName,
-				"max_restarts", maxRestarts,
-				"window_minutes", restartWindowMinutes,
-			)
-			continue
-		}
+func (j *AutoHealJob) processCandidateInternal(
+	ctx context.Context,
+	dockerClient *client.Client,
+	candidate container.Summary,
+	maxRestarts int,
+	restartWindow time.Duration,
+	restartWindowMinutes int,
+) {
+	containerID := candidate.ID
+	containerName := j.getContainerName(candidate.Names)
 
-		// Restart the container
-		slog.InfoContext(ctx, "auto-heal restarting unhealthy container", "container", containerName, "container_id", c.ID)
-		if _, err := dockerClient.ContainerRestart(ctx, c.ID, client.ContainerRestartOptions{}); err != nil {
-			slog.ErrorContext(ctx, "auto-heal failed to restart container", "container", containerName, "error", err)
-			continue
-		}
+	inspect, err := j.inspectContainerInternal(ctx, dockerClient, containerID)
+	if err != nil {
+		slog.WarnContext(ctx, "auto-heal failed to inspect container", "container", containerName, "error", err)
+		return
+	}
 
-		// Record the restart
-		j.recordRestart(c.ID)
+	if inspect.State == nil || inspect.State.Health == nil {
+		return
+	}
+	if inspect.State.Health.Status != container.Unhealthy {
+		return
+	}
 
-		// Log event
+	if !j.canRestart(containerID, maxRestarts, restartWindow) {
+		slog.WarnContext(ctx, "auto-heal restart-loop protection: skipping container",
+			"container", containerName,
+			"max_restarts", maxRestarts,
+			"window_minutes", restartWindowMinutes,
+		)
+		return
+	}
+
+	if err := j.restartContainerInternal(ctx, dockerClient, containerID); err != nil {
+		slog.ErrorContext(ctx, "auto-heal failed to restart container", "container", containerName, "error", err)
+		return
+	}
+
+	j.recordRestart(containerID)
+	j.postRestartActionsInternal(ctx, containerID, containerName)
+
+	slog.InfoContext(ctx, "auto-heal restarted unhealthy container", "container", containerName, "container_id", containerID)
+}
+
+func (j *AutoHealJob) postRestartActionsInternal(ctx context.Context, containerID, containerName string) {
+	if j.eventService != nil {
 		if err := j.eventService.LogContainerEvent(
 			ctx,
 			models.EventTypeContainerRestart,
-			c.ID,
+			containerID,
 			containerName,
 			"", // no user - system action
 			"system",
@@ -153,13 +189,12 @@ func (j *AutoHealJob) Run(ctx context.Context) {
 		); err != nil {
 			slog.WarnContext(ctx, "auto-heal failed to log event", "container", containerName, "error", err)
 		}
+	}
 
-		// Send notification
-		if err := j.notificationService.SendAutoHealNotification(ctx, containerName, c.ID); err != nil {
+	if j.notificationService != nil {
+		if err := j.notificationService.SendAutoHealNotification(ctx, containerName, containerID); err != nil {
 			slog.WarnContext(ctx, "auto-heal failed to send notification", "container", containerName, "error", err)
 		}
-
-		slog.InfoContext(ctx, "auto-heal successfully restarted container", "container", containerName)
 	}
 }
 
@@ -236,6 +271,49 @@ func (j *AutoHealJob) getContainerName(names []string) string {
 func (j *AutoHealJob) isExcluded(name string, excluded map[string]struct{}) bool {
 	_, ok := excluded[name]
 	return ok
+}
+
+func (j *AutoHealJob) inspectContainerInternal(ctx context.Context, dockerClient *client.Client, containerID string) (container.InspectResponse, error) {
+	if j.inspectContainer != nil {
+		return j.inspectContainer(ctx, dockerClient, containerID)
+	}
+
+	inspect, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, containerID, client.ContainerInspectOptions{})
+	if err != nil {
+		return container.InspectResponse{}, err
+	}
+
+	return inspect.Container, nil
+}
+
+func (j *AutoHealJob) restartContainerInternal(ctx context.Context, dockerClient *client.Client, containerID string) error {
+	if j.restartContainer != nil {
+		return j.restartContainer(ctx, dockerClient, containerID)
+	}
+
+	_, err := dockerClient.ContainerRestart(ctx, containerID, client.ContainerRestartOptions{})
+	return err
+}
+
+func (j *AutoHealJob) getDockerClientInternal(ctx context.Context) (*client.Client, error) {
+	if j.getDockerClient != nil {
+		return j.getDockerClient()
+	}
+
+	return j.dockerClientService.GetClient(ctx)
+}
+
+func (j *AutoHealJob) listContainersInternal(ctx context.Context, dockerClient *client.Client) ([]container.Summary, error) {
+	if j.listContainers != nil {
+		return j.listContainers(ctx, dockerClient)
+	}
+
+	containerList, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: false})
+	if err != nil {
+		return nil, err
+	}
+
+	return containerList.Items, nil
 }
 
 // ResetRestartTracking clears all restart records (exported for testing).

--- a/backend/pkg/scheduler/auto_heal_job_test.go
+++ b/backend/pkg/scheduler/auto_heal_job_test.go
@@ -1,10 +1,19 @@
 package scheduler
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/getarcaneapp/arcane/backend/internal/database"
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/internal/services"
+	glsqlite "github.com/glebarez/sqlite"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func newTestAutoHealJob() *AutoHealJob {
@@ -111,4 +120,67 @@ func TestAutoHeal_ResetRestartTracking(t *testing.T) {
 
 	// Should be allowed again
 	require.True(t, job.CanRestartExported("container-1", 5, 30*time.Minute))
+}
+
+func TestAutoHeal_Run_UsesBoundedConcurrency(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := gorm.Open(glsqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SettingVariable{}))
+
+	settingsSvc, err := services.NewSettingsService(ctx, &database.DB{DB: db})
+	require.NoError(t, err)
+	require.NoError(t, settingsSvc.SetBoolSetting(ctx, "autoHealEnabled", true))
+	require.NoError(t, settingsSvc.SetStringSetting(ctx, "autoHealExcludedContainers", "skip-me"))
+
+	job := NewAutoHealJob(nil, settingsSvc, nil, nil)
+	job.getDockerClient = func() (*client.Client, error) { return nil, nil }
+	job.listContainers = func(ctx context.Context, dockerClient *client.Client) ([]container.Summary, error) {
+		return []container.Summary{
+			{ID: "c1", Names: []string{"/one"}},
+			{ID: "c2", Names: []string{"/two"}},
+			{ID: "c3", Names: []string{"/three"}},
+			{ID: "c4", Names: []string{"/four"}},
+			{ID: "c5", Names: []string{"/five"}},
+			{ID: "c6", Names: []string{"/six"}},
+			{ID: "skip", Names: []string{"/skip-me"}},
+		}, nil
+	}
+
+	var current int32
+	var maxConcurrent int32
+	var restarts int32
+
+	job.inspectContainer = func(ctx context.Context, dockerClient *client.Client, containerID string) (container.InspectResponse, error) {
+		active := atomic.AddInt32(&current, 1)
+		for {
+			maxSeen := atomic.LoadInt32(&maxConcurrent)
+			if active <= maxSeen || atomic.CompareAndSwapInt32(&maxConcurrent, maxSeen, active) {
+				break
+			}
+		}
+		defer atomic.AddInt32(&current, -1)
+
+		time.Sleep(40 * time.Millisecond)
+
+		switch containerID {
+		case "c5":
+			return container.InspectResponse{State: &container.State{}}, nil
+		case "c6":
+			return container.InspectResponse{State: &container.State{Health: &container.Health{Status: container.Healthy}}}, nil
+		default:
+			return container.InspectResponse{State: &container.State{Health: &container.Health{Status: container.Unhealthy}}}, nil
+		}
+	}
+	job.restartContainer = func(ctx context.Context, dockerClient *client.Client, containerID string) error {
+		atomic.AddInt32(&restarts, 1)
+		return nil
+	}
+
+	job.Run(ctx)
+
+	require.Greater(t, atomic.LoadInt32(&maxConcurrent), int32(1))
+	require.LessOrEqual(t, atomic.LoadInt32(&maxConcurrent), int32(autoHealInspectConcurrency))
+	require.Equal(t, int32(4), atomic.LoadInt32(&restarts))
 }


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes #

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR delivers three independent performance improvements: (1) WebSocket log streams are now multiplexed — clients subscribing to the same `(env, kind, resource, format, …)` tuple share a single hub and source goroutine instead of spawning one per connection; (2) `GetSettings` now returns a cloned in-memory snapshot instead of issuing a DB query on every call; (3) the auto-heal scheduler parallelises per-container inspections with an `errgroup` bounded to 4 goroutines.

**Key improvements since the last review iteration:**
- The `done` flag on `wsLogStream` correctly prevents late-joining clients from attaching to a finished source stream, and `takeLogStreamCancelInternal` ensures the cancel function is only invoked once regardless of which code path (source goroutine vs. `releaseLogStreamInternal` vs. hub `onEmpty`) reaches zero first.
- The cgroup-limits cache now uses proper double-checked locking (`RLock` → check → `Lock` → re-check), preventing the thundering-herd of duplicate `DetectCgroupLimits` calls on expiry.
- `acquireSystemStatsSamplerInternal` releases `lifecycleMu` before the blocking CPU-baseline sample, and the `ready` channel ensures late-joining clients block until the first valid snapshot is stored rather than reading a zeroed `SystemStats{}`.
- `startContainerLogHub` now mirrors `startProjectLogHub` by using `newWSLogStreamInternal`, and container stream errors are broadcast to connected clients via `broadcastContainerLogStreamErrorInternal`.
- `UpdateSetting` now calls `refreshSettingsCacheInternal` exactly once, and `handleOidcConfigUpdate` uses `updateSettingValueNoRefreshInternal` to batch its two writes before the single cache refresh in `UpdateSettings`.

**Remaining minor concerns:**
- `waitForLogStreamSubscriberInternal` polls `hub.ClientCount()` every 5 ms per stream; a first-subscriber notification channel on the hub would be lighter.
- `acquireSystemStatsSamplerInternal` cannot be interrupted during the 1-second `cpu.Percent` baseline; clients that disconnect in that window are held for up to a second.
- `UpdateSettings` calls `GetSettings(ctx)` (which re-applies env overrides on top of a cache clone) when `GetSettingsConfig().Clone()` + `applyEnvOverrides` would be equivalent and slightly cheaper.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge after the author reviews the two P2 suggestions; no blocking correctness issues remain.
- All critical bugs identified in the previous review iteration (dead-source stream trap, memory leak, thundering herd on cgroup cache, zeroed-stats race, triple-cancel, blocking collection under lifecycleMu, silently-discarded container errors) have been cleanly addressed. The remaining comments are style/optimization suggestions (polling vs. channel notification, uninterruptible CPU baseline, minor redundancy in UpdateSettings). The concurrent logic is well-tested with injected dependencies and deterministic synchronization primitives.
- backend/internal/api/ws_handler.go — acquireSystemStatsSamplerInternal (CPU init blocking) and waitForLogStreamSubscriberInternal (polling) are the only areas that could still benefit from small refinements.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/api/ws_handler.go | Major overhaul adding shared log stream multiplexing, system stats sampler lifecycle management, and cgroup limit caching. Previous session's critical bugs (dead-source trap, memory leak, thundering herd, zeroed-stats race) are all addressed. The `done` flag + `takeLogStreamCancelInternal` guard prevent double-cancel and stale reuse. A few minor concerns remain (polling in waitForLogStreamSubscriberInternal, uninterruptible CPU init). |
| backend/internal/api/ws_handler_test.go | Comprehensive test coverage added for stream sharing, sampler lifecycle, cgroup cache deduplication, and error broadcasting. Previous timing-sensitive time.Sleep calls replaced with require.Eventually/require.Never. Cgroup cache test now uses proper WaitGroup + channel sync instead of time.Sleep. |
| backend/internal/models/settings.go | Introduces a package-level sync.Once field cache (settingsFieldCache) to avoid repeated reflection on every settings read. All reflection-heavy loops (ToSettingVariableSlice, FieldByKey, IsLocalSetting, UpdateField) now use O(1) map/index lookups. Adds Clone() method for safe snapshot copying. Clean and correct implementation. |
| backend/internal/services/settings_service.go | GetSettings now returns a clone of the in-memory snapshot instead of querying the DB. UpdateSetting refreshes the cache via refreshSettingsCacheInternal. handleOidcConfigUpdate correctly uses updateSettingValueNoRefreshInternal to batch its two writes with a single refresh. Redundant LoadDatabaseSettings calls cleaned up. |
| backend/pkg/scheduler/auto_heal_job.go | Run() parallelised with errgroup (bounded to autoHealInspectConcurrency=4). Logic extracted into filterCandidatesInternal/processCandidateInternal. Nil guards added for eventService/notificationService. Injectable docker ops added for testability. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (6)</h3></summary>

1. `backend/internal/api/ws_handler.go`, line 331-354 ([link](https://github.com/getarcaneapp/arcane/blob/178811f7477217d22ff7e9edbaf59d6045750ebc/backend/internal/api/ws_handler.go#L331-L354)) 

   **Two tickers at the identical 1-second interval**

   Both `cpuTicker` and `sampleTicker` are created with `1 * time.Second`. Because they are created at almost exactly the same moment they will fire simultaneously on every tick. In Go's `select`, when both channels are ready the runtime picks one at random per iteration, so both **do** fire each second — but in two consecutive iterations rather than being truly concurrent. The result is just extra round-trips through the event loop.

   More importantly, `collectSystemStatsSnapshotInternal` (the `sampleTicker` branch) already calls `collectSystemStats`, which reads from `h.cpuCache` that the `cpuTicker` branch maintains. When `sampleTicker` fires first in a given second the snapshot will use the CPU value from the **previous** second, which is the existing pre-PR behaviour for the very first sample anyway.

   If the intent is to keep CPU sampling at 1 s and full-stats sampling at a different cadence (e.g. every N seconds), the two tickers should have different durations. If the intent is to sample everything at 1 s, a single ticker is cleaner:

   ```go
   tick := time.NewTicker(time.Second)
   defer tick.Stop()

   for {
       select {
       case <-ctx.Done():
           return
       case <-tick.C:
           if vals, err := cpu.Percent(0, false); err == nil && len(vals) > 0 {
               h.cpuCache.Lock()
               h.cpuCache.value = vals[0]
               h.cpuCache.timestamp = time.Now()
               h.cpuCache.Unlock()
           }
           h.storeSystemStatsSnapshotInternal(h.collectSystemStatsSnapshotInternal(ctx))
       }
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/api/ws_handler.go
   Line: 331-354

   Comment:
   **Two tickers at the identical 1-second interval**

   Both `cpuTicker` and `sampleTicker` are created with `1 * time.Second`. Because they are created at almost exactly the same moment they will fire simultaneously on every tick. In Go's `select`, when both channels are ready the runtime picks one at random per iteration, so both **do** fire each second — but in two consecutive iterations rather than being truly concurrent. The result is just extra round-trips through the event loop.

   More importantly, `collectSystemStatsSnapshotInternal` (the `sampleTicker` branch) already calls `collectSystemStats`, which reads from `h.cpuCache` that the `cpuTicker` branch maintains. When `sampleTicker` fires first in a given second the snapshot will use the CPU value from the **previous** second, which is the existing pre-PR behaviour for the very first sample anyway.

   If the intent is to keep CPU sampling at 1 s and full-stats sampling at a different cadence (e.g. every N seconds), the two tickers should have different durations. If the intent is to sample everything at 1 s, a single ticker is cleaner:

   ```go
   tick := time.NewTicker(time.Second)
   defer tick.Stop()

   for {
       select {
       case <-ctx.Done():
           return
       case <-tick.C:
           if vals, err := cpu.Percent(0, false); err == nil && len(vals) > 0 {
               h.cpuCache.Lock()
               h.cpuCache.value = vals[0]
               h.cpuCache.timestamp = time.Now()
               h.cpuCache.Unlock()
           }
           h.storeSystemStatsSnapshotInternal(h.collectSystemStatsSnapshotInternal(ctx))
       }
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fapi%2Fws_handler.go%0ALine%3A%20331-354%0A%0AComment%3A%0A**Two%20tickers%20at%20the%20identical%201-second%20interval**%0A%0ABoth%20%60cpuTicker%60%20and%20%60sampleTicker%60%20are%20created%20with%20%601%20*%20time.Second%60.%20Because%20they%20are%20created%20at%20almost%20exactly%20the%20same%20moment%20they%20will%20fire%20simultaneously%20on%20every%20tick.%20In%20Go's%20%60select%60%2C%20when%20both%20channels%20are%20ready%20the%20runtime%20picks%20one%20at%20random%20per%20iteration%2C%20so%20both%20**do**%20fire%20each%20second%20%E2%80%94%20but%20in%20two%20consecutive%20iterations%20rather%20than%20being%20truly%20concurrent.%20The%20result%20is%20just%20extra%20round-trips%20through%20the%20event%20loop.%0A%0AMore%20importantly%2C%20%60collectSystemStatsSnapshotInternal%60%20%28the%20%60sampleTicker%60%20branch%29%20already%20calls%20%60collectSystemStats%60%2C%20which%20reads%20from%20%60h.cpuCache%60%20that%20the%20%60cpuTicker%60%20branch%20maintains.%20When%20%60sampleTicker%60%20fires%20first%20in%20a%20given%20second%20the%20snapshot%20will%20use%20the%20CPU%20value%20from%20the%20**previous**%20second%2C%20which%20is%20the%20existing%20pre-PR%20behaviour%20for%20the%20very%20first%20sample%20anyway.%0A%0AIf%20the%20intent%20is%20to%20keep%20CPU%20sampling%20at%201%20s%20and%20full-stats%20sampling%20at%20a%20different%20cadence%20%28e.g.%20every%20N%20seconds%29%2C%20the%20two%20tickers%20should%20have%20different%20durations.%20If%20the%20intent%20is%20to%20sample%20everything%20at%201%20s%2C%20a%20single%20ticker%20is%20cleaner%3A%0A%0A%60%60%60go%0Atick%20%3A%3D%20time.NewTicker%28time.Second%29%0Adefer%20tick.Stop%28%29%0A%0Afor%20%7B%0A%20%20%20%20select%20%7B%0A%20%20%20%20case%20%3C-ctx.Done%28%29%3A%0A%20%20%20%20%20%20%20%20return%0A%20%20%20%20case%20%3C-tick.C%3A%0A%20%20%20%20%20%20%20%20if%20vals%2C%20err%20%3A%3D%20cpu.Percent%280%2C%20false%29%3B%20err%20%3D%3D%20nil%20%26%26%20len%28vals%29%20%3E%200%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20h.cpuCache.Lock%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20h.cpuCache.value%20%3D%20vals%5B0%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20h.cpuCache.timestamp%20%3D%20time.Now%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20h.cpuCache.Unlock%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20h.storeSystemStatsSnapshotInternal%28h.collectSystemStatsSnapshotInternal%28ctx%29%29%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

2. `backend/internal/api/ws_handler.go`, line 387-403 ([link](https://github.com/getarcaneapp/arcane/blob/178811f7477217d22ff7e9edbaf59d6045750ebc/backend/internal/api/ws_handler.go#L387-L403)) 

   **Hostname initialisation piggy-backs on `getCPUCount` as a hidden side-effect**

   `getHostname` relies on the fact that `getCPUCount` internally calls `h.systemStaticInfo.once.Do(...)`, which also fetches the hostname. This is a subtle temporal coupling: `getHostname` will silently return an empty string if `getCPUCount` is ever refactored to use a separate `sync.Once`, or if the initialization order changes.

   A cleaner approach is to expose the initialization directly, for example:

   ```go
   func (h *WebSocketHandler) getHostname() string {
       h.initSystemStaticInfoInternal()
       return h.systemStaticInfo.hostname
   }

   func (h *WebSocketHandler) getCPUCount() int {
       h.initSystemStaticInfoInternal()
       return h.systemStaticInfo.cpuCount
   }

   func (h *WebSocketHandler) initSystemStaticInfoInternal() {
       h.systemStaticInfo.once.Do(func() { /* ... */ })
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/api/ws_handler.go
   Line: 387-403

   Comment:
   **Hostname initialisation piggy-backs on `getCPUCount` as a hidden side-effect**

   `getHostname` relies on the fact that `getCPUCount` internally calls `h.systemStaticInfo.once.Do(...)`, which also fetches the hostname. This is a subtle temporal coupling: `getHostname` will silently return an empty string if `getCPUCount` is ever refactored to use a separate `sync.Once`, or if the initialization order changes.

   A cleaner approach is to expose the initialization directly, for example:

   ```go
   func (h *WebSocketHandler) getHostname() string {
       h.initSystemStaticInfoInternal()
       return h.systemStaticInfo.hostname
   }

   func (h *WebSocketHandler) getCPUCount() int {
       h.initSystemStaticInfoInternal()
       return h.systemStaticInfo.cpuCount
   }

   func (h *WebSocketHandler) initSystemStaticInfoInternal() {
       h.systemStaticInfo.once.Do(func() { /* ... */ })
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fapi%2Fws_handler.go%0ALine%3A%20387-403%0A%0AComment%3A%0A**Hostname%20initialisation%20piggy-backs%20on%20%60getCPUCount%60%20as%20a%20hidden%20side-effect**%0A%0A%60getHostname%60%20relies%20on%20the%20fact%20that%20%60getCPUCount%60%20internally%20calls%20%60h.systemStaticInfo.once.Do%28...%29%60%2C%20which%20also%20fetches%20the%20hostname.%20This%20is%20a%20subtle%20temporal%20coupling%3A%20%60getHostname%60%20will%20silently%20return%20an%20empty%20string%20if%20%60getCPUCount%60%20is%20ever%20refactored%20to%20use%20a%20separate%20%60sync.Once%60%2C%20or%20if%20the%20initialization%20order%20changes.%0A%0AA%20cleaner%20approach%20is%20to%20expose%20the%20initialization%20directly%2C%20for%20example%3A%0A%0A%60%60%60go%0Afunc%20%28h%20*WebSocketHandler%29%20getHostname%28%29%20string%20%7B%0A%20%20%20%20h.initSystemStaticInfoInternal%28%29%0A%20%20%20%20return%20h.systemStaticInfo.hostname%0A%7D%0A%0Afunc%20%28h%20*WebSocketHandler%29%20getCPUCount%28%29%20int%20%7B%0A%20%20%20%20h.initSystemStaticInfoInternal%28%29%0A%20%20%20%20return%20h.systemStaticInfo.cpuCount%0A%7D%0A%0Afunc%20%28h%20*WebSocketHandler%29%20initSystemStaticInfoInternal%28%29%20%7B%0A%20%20%20%20h.systemStaticInfo.once.Do%28func%28%29%20%7B%20%2F*%20...%20*%2F%20%7D%29%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

3. `backend/internal/services/settings_service.go`, line 892-899 ([link](https://github.com/getarcaneapp/arcane/blob/43ded6089722202b00bd702d28d9cb7bbff0ae23/backend/internal/services/settings_service.go#L892-L899)) 

   **Empty-string setting values silently treated as "missing"**

   `GetStringSetting` (and the analogous `GetBoolSetting` and `GetIntSetting`) return `defaultValue` both when the key does not exist *and* when the key exists with an explicitly empty value (`val == ""`). This conflates two distinct states and can mask a deliberately-cleared setting.

   A concrete case: `autoHealExcludedContainers` is intentionally set to `""` in the DB to clear a previous exclusion list. `GetStringSetting(ctx, "autoHealExcludedContainers", "")` returns `""` (accidentally correct here because `defaultValue` is also `""`), but another caller that passes a non-empty `defaultValue` would wrongly receive the default instead of the stored empty string.

   Consider separating the two conditions, or documenting that empty-string values always fall back to the default:

   ```go
   func (s *SettingsService) GetStringSetting(ctx context.Context, key, defaultValue string) string {
       cfg := s.GetSettingsConfig()
       val, _, _, err := cfg.FieldByKey(key)
       if err != nil {
           return defaultValue  // key not found → use default
       }
       return val  // return empty string if that is what is stored
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/settings_service.go
   Line: 892-899

   Comment:
   **Empty-string setting values silently treated as "missing"**

   `GetStringSetting` (and the analogous `GetBoolSetting` and `GetIntSetting`) return `defaultValue` both when the key does not exist *and* when the key exists with an explicitly empty value (`val == ""`). This conflates two distinct states and can mask a deliberately-cleared setting.

   A concrete case: `autoHealExcludedContainers` is intentionally set to `""` in the DB to clear a previous exclusion list. `GetStringSetting(ctx, "autoHealExcludedContainers", "")` returns `""` (accidentally correct here because `defaultValue` is also `""`), but another caller that passes a non-empty `defaultValue` would wrongly receive the default instead of the stored empty string.

   Consider separating the two conditions, or documenting that empty-string values always fall back to the default:

   ```go
   func (s *SettingsService) GetStringSetting(ctx context.Context, key, defaultValue string) string {
       cfg := s.GetSettingsConfig()
       val, _, _, err := cfg.FieldByKey(key)
       if err != nil {
           return defaultValue  // key not found → use default
       }
       return val  // return empty string if that is what is stored
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fsettings_service.go%0ALine%3A%20892-899%0A%0AComment%3A%0A**Empty-string%20setting%20values%20silently%20treated%20as%20%22missing%22**%0A%0A%60GetStringSetting%60%20%28and%20the%20analogous%20%60GetBoolSetting%60%20and%20%60GetIntSetting%60%29%20return%20%60defaultValue%60%20both%20when%20the%20key%20does%20not%20exist%20*and*%20when%20the%20key%20exists%20with%20an%20explicitly%20empty%20value%20%28%60val%20%3D%3D%20%22%22%60%29.%20This%20conflates%20two%20distinct%20states%20and%20can%20mask%20a%20deliberately-cleared%20setting.%0A%0AA%20concrete%20case%3A%20%60autoHealExcludedContainers%60%20is%20intentionally%20set%20to%20%60%22%22%60%20in%20the%20DB%20to%20clear%20a%20previous%20exclusion%20list.%20%60GetStringSetting%28ctx%2C%20%22autoHealExcludedContainers%22%2C%20%22%22%29%60%20returns%20%60%22%22%60%20%28accidentally%20correct%20here%20because%20%60defaultValue%60%20is%20also%20%60%22%22%60%29%2C%20but%20another%20caller%20that%20passes%20a%20non-empty%20%60defaultValue%60%20would%20wrongly%20receive%20the%20default%20instead%20of%20the%20stored%20empty%20string.%0A%0AConsider%20separating%20the%20two%20conditions%2C%20or%20documenting%20that%20empty-string%20values%20always%20fall%20back%20to%20the%20default%3A%0A%0A%60%60%60go%0Afunc%20%28s%20*SettingsService%29%20GetStringSetting%28ctx%20context.Context%2C%20key%2C%20defaultValue%20string%29%20string%20%7B%0A%20%20%20%20cfg%20%3A%3D%20s.GetSettingsConfig%28%29%0A%20%20%20%20val%2C%20_%2C%20_%2C%20err%20%3A%3D%20cfg.FieldByKey%28key%29%0A%20%20%20%20if%20err%20!%3D%20nil%20%7B%0A%20%20%20%20%20%20%20%20return%20defaultValue%20%20%2F%2F%20key%20not%20found%20%E2%86%92%20use%20default%0A%20%20%20%20%7D%0A%20%20%20%20return%20val%20%20%2F%2F%20return%20empty%20string%20if%20that%20is%20what%20is%20stored%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

4. `backend/pkg/scheduler/auto_heal_job.go`, line 62-65 ([link](https://github.com/getarcaneapp/arcane/blob/43ded6089722202b00bd702d28d9cb7bbff0ae23/backend/pkg/scheduler/auto_heal_job.go#L62-L65)) 

   **Dead `if schedule == ""` guard after `GetStringSetting`**

   `GetStringSetting` already returns the supplied default (`"*/30 * * * * *"`) when the stored value is empty, so `schedule` can never be `""` here. The second `if schedule == ""` guard is unreachable dead code.

   If the intent is to protect against an empty cron string (e.g. if `GetStringSetting` is later changed to return `""` for missing keys), the guard should be kept and clearly documented. Otherwise, removing it avoids misleading readers:

   ```go
   func (j *AutoHealJob) Schedule(ctx context.Context) string {
       schedule := j.settingsService.GetStringSetting(ctx, "autoHealInterval", "*/30 * * * * *")

       parser := cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/pkg/scheduler/auto_heal_job.go
   Line: 62-65

   Comment:
   **Dead `if schedule == ""` guard after `GetStringSetting`**

   `GetStringSetting` already returns the supplied default (`"*/30 * * * * *"`) when the stored value is empty, so `schedule` can never be `""` here. The second `if schedule == ""` guard is unreachable dead code.

   If the intent is to protect against an empty cron string (e.g. if `GetStringSetting` is later changed to return `""` for missing keys), the guard should be kept and clearly documented. Otherwise, removing it avoids misleading readers:

   ```go
   func (j *AutoHealJob) Schedule(ctx context.Context) string {
       schedule := j.settingsService.GetStringSetting(ctx, "autoHealInterval", "*/30 * * * * *")

       parser := cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Fscheduler%2Fauto_heal_job.go%0ALine%3A%2062-65%0A%0AComment%3A%0A**Dead%20%60if%20schedule%20%3D%3D%20%22%22%60%20guard%20after%20%60GetStringSetting%60**%0A%0A%60GetStringSetting%60%20already%20returns%20the%20supplied%20default%20%28%60%22*%2F30%20*%20*%20*%20*%20*%22%60%29%20when%20the%20stored%20value%20is%20empty%2C%20so%20%60schedule%60%20can%20never%20be%20%60%22%22%60%20here.%20The%20second%20%60if%20schedule%20%3D%3D%20%22%22%60%20guard%20is%20unreachable%20dead%20code.%0A%0AIf%20the%20intent%20is%20to%20protect%20against%20an%20empty%20cron%20string%20%28e.g.%20if%20%60GetStringSetting%60%20is%20later%20changed%20to%20return%20%60%22%22%60%20for%20missing%20keys%29%2C%20the%20guard%20should%20be%20kept%20and%20clearly%20documented.%20Otherwise%2C%20removing%20it%20avoids%20misleading%20readers%3A%0A%0A%60%60%60go%0Afunc%20%28j%20*AutoHealJob%29%20Schedule%28ctx%20context.Context%29%20string%20%7B%0A%20%20%20%20schedule%20%3A%3D%20j.settingsService.GetStringSetting%28ctx%2C%20%22autoHealInterval%22%2C%20%22*%2F30%20*%20*%20*%20*%20*%22%29%0A%0A%20%20%20%20parser%20%3A%3D%20cron.NewParser%28cron.Second%20%7C%20cron.Minute%20%7C%20cron.Hour%20%7C%20cron.Dom%20%7C%20cron.Month%20%7C%20cron.Dow%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

5. `backend/internal/services/settings_service.go`, line 482-507 ([link](https://github.com/getarcaneapp/arcane/blob/05422a565ed600fab93684fbabae7098c0826d59/backend/internal/services/settings_service.go#L482-L507)) 

   **`UpdateSettings` response silently drops env-variable overrides**

   `settings` is now fetched from `GetSettingsConfig()` (line 482), which returns the raw database snapshot with no env overrides applied. The old code used `GetSettings(ctx)`, which applied `applyEnvOverrides` before returning. As a result, the slice returned at line 507 will show un-overridden DB values even when `DOCKER_HOST` or other `envOverride`-tagged vars are set.

   This creates a confusing inconsistency: `GET /settings` (which goes through `GetSettings`) shows the env-overridden value, but the `PATCH /settings` response shows the raw DB value.

   Applying env overrides before serializing the return value keeps the two endpoints consistent:

6. `backend/internal/api/ws_handler.go`, line 951-958 ([link](https://github.com/getarcaneapp/arcane/blob/027017fab1da4f271fee4f68d8ea34254e3b23c8/backend/internal/api/ws_handler.go#L951-L958)) 

   **`acquireSystemStatsSamplerInternal` cannot be cancelled during CPU init**

   `initializeCPUCache()` calls `cpu.Percent(time.Second, false)`, which blocks unconditionally for ~1 second. If all clients disconnect during this window, `releaseSystemStatsSamplerInternal` cancels the context and sets `running = false`, but the function is already past the lock and cannot observe the cancellation. The function returns, registers the deferred `releaseSystemStatsSamplerInternal`, and eventually cleans up correctly — so there is no leak — but the `SystemStats` handler is pinned for up to a second longer than the connection lasts, and a new sampler cycle won't start until after the deferred release runs.

   Consider accepting a `context.Context` parameter so the CPU init can bail out early if the client disconnects before the baseline sample completes:

   ```go
   func (h *WebSocketHandler) acquireSystemStatsSamplerInternal(ctx context.Context) {
       ...
       go func() {
           h.initializeCPUCacheCtx(ctx) // bails on ctx.Done()
           h.storeSystemStatsSnapshotInternal(h.collectSystemStatsSnapshotInternal(ctx))
           close(ready)
           if ctx.Err() == nil {
               h.runSystemStatsSamplerInternal(ctx)
           }
       }()
   }
   ```

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Finternal%2Fapi%2Fws_handler.go%3A951-958%0A**%60acquireSystemStatsSamplerInternal%60%20cannot%20be%20cancelled%20during%20CPU%20init**%0A%0A%60initializeCPUCache%28%29%60%20calls%20%60cpu.Percent%28time.Second%2C%20false%29%60%2C%20which%20blocks%20unconditionally%20for%20~1%20second.%20If%20all%20clients%20disconnect%20during%20this%20window%2C%20%60releaseSystemStatsSamplerInternal%60%20cancels%20the%20context%20and%20sets%20%60running%20%3D%20false%60%2C%20but%20the%20function%20is%20already%20past%20the%20lock%20and%20cannot%20observe%20the%20cancellation.%20The%20function%20returns%2C%20registers%20the%20deferred%20%60releaseSystemStatsSamplerInternal%60%2C%20and%20eventually%20cleans%20up%20correctly%20%E2%80%94%20so%20there%20is%20no%20leak%20%E2%80%94%20but%20the%20%60SystemStats%60%20handler%20is%20pinned%20for%20up%20to%20a%20second%20longer%20than%20the%20connection%20lasts%2C%20and%20a%20new%20sampler%20cycle%20won't%20start%20until%20after%20the%20deferred%20release%20runs.%0A%0AConsider%20accepting%20a%20%60context.Context%60%20parameter%20so%20the%20CPU%20init%20can%20bail%20out%20early%20if%20the%20client%20disconnects%20before%20the%20baseline%20sample%20completes%3A%0A%0A%60%60%60go%0Afunc%20%28h%20*WebSocketHandler%29%20acquireSystemStatsSamplerInternal%28ctx%20context.Context%29%20%7B%0A%20%20%20%20...%0A%20%20%20%20go%20func%28%29%20%7B%0A%20%20%20%20%20%20%20%20h.initializeCPUCacheCtx%28ctx%29%20%2F%2F%20bails%20on%20ctx.Done%28%29%0A%20%20%20%20%20%20%20%20h.storeSystemStatsSnapshotInternal%28h.collectSystemStatsSnapshotInternal%28ctx%29%29%0A%20%20%20%20%20%20%20%20close%28ready%29%0A%20%20%20%20%20%20%20%20if%20ctx.Err%28%29%20%3D%3D%20nil%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20h.runSystemStatsSamplerInternal%28ctx%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%28%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Abackend%2Finternal%2Fapi%2Fws_handler.go%3A490-512%0A**%60waitForLogStreamSubscriberInternal%60%20polls%20the%20hub%20client%20count**%0A%0AThe%20source%20goroutine%20spins%20on%20a%205%20ms%20ticker%20waiting%20for%20the%20hub%20to%20report%20%60ClientCount%28%29%20%3E%200%60.%20In%20practice%20clients%20connect%20almost%20immediately%20%28the%20stream%20was%20just%20returned%20by%20%60getOrCreateLogStreamInternal%60%29%2C%20so%20this%20rarely%20runs%20more%20than%20one%20or%20two%20iterations.%20However%20it%20still%20creates%20an%20extra%20goroutine%20%28the%20ticker%20goroutine%20inside%20%60time.NewTicker%60%29%20for%20every%20log%20stream%2C%20and%20reads%20the%20hub's%20read-lock%20every%205%20ms.%0A%0AA%20simpler%2C%20zero-overhead%20alternative%20is%20a%20%22first%20subscriber%22%20channel%20set%20before%20%60hub.Run%60%3A%0A%0A%60%60%60go%0A%2F%2F%20in%20newWSLogStreamInternal%20%28or%20the%20hub%20itself%29%3A%0AfirstSub%20%3A%3D%20make%28chan%20struct%7B%7D%29%0Als.hub.SetOnFirstClient%28func%28%29%20%7B%20close%28firstSub%29%20%7D%29%0A%0A%2F%2F%20in%20the%20source%20goroutine%3A%0Aselect%20%7B%0Acase%20%3C-ctx.Done%28%29%3A%0A%20%20%20%20return%0Acase%20%3C-firstSub%3A%0A%7D%0A%60%60%60%0A%0AThis%20avoids%20any%20polling%20and%20removes%20the%20ticker%20goroutine%20entirely.%0A%0A%23%23%23%20Issue%203%20of%203%0Abackend%2Finternal%2Fservices%2Fsettings_service.go%3A463-466%0A**%60UpdateSettings%60%20calls%20%60GetSettings%60%20%28DB%20path%29%20then%20immediately%20calls%20%60refreshSettingsCacheInternal%60%20%28another%20DB%20read%29**%0A%0A%60GetSettings%60%20at%20line%20465%20now%20returns%20a%20clone%20of%20the%20in-memory%20cache%20with%20env%20overrides%20applied%20%E2%80%94%20it%20no%20longer%20hits%20the%20database.%20However%20%60refreshSettingsCacheInternal%60%20is%20still%20called%20unconditionally%20after%20%60persistSettings%60%2C%20which%20performs%20a%20full%20DB%20load.%20The%20double-read%20is%20not%20a%20correctness%20issue%2C%20but%20the%20%60GetSettings%60%20call%20here%20is%20used%20purely%20to%20build%20%60cfg%60%20for%20%60prepareUpdateValues%60.%20Using%20%60s.GetSettingsConfig%28%29%60%20directly%20%28and%20applying%20env%20overrides%20inline%20if%20needed%20for%20comparison%29%20would%20save%20the%20extra%20clone%20allocation%20and%20make%20the%20intent%20clearer.%0A%0A%60%60%60go%0Acfg%2C%20err%20%3A%3D%20s.GetSettings%28ctx%29%20%2F%2F%20reads%20cache%20%2B%20clones%20%2B%20applies%20env%20overrides%0A%60%60%60%0Avs.%0A%60%60%60go%0Acfg%20%3A%3D%20s.GetSettingsConfig%28%29.Clone%28%29%20%2F%2F%20same%20result%2C%20no%20extra%20function%20call%20overhead%0As.applyEnvOverrides%28ctx%2C%20cfg%29%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/api/ws_handler.go
Line: 951-958

Comment:
**`acquireSystemStatsSamplerInternal` cannot be cancelled during CPU init**

`initializeCPUCache()` calls `cpu.Percent(time.Second, false)`, which blocks unconditionally for ~1 second. If all clients disconnect during this window, `releaseSystemStatsSamplerInternal` cancels the context and sets `running = false`, but the function is already past the lock and cannot observe the cancellation. The function returns, registers the deferred `releaseSystemStatsSamplerInternal`, and eventually cleans up correctly — so there is no leak — but the `SystemStats` handler is pinned for up to a second longer than the connection lasts, and a new sampler cycle won't start until after the deferred release runs.

Consider accepting a `context.Context` parameter so the CPU init can bail out early if the client disconnects before the baseline sample completes:

```go
func (h *WebSocketHandler) acquireSystemStatsSamplerInternal(ctx context.Context) {
    ...
    go func() {
        h.initializeCPUCacheCtx(ctx) // bails on ctx.Done()
        h.storeSystemStatsSnapshotInternal(h.collectSystemStatsSnapshotInternal(ctx))
        close(ready)
        if ctx.Err() == nil {
            h.runSystemStatsSamplerInternal(ctx)
        }
    }()
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/api/ws_handler.go
Line: 490-512

Comment:
**`waitForLogStreamSubscriberInternal` polls the hub client count**

The source goroutine spins on a 5 ms ticker waiting for the hub to report `ClientCount() > 0`. In practice clients connect almost immediately (the stream was just returned by `getOrCreateLogStreamInternal`), so this rarely runs more than one or two iterations. However it still creates an extra goroutine (the ticker goroutine inside `time.NewTicker`) for every log stream, and reads the hub's read-lock every 5 ms.

A simpler, zero-overhead alternative is a "first subscriber" channel set before `hub.Run`:

```go
// in newWSLogStreamInternal (or the hub itself):
firstSub := make(chan struct{})
ls.hub.SetOnFirstClient(func() { close(firstSub) })

// in the source goroutine:
select {
case <-ctx.Done():
    return
case <-firstSub:
}
```

This avoids any polling and removes the ticker goroutine entirely.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/services/settings_service.go
Line: 463-466

Comment:
**`UpdateSettings` calls `GetSettings` (DB path) then immediately calls `refreshSettingsCacheInternal` (another DB read)**

`GetSettings` at line 465 now returns a clone of the in-memory cache with env overrides applied — it no longer hits the database. However `refreshSettingsCacheInternal` is still called unconditionally after `persistSettings`, which performs a full DB load. The double-read is not a correctness issue, but the `GetSettings` call here is used purely to build `cfg` for `prepareUpdateValues`. Using `s.GetSettingsConfig()` directly (and applying env overrides inline if needed for comparison) would save the extra clone allocation and make the intent clearer.

```go
cfg, err := s.GetSettings(ctx) // reads cache + clones + applies env overrides
```
vs.
```go
cfg := s.GetSettingsConfig().Clone() // same result, no extra function call overhead
s.applyEnvOverrides(ctx, cfg)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (9): Last reviewed commit: ["perf: share websocket streams, cache set..."](https://github.com/getarcaneapp/arcane/commit/027017fab1da4f271fee4f68d8ea34254e3b23c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=24178403)</sub>

<!-- /greptile_comment -->