### PR TITLE
fix: dockerfile_inline builds not working from projects

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -837,8 +837,10 @@ func (s *ProjectService) DeployProject(ctx context.Context, projectID string, us
 		return fmt.Errorf("failed to update project status to deploying: %w", err)
 	}
 
-	if perr := s.prepareProjectImagesForDeploy(ctx, projectID, project, io.Discard, nil, &user, resolvedPullPolicy); perr != nil {
-		slog.Warn("prepare images for deploy failed (continuing to compose up)", "projectID", projectID, "error", perr)
+	progressWriter, _ := ctx.Value(projects.ProgressWriterKey{}).(io.Writer)
+	if perr := s.prepareProjectImagesForDeploy(ctx, projectID, project, progressWriter, nil, &user, resolvedPullPolicy); perr != nil {
+		s.restoreProjectStatusAfterFailedDeployInternal(ctx, projectID)
+		return fmt.Errorf("failed to prepare project images for deploy: %w", perr)
 	}
 
 	removeOrphans := projectFromDb.GitOpsManagedBy != nil && *projectFromDb.GitOpsManagedBy != ""
@@ -850,7 +852,7 @@ func (s *ProjectService) DeployProject(ctx context.Context, projectID string, us
 		if containers, psErr := s.GetProjectServices(ctx, projectID); psErr == nil {
 			slog.Info("containers after failed deploy", "projectID", projectID, "containers", containers)
 		}
-		_ = s.updateProjectStatusandCountsInternal(ctx, projectID, models.ProjectStatusStopped)
+		s.restoreProjectStatusAfterFailedDeployInternal(ctx, projectID)
 
 		// Provide more helpful error messages
 		errMsg := err.Error()
@@ -1258,6 +1260,9 @@ func (s *ProjectService) prepareProjectImagesForDeploy(
 		}
 
 		decision := decideDeployImageAction(svc, pullPolicyOverride)
+		if updated {
+			decision = deployImageDecision{Build: true}
+		}
 		if err := s.ensureDeployServiceImageReady(ctx, projectID, project, name, svc, imageName, decision, progressWriter, credentials, user, pathMapper); err != nil {
 			return err
 		}
@@ -1442,7 +1447,7 @@ func decideDeployImageAction(svc composetypes.ServiceConfig, pullPolicyOverride 
 	}
 }
 
-func resolveBuildContext(workingDir string, svc composetypes.ServiceConfig, serviceName string, pathMapper *pathmapper.PathMapper) (string, error) {
+func resolveBuildContextInternal(workingDir string, svc composetypes.ServiceConfig, serviceName string) (string, error) {
 	contextDir := strings.TrimSpace(svc.Build.Context)
 	if contextDir == "" {
 		contextDir = workingDir
@@ -1454,32 +1459,16 @@ func resolveBuildContext(workingDir string, svc composetypes.ServiceConfig, serv
 		return "", fmt.Errorf("build context not set for service %s", serviceName)
 	}
 
-	if pathMapper == nil {
-		return contextDir, nil
-	}
-
-	mapped, err := pathMapper.ContainerToHost(contextDir)
-	if err != nil {
-		return "", fmt.Errorf("failed to map build context for %s: %w", serviceName, err)
-	}
-	return mapped, nil
+	return contextDir, nil
 }
 
-func resolveDockerfilePath(svc composetypes.ServiceConfig, serviceName string, pathMapper *pathmapper.PathMapper) (string, error) {
+func resolveDockerfilePathInternal(svc composetypes.ServiceConfig) (string, error) {
 	dockerfilePath := strings.TrimSpace(svc.Build.Dockerfile)
 	if dockerfilePath == "" {
 		dockerfilePath = "Dockerfile"
 	}
 
-	if !filepath.IsAbs(dockerfilePath) || pathMapper == nil {
-		return dockerfilePath, nil
-	}
-
-	mapped, err := pathMapper.ContainerToHost(dockerfilePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to map dockerfile path for %s: %w", serviceName, err)
-	}
-	return mapped, nil
+	return dockerfilePath, nil
 }
 
 func buildArgsFromCompose(args map[string]*string) map[string]string {
@@ -1610,31 +1599,40 @@ func (s *ProjectService) prepareServiceBuildRequest(
 		return imagetypes.BuildRequest{}, updatedSvc, updated, fmt.Errorf("service %s must define an image when push is enabled", serviceName)
 	}
 
-	contextDir, err := resolveBuildContext(project.WorkingDir, updatedSvc, serviceName, pathMapper)
+	contextDir, err := resolveBuildContextInternal(project.WorkingDir, updatedSvc, serviceName)
 	if err != nil {
 		return imagetypes.BuildRequest{}, updatedSvc, updated, err
 	}
 
-	dockerfilePath, err := resolveDockerfilePath(updatedSvc, serviceName, pathMapper)
-	if err != nil {
-		return imagetypes.BuildRequest{}, updatedSvc, updated, err
+	dockerfileInline := updatedSvc.Build.DockerfileInline
+	if strings.TrimSpace(updatedSvc.Build.Dockerfile) != "" && strings.TrimSpace(dockerfileInline) != "" {
+		return imagetypes.BuildRequest{}, updatedSvc, updated, fmt.Errorf("service %s cannot define both dockerfile and dockerfile_inline", serviceName)
+	}
+
+	dockerfilePath := ""
+	if strings.TrimSpace(dockerfileInline) == "" {
+		dockerfilePath, err = resolveDockerfilePathInternal(updatedSvc)
+		if err != nil {
+			return imagetypes.BuildRequest{}, updatedSvc, updated, err
+		}
 	}
 
 	buildReq := imagetypes.BuildRequest{
-		ContextDir: contextDir,
-		Dockerfile: dockerfilePath,
-		Tags:       mergeBuildTags(imageName, updatedSvc.Build.Tags),
-		Target:     strings.TrimSpace(updatedSvc.Build.Target),
-		BuildArgs:  buildArgsFromCompose(updatedSvc.Build.Args),
-		Labels:     labelsFromCompose(updatedSvc.Build.Labels),
-		CacheFrom:  append([]string(nil), updatedSvc.Build.CacheFrom...),
-		CacheTo:    append([]string(nil), updatedSvc.Build.CacheTo...),
-		NoCache:    updatedSvc.Build.NoCache,
-		Pull:       updatedSvc.Build.Pull,
-		Network:    strings.TrimSpace(updatedSvc.Build.Network),
-		Isolation:  strings.TrimSpace(updatedSvc.Build.Isolation),
-		ShmSize:    int64(updatedSvc.Build.ShmSize),
-		Ulimits:    ulimitsFromCompose(updatedSvc.Build.Ulimits),
+		ContextDir:       contextDir,
+		Dockerfile:       dockerfilePath,
+		DockerfileInline: dockerfileInline,
+		Tags:             mergeBuildTags(imageName, updatedSvc.Build.Tags),
+		Target:           strings.TrimSpace(updatedSvc.Build.Target),
+		BuildArgs:        buildArgsFromCompose(updatedSvc.Build.Args),
+		Labels:           labelsFromCompose(updatedSvc.Build.Labels),
+		CacheFrom:        append([]string(nil), updatedSvc.Build.CacheFrom...),
+		CacheTo:          append([]string(nil), updatedSvc.Build.CacheTo...),
+		NoCache:          updatedSvc.Build.NoCache,
+		Pull:             updatedSvc.Build.Pull,
+		Network:          strings.TrimSpace(updatedSvc.Build.Network),
+		Isolation:        strings.TrimSpace(updatedSvc.Build.Isolation),
+		ShmSize:          int64(updatedSvc.Build.ShmSize),
+		Ulimits:          ulimitsFromCompose(updatedSvc.Build.Ulimits),
 		Entitlements: append(
 			[]string(nil),
 			updatedSvc.Build.Entitlements...,
@@ -1652,6 +1650,30 @@ func (s *ProjectService) prepareServiceBuildRequest(
 	}
 
 	return buildReq, updatedSvc, updated, nil
+}
+
+func (s *ProjectService) restoreProjectStatusAfterFailedDeployInternal(ctx context.Context, projectID string) {
+	services, err := s.GetProjectServices(ctx, projectID)
+	if err == nil {
+		serviceCount, runningCount := s.getServiceCounts(services)
+		status := s.calculateProjectStatus(services)
+		if updateErr := s.db.WithContext(ctx).Model(&models.Project{}).Where("id = ?", projectID).Updates(map[string]any{
+			"status":        status,
+			"service_count": serviceCount,
+			"running_count": runningCount,
+			"updated_at":    time.Now(),
+		}).Error; updateErr == nil {
+			return
+		} else {
+			slog.WarnContext(ctx, "failed to restore project status after deploy failure", "projectID", projectID, "error", updateErr)
+		}
+	} else {
+		slog.WarnContext(ctx, "failed to inspect project services after deploy failure", "projectID", projectID, "error", err)
+	}
+
+	if updateErr := s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusStopped); updateErr != nil {
+		slog.WarnContext(ctx, "failed to set stopped status after deploy failure", "projectID", projectID, "error", updateErr)
+	}
 }
 
 func (s *ProjectService) buildProjectServicesInternal(ctx context.Context, projectID string, project *composetypes.Project, options ProjectBuildOptions, progressWriter io.Writer, user *models.User) error {

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -2,12 +2,17 @@ package services
 
 import (
 	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	composetypes "github.com/compose-spec/compose-go/v2/types"
+	"github.com/getarcaneapp/arcane/backend/internal/utils/pathmapper"
+	buildtypes "github.com/getarcaneapp/arcane/types/builds"
+	imagetypes "github.com/getarcaneapp/arcane/types/image"
 	glsqlite "github.com/glebarez/sqlite"
 	"github.com/moby/moby/api/types/container"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +22,19 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 )
+
+type testBuildBuilder struct {
+	err error
+}
+
+func (b testBuildBuilder) BuildImage(_ context.Context, _ imagetypes.BuildRequest, _ io.Writer, _ string) (*imagetypes.BuildResult, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+	return &imagetypes.BuildResult{Provider: "local"}, nil
+}
+
+var _ buildtypes.Builder = testBuildBuilder{}
 
 func setupProjectTestDB(t *testing.T) *database.DB {
 	t.Helper()
@@ -710,6 +728,64 @@ func TestProjectService_PrepareServiceBuildRequest_MapsComposeFields(t *testing.
 	assert.Contains(t, req.ExtraHosts[0], "10.0.0.5")
 }
 
+func TestProjectService_PrepareServiceBuildRequest_UsesExecutorVisiblePaths(t *testing.T) {
+	svc := &ProjectService{}
+	proj := &composetypes.Project{WorkingDir: "/app/data/projects/demo", Name: "demo"}
+	pm := pathmapper.NewPathMapper("/app/data/projects", "/docker-data/arcane/projects")
+
+	serviceCfg := composetypes.ServiceConfig{
+		Name:  "web",
+		Image: "example/web:latest",
+		Build: &composetypes.BuildConfig{
+			Context:    ".",
+			Dockerfile: "/app/data/projects/demo/Dockerfile.custom",
+		},
+	}
+
+	req, _, _, err := svc.prepareServiceBuildRequest(
+		context.Background(),
+		"project-id",
+		proj,
+		"web",
+		serviceCfg,
+		ProjectBuildOptions{},
+		pm,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/app/data/projects/demo", req.ContextDir)
+	assert.Equal(t, "/app/data/projects/demo/Dockerfile.custom", req.Dockerfile)
+}
+
+func TestProjectService_PrepareServiceBuildRequest_UsesInlineDockerfile(t *testing.T) {
+	svc := &ProjectService{}
+	proj := &composetypes.Project{WorkingDir: "/tmp/project", Name: "demo"}
+
+	serviceCfg := composetypes.ServiceConfig{
+		Name:  "web",
+		Image: "example/web:latest",
+		Build: &composetypes.BuildConfig{
+			Context:          ".",
+			DockerfileInline: "FROM alpine:3.20\nRUN echo inline\n",
+		},
+	}
+
+	req, _, _, err := svc.prepareServiceBuildRequest(
+		context.Background(),
+		"project-id",
+		proj,
+		"web",
+		serviceCfg,
+		ProjectBuildOptions{},
+		nil,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/tmp/project", req.ContextDir)
+	assert.Empty(t, req.Dockerfile)
+	assert.Equal(t, "FROM alpine:3.20\nRUN echo inline\n", req.DockerfileInline)
+}
+
 func TestNormalizePullPolicy(t *testing.T) {
 	assert.Equal(t, "missing", normalizePullPolicy("if_not_present"))
 	assert.Equal(t, "build", normalizePullPolicy(" BUILD "))
@@ -786,6 +862,84 @@ func TestProjectService_PrepareServiceBuildRequest_GeneratedImageProviderGuardra
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must define an image when push is enabled")
+}
+
+func TestProjectService_DeployProject_StopsOnBuildPreparationError(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectsRoot := t.TempDir()
+	projectDir := filepath.Join(projectsRoot, "demo")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	composeContent := "services:\n" +
+		"  web:\n" +
+		"    pull_policy: build\n" +
+		"    build:\n" +
+		"      context: .\n"
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "compose.yaml"), []byte(composeContent), 0o644))
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot+":"+projectsRoot))
+
+	proj := &models.Project{
+		BaseModel: models.BaseModel{ID: "p1"},
+		Name:      "demo",
+		Path:      projectDir,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(proj).Error)
+
+	buildSvc := &BuildService{builder: testBuildBuilder{err: errors.New("boom build")}}
+	svc := NewProjectService(db, settingsService, nil, nil, nil, buildSvc)
+
+	err = svc.DeployProject(ctx, "p1", models.User{BaseModel: models.BaseModel{ID: "u1"}, Username: "tester"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to prepare project images for deploy")
+	assert.Contains(t, err.Error(), "boom build")
+
+	var updated models.Project
+	require.NoError(t, db.First(&updated, "id = ?", "p1").Error)
+	assert.Equal(t, models.ProjectStatusStopped, updated.Status)
+}
+
+func TestProjectService_DeployProject_BuildsGeneratedImageWithoutPull(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectsRoot := t.TempDir()
+	projectDir := filepath.Join(projectsRoot, "demo")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	composeContent := "services:\n" +
+		"  caddy:\n" +
+		"    build:\n" +
+		"      dockerfile_inline: |\n" +
+		"        FROM caddy:builder AS builder\n" +
+		"        RUN xcaddy build --with github.com/caddyserver/replace-response\n" +
+		"\n" +
+		"        FROM caddy:latest\n" +
+		"        COPY --from=builder /usr/bin/caddy /usr/bin/caddy\n"
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "compose.yaml"), []byte(composeContent), 0o644))
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot+":"+projectsRoot))
+
+	proj := &models.Project{
+		BaseModel: models.BaseModel{ID: "p-generated"},
+		Name:      "build-test",
+		Path:      projectDir,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(proj).Error)
+
+	buildSvc := &BuildService{builder: testBuildBuilder{err: errors.New("boom build")}}
+	svc := NewProjectService(db, settingsService, nil, nil, nil, buildSvc)
+
+	err = svc.DeployProject(ctx, proj.ID, models.User{BaseModel: models.BaseModel{ID: "u1"}, Username: "tester"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to prepare project images for deploy")
+	assert.Contains(t, err.Error(), "boom build")
+	assert.NotContains(t, err.Error(), "failed to pull image arcane.local/")
+	assert.NotContains(t, err.Error(), "failed to resolve reference \"arcane.local/")
 }
 
 //go:fix inline

--- a/backend/pkg/libarcane/libbuild/builder_buildkit.go
+++ b/backend/pkg/libarcane/libbuild/builder_buildkit.go
@@ -99,21 +99,26 @@ func normalizeEntitlementsInternal(entitlements []string, privileged bool) []str
 	return out
 }
 
-func (b *builder) buildSolveOptInternal(ctx context.Context, req imagetypes.BuildRequest) (buildkit.SolveOpt, <-chan error, error) {
-	contextDir := filepath.Clean(req.ContextDir)
-
-	dockerfilePath := strings.TrimSpace(req.Dockerfile)
-	if dockerfilePath == "" {
-		dockerfilePath = "Dockerfile"
+func (b *builder) buildSolveOptInternal(ctx context.Context, req imagetypes.BuildRequest) (buildkit.SolveOpt, <-chan error, func(), error) {
+	fsInput, err := prepareBuildFilesystemInputInternal(req)
+	if err != nil {
+		return buildkit.SolveOpt{}, nil, nil, err
 	}
 
-	fullDockerfilePath := dockerfilePath
-	if !filepath.IsAbs(dockerfilePath) {
-		fullDockerfilePath = filepath.Join(contextDir, dockerfilePath)
+	contextDir, dockerfilePath, cleanup, err := prepareBuildContextInternal(fsInput)
+	if err != nil {
+		return buildkit.SolveOpt{}, nil, nil, err
+	}
+
+	dockerfileDir := contextDir
+	dockerfileFilename := dockerfilePath
+	if dockerfileRelDir := filepath.Dir(filepath.FromSlash(dockerfilePath)); dockerfileRelDir != "." {
+		dockerfileDir = filepath.Join(contextDir, dockerfileRelDir)
+		dockerfileFilename = filepath.Base(dockerfilePath)
 	}
 
 	frontendAttrs := map[string]string{
-		"filename": filepath.Base(fullDockerfilePath),
+		"filename": dockerfileFilename,
 	}
 	if strings.TrimSpace(req.Target) != "" {
 		frontendAttrs["target"] = strings.TrimSpace(req.Target)
@@ -143,7 +148,7 @@ func (b *builder) buildSolveOptInternal(ctx context.Context, req imagetypes.Buil
 		FrontendAttrs: frontendAttrs,
 		LocalDirs: map[string]string{
 			"context":    contextDir,
-			"dockerfile": filepath.Dir(fullDockerfilePath),
+			"dockerfile": dockerfileDir,
 		},
 		CacheImports:        parseBuildkitCacheEntriesInternal(req.CacheFrom),
 		CacheExports:        parseBuildkitCacheEntriesInternal(req.CacheTo),
@@ -165,7 +170,8 @@ func (b *builder) buildSolveOptInternal(ctx context.Context, req imagetypes.Buil
 	if req.Load {
 		exportEntry, errCh, err := b.buildLoadExportInternal(ctx, req.Tags)
 		if err != nil {
-			return buildkit.SolveOpt{}, nil, err
+			cleanup()
+			return buildkit.SolveOpt{}, nil, nil, err
 		}
 		loadErrCh = errCh
 		exports = append(exports, exportEntry)
@@ -175,7 +181,7 @@ func (b *builder) buildSolveOptInternal(ctx context.Context, req imagetypes.Buil
 		solveOpt.Exports = exports
 	}
 
-	return solveOpt, loadErrCh, nil
+	return solveOpt, loadErrCh, cleanup, nil
 }
 
 func (b *builder) buildLoadExportInternal(ctx context.Context, tags []string) (buildkit.ExportEntry, chan error, error) {

--- a/backend/pkg/libarcane/libbuild/builder_buildkit_test.go
+++ b/backend/pkg/libarcane/libbuild/builder_buildkit_test.go
@@ -1,0 +1,45 @@
+package libbuild
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	imagetypes "github.com/getarcaneapp/arcane/types/image"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSolveOptInternal_StagesInlineDockerfile(t *testing.T) {
+	contextDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(contextDir, "app.txt"), []byte("hello\n"), 0o644))
+
+	b := &builder{}
+	req := imagetypes.BuildRequest{
+		ContextDir:       contextDir,
+		DockerfileInline: "FROM alpine:3.20\nCOPY app.txt /app.txt\n",
+		BuildArgs: map[string]string{
+			"FOO": "bar",
+		},
+	}
+
+	solveOpt, loadErrCh, cleanup, err := b.buildSolveOptInternal(context.Background(), req)
+	require.NoError(t, err)
+	defer cleanup()
+	assert.Nil(t, loadErrCh)
+	assert.Equal(t, ".arcane.inline.Dockerfile", solveOpt.FrontendAttrs["filename"])
+
+	contextPath := solveOpt.LocalDirs["context"]
+	dockerfileDir := solveOpt.LocalDirs["dockerfile"]
+	assert.NotEmpty(t, contextPath)
+	assert.Equal(t, contextPath, dockerfileDir)
+
+	contents, err := os.ReadFile(filepath.Join(dockerfileDir, solveOpt.FrontendAttrs["filename"]))
+	require.NoError(t, err)
+	assert.Equal(t, "FROM alpine:3.20\nCOPY app.txt /app.txt\n", string(contents))
+
+	appContents, err := os.ReadFile(filepath.Join(contextPath, "app.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello\n", string(appContents))
+}

--- a/backend/pkg/libarcane/libbuild/builder_core.go
+++ b/backend/pkg/libarcane/libbuild/builder_core.go
@@ -84,11 +84,12 @@ func (b *builder) BuildImage(ctx context.Context, req imagetypes.BuildRequest, p
 		}
 	}()
 
-	solveOpt, loadErrCh, err := b.buildSolveOptInternal(buildCtx, req)
+	solveOpt, loadErrCh, cleanupSolveOpt, err := b.buildSolveOptInternal(buildCtx, req)
 	if err != nil {
 		buildErr = err
 		return nil, err
 	}
+	defer cleanupSolveOpt()
 
 	authProvider := authprovider.NewDockerAuthProvider(authprovider.DockerAuthProviderConfig{
 		AuthConfigProvider: buildkitAuthConfigProviderInternal(authprovider.LoadAuthConfig(config.LoadDefaultConfigFile(os.Stderr)), b.registryAuthProvider),

--- a/backend/pkg/libarcane/libbuild/builder_docker.go
+++ b/backend/pkg/libarcane/libbuild/builder_docker.go
@@ -23,21 +23,26 @@ import (
 )
 
 type dockerBuildInput struct {
+	buildFilesystemInput
+	platform    string
+	buildArgs   map[string]*string
+	labels      map[string]string
+	cacheFrom   []string
+	noCache     bool
+	pullParent  bool
+	networkMode string
+	isolation   string
+	shmSize     int64
+	ulimits     []*dockercontainer.Ulimit
+	extraHosts  []string
+}
+
+type buildFilesystemInput struct {
 	contextDir           string
 	fullDockerfilePath   string
 	relDockerfile        string
 	dockerfileOutsideCtx bool
-	platform             string
-	buildArgs            map[string]*string
-	labels               map[string]string
-	cacheFrom            []string
-	noCache              bool
-	pullParent           bool
-	networkMode          string
-	isolation            string
-	shmSize              int64
-	ulimits              []*dockercontainer.Ulimit
-	extraHosts           []string
+	dockerfileInline     string
 }
 
 func parseUlimitsInternal(values map[string]string) []*dockercontainer.Ulimit {
@@ -79,19 +84,19 @@ func parseUlimitsInternal(values map[string]string) []*dockercontainer.Ulimit {
 	return out
 }
 
-func prepareDockerBuildInputInternal(req imagetypes.BuildRequest) (dockerBuildInput, bool, error) {
+func prepareBuildFilesystemInputInternal(req imagetypes.BuildRequest) (buildFilesystemInput, error) {
 	contextDir := filepath.Clean(req.ContextDir)
 	if contextDir == "" {
-		return dockerBuildInput{}, false, errors.New("contextDir is required")
+		return buildFilesystemInput{}, errors.New("contextDir is required")
 	}
 
-	if len(req.Platforms) > 1 {
-		return dockerBuildInput{}, true, fmt.Errorf("docker build fallback does not support multi-platform builds")
-	}
-
-	platform := ""
-	if len(req.Platforms) == 1 {
-		platform = strings.TrimSpace(req.Platforms[0])
+	if strings.TrimSpace(req.DockerfileInline) != "" {
+		return buildFilesystemInput{
+			contextDir:           contextDir,
+			relDockerfile:        ".arcane.inline.Dockerfile",
+			dockerfileOutsideCtx: true,
+			dockerfileInline:     req.DockerfileInline,
+		}, nil
 	}
 
 	dockerfilePath := strings.TrimSpace(req.Dockerfile)
@@ -110,6 +115,29 @@ func prepareDockerBuildInputInternal(req imagetypes.BuildRequest) (dockerBuildIn
 		relDockerfile = filepath.Base(fullDockerfilePath)
 	} else {
 		relDockerfile = filepath.ToSlash(relDockerfile)
+	}
+
+	return buildFilesystemInput{
+		contextDir:           contextDir,
+		fullDockerfilePath:   fullDockerfilePath,
+		relDockerfile:        relDockerfile,
+		dockerfileOutsideCtx: dockerfileOutsideCtx,
+	}, nil
+}
+
+func prepareDockerBuildInputInternal(req imagetypes.BuildRequest) (dockerBuildInput, bool, error) {
+	fsInput, err := prepareBuildFilesystemInputInternal(req)
+	if err != nil {
+		return dockerBuildInput{}, false, err
+	}
+
+	if len(req.Platforms) > 1 {
+		return dockerBuildInput{}, true, fmt.Errorf("docker build fallback does not support multi-platform builds")
+	}
+
+	platform := ""
+	if len(req.Platforms) == 1 {
+		platform = strings.TrimSpace(req.Platforms[0])
 	}
 
 	buildArgs := map[string]*string{}
@@ -155,10 +183,7 @@ func prepareDockerBuildInputInternal(req imagetypes.BuildRequest) (dockerBuildIn
 	}
 
 	return dockerBuildInput{
-		contextDir:           contextDir,
-		fullDockerfilePath:   fullDockerfilePath,
-		relDockerfile:        relDockerfile,
-		dockerfileOutsideCtx: dockerfileOutsideCtx,
+		buildFilesystemInput: fsInput,
 		platform:             platform,
 		buildArgs:            buildArgs,
 		labels:               labels,
@@ -235,8 +260,8 @@ func copyContextTreeInternal(srcRoot, dstRoot string) error {
 	})
 }
 
-func prepareDockerBuildContextInternal(input dockerBuildInput) (string, string, func(), error) {
-	if !input.dockerfileOutsideCtx {
+func prepareBuildContextInternal(input buildFilesystemInput) (string, string, func(), error) {
+	if input.dockerfileInline == "" && !input.dockerfileOutsideCtx {
 		return input.contextDir, input.relDockerfile, func() {}, nil
 	}
 
@@ -254,6 +279,20 @@ func prepareDockerBuildContextInternal(input dockerBuildInput) (string, string, 
 		return "", "", nil, fmt.Errorf("failed to stage build context: %w", err)
 	}
 
+	if input.dockerfileInline != "" {
+		stagedDockerfilePath := filepath.Join(stagingDir, filepath.FromSlash(input.relDockerfile))
+		if err := os.MkdirAll(filepath.Dir(stagedDockerfilePath), 0o755); err != nil {
+			cleanup()
+			return "", "", nil, fmt.Errorf("failed to create inline Dockerfile path: %w", err)
+		}
+		if err := os.WriteFile(stagedDockerfilePath, []byte(input.dockerfileInline), 0o600); err != nil {
+			cleanup()
+			return "", "", nil, fmt.Errorf("failed to stage inline Dockerfile: %w", err)
+		}
+
+		return stagingDir, filepath.ToSlash(input.relDockerfile), cleanup, nil
+	}
+
 	const stagedDockerfile = ".arcane.external.Dockerfile"
 	stagedDockerfilePath := filepath.Join(stagingDir, stagedDockerfile)
 	dockerfileInfo, err := os.Stat(input.fullDockerfilePath)
@@ -268,6 +307,10 @@ func prepareDockerBuildContextInternal(input dockerBuildInput) (string, string, 
 	}
 
 	return stagingDir, stagedDockerfile, cleanup, nil
+}
+
+func prepareDockerBuildContextInternal(input dockerBuildInput) (string, string, func(), error) {
+	return prepareBuildContextInternal(input.buildFilesystemInput)
 }
 
 func (b *builder) performDockerBuildInternal(

--- a/backend/pkg/libarcane/libbuild/builder_docker_test.go
+++ b/backend/pkg/libarcane/libbuild/builder_docker_test.go
@@ -1,6 +1,8 @@
 package libbuild
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	imagetypes "github.com/getarcaneapp/arcane/types/image"
@@ -64,4 +66,30 @@ func TestBuildDockerImageOptionsInternal_EmptyAuthConfigsBecomesNil(t *testing.T
 	buildOpts, err := buildDockerImageOptionsInternal(req, input, "Dockerfile", map[string]dockerregistry.AuthConfig{})
 	require.NoError(t, err)
 	assert.Nil(t, buildOpts.AuthConfigs)
+}
+
+func TestPrepareDockerBuildContextInternal_StagesInlineDockerfile(t *testing.T) {
+	contextDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(contextDir, "app.txt"), []byte("hello\n"), 0o644))
+
+	req := imagetypes.BuildRequest{
+		ContextDir:       contextDir,
+		DockerfileInline: "FROM alpine:3.20\nCOPY app.txt /app.txt\n",
+	}
+
+	input, reportProgress, err := prepareDockerBuildInputInternal(req)
+	require.NoError(t, err)
+	assert.False(t, reportProgress)
+
+	buildContextDir, dockerfileForBuild, cleanup, err := prepareDockerBuildContextInternal(input)
+	require.NoError(t, err)
+	defer cleanup()
+
+	contents, err := os.ReadFile(filepath.Join(buildContextDir, filepath.FromSlash(dockerfileForBuild)))
+	require.NoError(t, err)
+	assert.Equal(t, "FROM alpine:3.20\nCOPY app.txt /app.txt\n", string(contents))
+
+	appContents, err := os.ReadFile(filepath.Join(buildContextDir, "app.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello\n", string(appContents))
 }

--- a/backend/pkg/libarcane/libbuild/builder_utils.go
+++ b/backend/pkg/libarcane/libbuild/builder_utils.go
@@ -32,6 +32,10 @@ func validateBuildRequestInternal(req imagetypes.BuildRequest, providerName stri
 		return fmt.Errorf("build context not found: %w", err)
 	}
 
+	if strings.TrimSpace(req.Dockerfile) != "" && strings.TrimSpace(req.DockerfileInline) != "" {
+		return errors.New("dockerfile and dockerfileInline are mutually exclusive")
+	}
+
 	if providerName == "depot" && !req.Push {
 		return errors.New("depot builds must push images to a registry")
 	}
@@ -45,6 +49,9 @@ func validateBuildRequestInternal(req imagetypes.BuildRequest, providerName stri
 	}
 
 	dockerfilePath := strings.TrimSpace(req.Dockerfile)
+	if strings.TrimSpace(req.DockerfileInline) != "" {
+		return nil
+	}
 	if dockerfilePath == "" {
 		dockerfilePath = "Dockerfile"
 	}

--- a/backend/pkg/libarcane/libbuild/builder_utils_test.go
+++ b/backend/pkg/libarcane/libbuild/builder_utils_test.go
@@ -72,3 +72,30 @@ func TestValidateBuildRequestInternal_RespectsTrimmedValues(t *testing.T) {
 	err := validateBuildRequestInternal(req, "local")
 	assert.NoError(t, err)
 }
+
+func TestValidateBuildRequestInternal_AllowsInlineDockerfile(t *testing.T) {
+	contextDir := t.TempDir()
+	req := imagetypes.BuildRequest{
+		ContextDir:       contextDir,
+		DockerfileInline: "FROM alpine:3.20\nRUN echo inline\n",
+		Tags:             []string{"ghcr.io/getarcaneapp/arcane:test"},
+		Load:             true,
+	}
+
+	err := validateBuildRequestInternal(req, "local")
+	assert.NoError(t, err)
+}
+
+func TestValidateBuildRequestInternal_RejectsDockerfileAndInlineTogether(t *testing.T) {
+	contextDir := createBuildContextWithDockerfileInternal(t)
+	req := imagetypes.BuildRequest{
+		ContextDir:       contextDir,
+		Dockerfile:       "Dockerfile",
+		DockerfileInline: "FROM alpine:3.20\n",
+		Tags:             []string{"ghcr.io/getarcaneapp/arcane:test"},
+		Load:             true,
+	}
+
+	err := validateBuildRequestInternal(req, "local")
+	require.EqualError(t, err, "dockerfile and dockerfileInline are mutually exclusive")
+}

--- a/frontend/src/lib/components/action-buttons.svelte
+++ b/frontend/src/lib/components/action-buttons.svelte
@@ -206,7 +206,9 @@
 		}
 	});
 	const deployPopoverIcon = $derived(deployProgressPhase === 'build' ? HammerIcon : DownloadIcon);
-	const deployPopoverLayers = $derived.by(() => (deployProgressPhase === 'pull' ? layerProgress : {}));
+	const deployPopoverLayers = $derived.by(() =>
+		deployProgressPhase === 'pull' || deployProgressPhase === 'build' ? layerProgress : {}
+	);
 
 	// Tailwind xl breakpoint is 1280px. We use this to avoid mounting two desktop variants at once
 	// (which would duplicate portaled popovers when the same `open` state is bound twice).
@@ -295,6 +297,64 @@
 
 	function updatePullProgress() {
 		pullProgress = calculateOverallProgress(layerProgress);
+	}
+
+	function updateLayerProgressFromStreamData(data: any) {
+		const layerId = String(data?.id ?? '').trim();
+		if (!layerId) return;
+
+		const currentLayer = layerProgress[layerId] || { current: 0, total: 0, status: '' };
+		if (data?.status) {
+			currentLayer.status = String(data.status);
+		}
+
+		if (data?.progressDetail) {
+			const { current, total } = data.progressDetail;
+			if (typeof current === 'number') currentLayer.current = current;
+			if (typeof total === 'number') currentLayer.total = total;
+		}
+
+		layerProgress[layerId] = currentLayer;
+		updatePullProgress();
+	}
+
+	function handleBuildStreamLine(
+		data: any,
+		errorFallback: string,
+		errorFormatter: (message: string) => string,
+		onError?: (message: string) => void
+	): boolean {
+		if (!data) return false;
+
+		if (data.phase === 'begin') {
+			pullStatusText = m.progress_building_images_starting();
+			appendBuildOutputLine(m.build_phase_started(), data.service);
+		}
+
+		if (data.status) {
+			pullStatusText = String(data.status);
+			appendBuildOutputLine(data.status, data.service);
+		}
+
+		if (data.id) {
+			updateLayerProgressFromStreamData(data);
+		}
+
+		if (data.phase === 'complete') {
+			pullStatusText = m.build_completed();
+			pullProgress = 100;
+			appendBuildOutputLine(m.build_phase_completed(), data.service);
+		}
+
+		if (data.error) {
+			const errMsg = typeof data.error === 'string' ? data.error : data.error.message || errorFallback;
+			pullError = errMsg;
+			pullStatusText = errorFormatter(errMsg);
+			onError?.(errMsg);
+			return true;
+		}
+
+		return false;
 	}
 
 	async function handleRefresh() {
@@ -411,42 +471,19 @@
 						deployLastNonWaitingStatus = '';
 					}
 
-					if (deployData.phase === 'begin') {
-						pullStatusText = m.progress_building_images_starting();
-						appendBuildOutputLine(m.build_phase_started(), deployData.service);
-					} else if (deployData.phase === 'complete') {
-						pullStatusText = m.build_completed();
-						pullProgress = 100;
-						appendBuildOutputLine(m.build_phase_completed(), deployData.service);
-					}
-
-					if (deployData.status) {
-						pullStatusText = String(deployData.status);
-						appendBuildOutputLine(deployData.status, deployData.service);
-					}
-
-					if (deployData.error) {
-						const errMsg =
-							typeof deployData.error === 'string' ? deployData.error : deployData.error.message || m.progress_deploy_failed();
-						pullError = errMsg;
-						pullStatusText = m.progress_deploy_failed_with_error({ error: errMsg });
-						hadError = true;
-						deployPulling = false;
+					if (
+						handleBuildStreamLine(
+							deployData,
+							m.progress_deploy_failed(),
+							(errMsg) => m.progress_deploy_failed_with_error({ error: errMsg }),
+							() => {
+								hadError = true;
+								deployPulling = false;
+							}
+						)
+					) {
 						return;
 					}
-
-					if (deployData.id) {
-						const currentLayer = layerProgress[deployData.id] || { current: 0, total: 0, status: '' };
-						currentLayer.status = deployData.status || currentLayer.status;
-						if (deployData.progressDetail) {
-							const { current, total } = deployData.progressDetail;
-							if (typeof current === 'number') currentLayer.current = current;
-							if (typeof total === 'number') currentLayer.total = total;
-						}
-						layerProgress[deployData.id] = currentLayer;
-					}
-
-					updatePullProgress();
 					return;
 				}
 
@@ -742,17 +779,7 @@
 				(data) => {
 					if (!data) return;
 
-					if (data.error) {
-						const errMsg = typeof data.error === 'string' ? data.error : data.error.message || m.build_failed();
-						pullError = errMsg;
-						pullStatusText = m.build_failed_with_error({ error: errMsg });
-						return;
-					}
-
-					if (data.status) {
-						pullStatusText = data.status;
-						appendBuildOutputLine(data.status, data.service);
-					}
+					handleBuildStreamLine(data, m.build_failed(), (errMsg) => m.build_failed_with_error({ error: errMsg }));
 				}
 			);
 
@@ -808,6 +835,7 @@
 							loading={deployPulling}
 							icon={deployPopoverIcon}
 							layers={deployPopoverLayers}
+							showOutputPanel={deployProgressPhase === 'build'}
 							outputLines={deployProgressPhase === 'build' ? buildOutputLines : []}
 						>
 							<DeploySplitButton
@@ -868,6 +896,8 @@
 								error={pullError}
 								loading={projectBuilding}
 								icon={HammerIcon}
+								layers={layerProgress}
+								showOutputPanel={projectBuilding}
 								outputLines={buildOutputLines}
 							>
 								<ArcaneButton
@@ -1018,6 +1048,7 @@
 						loading={deployPulling}
 						icon={deployPopoverIcon}
 						layers={deployPopoverLayers}
+						showOutputPanel={deployProgressPhase === 'build'}
 						outputLines={deployProgressPhase === 'build' ? buildOutputLines : []}
 						triggerClass="hidden"
 					>
@@ -1034,6 +1065,8 @@
 						error={pullError}
 						loading={projectBuilding}
 						icon={HammerIcon}
+						layers={layerProgress}
+						showOutputPanel={projectBuilding}
 						outputLines={buildOutputLines}
 						triggerClass="hidden"
 					>
@@ -1075,6 +1108,7 @@
 						loading={deployPulling}
 						icon={deployPopoverIcon}
 						layers={deployPopoverLayers}
+						showOutputPanel={deployProgressPhase === 'build'}
 						outputLines={deployProgressPhase === 'build' ? buildOutputLines : []}
 					>
 						<DeploySplitButton customLabel={deployButtonLabel} onDeploy={() => handleDeploy()} loading={uiLoading.start} />
@@ -1109,6 +1143,8 @@
 							error={pullError}
 							loading={projectBuilding}
 							icon={HammerIcon}
+							layers={layerProgress}
+							showOutputPanel={projectBuilding}
 							outputLines={buildOutputLines}
 						>
 							<ArcaneButton action="build" onclick={() => handleProjectBuild()} loading={projectBuilding} />

--- a/frontend/src/lib/components/progress-popover.svelte
+++ b/frontend/src/lib/components/progress-popover.svelte
@@ -42,6 +42,8 @@
 		onCancel?: () => void;
 		layers?: Record<string, LayerProgress>;
 		outputLines?: string[];
+		showOutputPanel?: boolean;
+		outputPlaceholder?: string;
 		triggerClass?: string;
 		children: Snippet;
 	}
@@ -65,6 +67,8 @@
 		onCancel,
 		layers = {},
 		outputLines = [],
+		showOutputPanel = false,
+		outputPlaceholder = m.build_output_placeholder(),
 		triggerClass,
 		children
 	}: Props = $props();
@@ -83,6 +87,7 @@
 
 	const percent = $derived(Math.round(progress));
 	const isComplete = $derived(progress >= 100);
+	const hasStructuredProgress = $derived(Object.keys(layers).length > 0 || progress > 0);
 
 	// Track if we've ever reached complete state to prevent flashing back
 	let hasReachedComplete = $state(false);
@@ -103,8 +108,9 @@
 
 	// Check if we're in an indeterminate phase (extracting with no byte progress)
 	const isIndeterminate = $derived(isIndeterminatePhase(layers, progress));
-	const isIndeterminateGeneric = $derived(mode !== 'pull' && loading && !isComplete && !error);
+	const isIndeterminateGeneric = $derived(mode !== 'pull' && loading && !isComplete && !error && !hasStructuredProgress);
 	const cleanStatusText = $derived(sanitizeLogText(statusText));
+	const genericStatus = $derived(cleanStatusText || subtitle);
 
 	// Derive aggregate status for display
 	const aggregateStatus = $derived(getAggregateStatus(layers, cleanStatusText, hasReachedComplete || isComplete));
@@ -184,8 +190,17 @@
 			<Item.Description class={cn(error && 'line-clamp-none break-words whitespace-pre-wrap')}>
 				{#if error}
 					{error}
+				{:else if mode !== 'pull' && layerStats.total > 0}
+					{hasReachedComplete ? 100 : percent}% · {genericStatus}
+					<span class="text-muted-foreground">
+						· {m.progress_layers_status({ completed: layerStats.completed, total: layerStats.total })}</span
+					>
 				{:else if mode !== 'pull'}
-					{aggregateStatus || subtitle}
+					{#if hasStructuredProgress || loading || hasReachedComplete}
+						{hasReachedComplete ? 100 : percent}% · {genericStatus}
+					{:else}
+						{genericStatus}
+					{/if}
 				{:else if layerStats.total > 0}
 					{aggregateStatus || subtitle}
 					<span class="text-muted-foreground">
@@ -256,7 +271,7 @@
 		</Collapsible.Root>
 	{/if}
 
-	{#if outputLines.length > 0 && !error}
+	{#if (showOutputPanel || outputLines.length > 0) && !error}
 		<div class="mt-2 overflow-hidden rounded-md border border-white/10 bg-black/80">
 			<div class="flex items-center justify-between border-b border-white/10 px-2 py-1">
 				<span class="text-[10px] font-medium tracking-wide text-emerald-300/80 uppercase">{m.build_output()}</span>
@@ -264,9 +279,9 @@
 			</div>
 			<pre
 				bind:this={outputContainer}
-				class="max-h-40 overflow-y-auto px-2 py-2 font-mono text-[11px] leading-relaxed whitespace-pre-wrap text-emerald-200">{#each outputLines as line, i (i)}<span
-						class="block break-words">{line}</span
-					>{/each}</pre>
+				class="max-h-40 overflow-y-auto px-2 py-2 font-mono text-[11px] leading-relaxed whitespace-pre-wrap text-emerald-200">{#if outputLines.length > 0}{#each outputLines as line, i (i)}<span
+							class="block break-words">{line}</span
+						>{/each}{:else}<span class="text-emerald-300/60">{outputPlaceholder}</span>{/if}</pre>
 		</div>
 	{/if}
 {/snippet}

--- a/types/image/image.go
+++ b/types/image/image.go
@@ -257,6 +257,11 @@ type BuildRequest struct {
 	// Required: false
 	Dockerfile string `json:"dockerfile,omitempty" doc:"Dockerfile path"`
 
+	// DockerfileInline is the inline Dockerfile content staged into the build context.
+	//
+	// Required: false
+	DockerfileInline string `json:"dockerfileInline,omitempty" doc:"Inline Dockerfile content"`
+
 	// Tags are image tags to apply.
 	//
 	// Required: false


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1959

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes `dockerfile_inline` builds not working from projects by propagating the compose `DockerfileInline` field all the way through the build pipeline — from `prepareServiceBuildRequest` into a new `BuildRequest.DockerfileInline` field, through a shared `prepareBuildFilesystemInputInternal` helper used by both Docker and BuildKit backends, and finally into a staged `.arcane.inline.Dockerfile` file inside the copied build context. It also tightens deploy error handling (build failures now abort the deploy rather than being silently swallowed) and surfaces real-time layer progress in the build popover UI.

Key changes:
- **`types/image/image.go`**: New `DockerfileInline` field on `BuildRequest`; inline and path-based Dockerfiles are made mutually exclusive in validation.
- **`builder_docker.go` / `builder_buildkit.go`**: Shared `buildFilesystemInput` struct and `prepareBuildFilesystemInputInternal` / `prepareBuildContextInternal` helpers centralise inline-Dockerfile staging for both backends; `buildSolveOptInternal` now returns a cleanup func.
- **`project_service.go`**: `prepareServiceBuildRequest` detects `dockerfile_inline` and skips `resolveDockerfilePath`; a forced `Build` decision is set when `updated == true`; the progress writer is now taken from the request context instead of `io.Discard`; a new `restoreProjectStatusAfterFailedDeploy` helper (name should end in `Internal` per project convention) replaces the inline status-reset calls.
- **`action-buttons.svelte` / `progress-popover.svelte`**: New `handleBuildStreamLine` and `updateLayerProgressFromStreamData` helpers unify build-stream handling; `showOutputPanel` prop allows the build output panel to appear before any log lines arrive; the deploy popover now shows layer progress during builds. New TS helpers use `any` parameter types and `updateLayerProgressFromStreamData` lacks an explicit return type — both against project conventions.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge after addressing the naming convention and TypeScript typing style issues; no logic or security problems found.
- The core inline-Dockerfile staging logic is sound and well-tested across both Docker and BuildKit backends. Deploy error handling is strictly improved. The only issues are a missing `Internal` suffix on an unexported Go helper and `any` usage in two new TypeScript helpers — both are style/convention violations rather than correctness bugs.
- `backend/internal/services/project_service.go` — `restoreProjectStatusAfterFailedDeploy` needs the `Internal` suffix; `resolveBuildContext` and `resolveDockerfilePath` carry now-dead parameters. `frontend/src/lib/components/action-buttons.svelte` — new helpers use `any` types.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/project_service.go | Core fix: adds `dockerfile_inline` support to `prepareServiceBuildRequest`, propagates a real progress writer through `DeployProject`, forces a build decision when the service config is updated, and extracts `restoreProjectStatusAfterFailedDeployInternal` (name missing `Internal` suffix). Two helper functions now carry dead parameters silenced with blank-identifier assignments. |
| backend/pkg/libarcane/libbuild/builder_docker.go | Refactored to extract `buildFilesystemInput` and `prepareBuildFilesystemInputInternal` shared by both Docker and BuildKit paths. Inline Dockerfile is staged into the context directory under `.arcane.inline.Dockerfile`. Logic is clean and well-scoped. |
| backend/pkg/libarcane/libbuild/builder_buildkit.go | Updated `buildSolveOptInternal` to delegate filesystem preparation to the shared `prepareBuildFilesystemInputInternal` / `prepareBuildContextInternal` helpers; return signature now includes a cleanup func. Handling looks correct for both inline and file-based Dockerfiles. |
| types/image/image.go | Adds `DockerfileInline` field to `BuildRequest` with correct JSON tag and documentation. Non-breaking additive change. |
| frontend/src/lib/components/action-buttons.svelte | Extracts `handleBuildStreamLine` and `updateLayerProgressFromStreamData` helpers to share build-stream handling between deploy and standalone build flows; surfaces layer-level progress during builds. New helpers use `any` parameter types and `updateLayerProgressFromStreamData` lacks an explicit return type, both against project conventions. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant PS as ProjectService.DeployProject
    participant PPID as prepareProjectImagesForDeploy
    participant PSBR as prepareServiceBuildRequest
    participant PBFSI as prepareBuildFilesystemInputInternal
    participant PBCI as prepareBuildContextInternal
    participant Builder as Builder (Docker / BuildKit)

    PS->>PS: extract progressWriter from ctx (or nil)
    PS->>PPID: prepareProjectImagesForDeploy(progressWriter)
    PPID->>PPID: for each service with build config
    PPID->>PSBR: prepareServiceBuildRequest(svc)
    PSBR->>PSBR: detect dockerfile_inline vs dockerfile
    PSBR-->>PPID: BuildRequest{DockerfileInline or Dockerfile}
    PPID->>PPID: if updated → force Build decision
    PPID->>Builder: ensureDeployServiceImageReady → BuildImage(req)
    Builder->>PBFSI: prepareBuildFilesystemInputInternal(req)
    alt has DockerfileInline
        PBFSI-->>Builder: buildFilesystemInput{relDockerfile: ".arcane.inline.Dockerfile"}
    else has Dockerfile path
        PBFSI-->>Builder: buildFilesystemInput{fullDockerfilePath, relDockerfile}
    end
    Builder->>PBCI: prepareBuildContextInternal(fsInput)
    alt dockerfileInline != ""
        PBCI->>PBCI: copy context tree to staging dir
        PBCI->>PBCI: write inline content to .arcane.inline.Dockerfile
        PBCI-->>Builder: (stagingDir, ".arcane.inline.Dockerfile", cleanup)
    else dockerfileOutsideCtx
        PBCI->>PBCI: copy context tree + stage external Dockerfile
        PBCI-->>Builder: (stagingDir, ".arcane.external.Dockerfile", cleanup)
    else
        PBCI-->>Builder: (contextDir, relDockerfile, noop cleanup)
    end
    Builder->>Builder: build image using resolved dirs
    Builder->>Builder: defer cleanup()
    Builder-->>PPID: BuildResult or error
    alt error
        PPID-->>PS: error
        PS->>PS: restoreProjectStatusAfterFailedDeployInternal
        PS-->>PS: return error
    else success
        PS->>PS: projects.ComposeUp(...)
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/lib/components/action-buttons.svelte`, line 760-777 ([link](https://github.com/getarcaneapp/arcane/blob/2b19233a5cd71cf5cbce6d65578aab1df02b5f5e/frontend/src/lib/components/action-buttons.svelte#L760-L777)) 

   **`any` type and missing return-type annotation**

   Two issues in the newly added helpers:

   1. `data: any` should use a specific type (or at minimum `unknown` with a type guard). The same applies to the `data: any` parameter in `handleBuildStreamLine` below.
   2. `updateLayerProgressFromStreamData` has no explicit return type; project conventions require all functions to declare their return type.

   

   And for `handleBuildStreamLine` (line 779):
   ```
   	function handleBuildStreamLine(
   		data: Record<string, unknown> | null | undefined,
   		...
   	): boolean {
   ```

   **Rule Used:** JavaScript/TypeScript Best Practices
   
   Use const/le... ([source](https://app.greptile.com/review/custom-context?memory=68c6ab5b-40de-4e3c-a803-95d60efb41a6))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/lib/components/action-buttons.svelte
   Line: 760-777
   
   Comment:
   **`any` type and missing return-type annotation**
   
   Two issues in the newly added helpers:
   
   1. `data: any` should use a specific type (or at minimum `unknown` with a type guard). The same applies to the `data: any` parameter in `handleBuildStreamLine` below.
   2. `updateLayerProgressFromStreamData` has no explicit return type; project conventions require all functions to declare their return type.
   
   
   
   And for `handleBuildStreamLine` (line 779):
   ```
   	function handleBuildStreamLine(
   		data: Record<string, unknown> | null | undefined,
   		...
   	): boolean {
   ```
   
   **Rule Used:** JavaScript/TypeScript Best Practices
   
   Use const/le... ([source](https://app.greptile.com/review/custom-context?memory=68c6ab5b-40de-4e3c-a803-95d60efb41a6))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20frontend%2Fsrc%2Flib%2Fcomponents%2Faction-buttons.svelte%0ALine%3A%20760-777%0A%0AComment%3A%0A**%60any%60%20type%20and%20missing%20return-type%20annotation**%0A%0ATwo%20issues%20in%20the%20newly%20added%20helpers%3A%0A%0A1.%20%60data%3A%20any%60%20should%20use%20a%20specific%20type%20%28or%20at%20minimum%20%60unknown%60%20with%20a%20type%20guard%29.%20The%20same%20applies%20to%20the%20%60data%3A%20any%60%20parameter%20in%20%60handleBuildStreamLine%60%20below.%0A2.%20%60updateLayerProgressFromStreamData%60%20has%20no%20explicit%20return%20type%3B%20project%20conventions%20require%20all%20functions%20to%20declare%20their%20return%20type.%0A%0A%60%60%60suggestion%0A%09function%20updateLayerProgressFromStreamData%28data%3A%20Record%3Cstring%2C%20unknown%3E%29%3A%20void%20%7B%0A%60%60%60%0A%0AAnd%20for%20%60handleBuildStreamLine%60%20%28line%20779%29%3A%0A%60%60%60%0A%09function%20handleBuildStreamLine%28%0A%09%09data%3A%20Record%3Cstring%2C%20unknown%3E%20%7C%20null%20%7C%20undefined%2C%0A%09%09...%0A%09%29%3A%20boolean%20%7B%0A%60%60%60%0A%0A**Rule%20Used%3A**%20JavaScript%2FTypeScript%20Best%20Practices%0A%0AUse%20const%2Fle...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D68c6ab5b-40de-4e3c-a803-95d60efb41a6%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A1661-1683%0A**Missing%20%60Internal%60%20suffix%20on%20unexported%20function**%0A%0AThe%20project%20coding%20convention%20requires%20all%20unexported%20functions%20to%20use%20the%20%60Internal%60%20suffix.%20%60restoreProjectStatusAfterFailedDeploy%60%20is%20unexported%20but%20does%20not%20follow%20this%20convention.%0A%0A%60%60%60suggestion%0Afunc%20%28s%20*ProjectService%29%20restoreProjectStatusAfterFailedDeployInternal%28ctx%20context.Context%2C%20projectID%20string%29%20%7B%0A%60%60%60%0A%0AUpdate%20the%20two%20call%20sites%20accordingly%20%28%60s.restoreProjectStatusAfterFailedDeployInternal%28ctx%2C%20projectID%29%60%29.%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A%23%23%23%20Issue%202%20of%203%0Afrontend%2Fsrc%2Flib%2Fcomponents%2Faction-buttons.svelte%3A760-777%0A**%60any%60%20type%20and%20missing%20return-type%20annotation**%0A%0ATwo%20issues%20in%20the%20newly%20added%20helpers%3A%0A%0A1.%20%60data%3A%20any%60%20should%20use%20a%20specific%20type%20%28or%20at%20minimum%20%60unknown%60%20with%20a%20type%20guard%29.%20The%20same%20applies%20to%20the%20%60data%3A%20any%60%20parameter%20in%20%60handleBuildStreamLine%60%20below.%0A2.%20%60updateLayerProgressFromStreamData%60%20has%20no%20explicit%20return%20type%3B%20project%20conventions%20require%20all%20functions%20to%20declare%20their%20return%20type.%0A%0A%60%60%60suggestion%0A%09function%20updateLayerProgressFromStreamData%28data%3A%20Record%3Cstring%2C%20unknown%3E%29%3A%20void%20%7B%0A%60%60%60%0A%0AAnd%20for%20%60handleBuildStreamLine%60%20%28line%20779%29%3A%0A%60%60%60%0A%09function%20handleBuildStreamLine%28%0A%09%09data%3A%20Record%3Cstring%2C%20unknown%3E%20%7C%20null%20%7C%20undefined%2C%0A%09%09...%0A%09%29%3A%20boolean%20%7B%0A%60%60%60%0A%0A**Rule%20Used%3A**%20JavaScript%2FTypeScript%20Best%20Practices%0A%0AUse%20const%2Fle...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D68c6ab5b-40de-4e3c-a803-95d60efb41a6%29%29%0A%0A%23%23%23%20Issue%203%20of%203%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A1462-1477%0A**Dead%20parameters%20silenced%20with%20%60_%20%3D%20%E2%80%A6%60**%0A%0ABoth%20%60resolveBuildContext%60%20and%20%60resolveDockerfilePath%60%20now%20carry%20parameters%20that%20are%20no%20longer%20used%20%28%60pathMapper%60%20and%20%60serviceName%60%20respectively%29%2C%20each%20suppressed%20with%20a%20blank-identifier%20assignment.%20Since%20these%20are%20unexported%20package-level%20functions%2C%20their%20signatures%20can%20be%20cleaned%20up%20without%20affecting%20public%20API%3A%0A%0A%60%60%60go%0A%2F%2F%20resolveBuildContext%20%E2%80%93%20drop%20pathMapper%0Afunc%20resolveBuildContext%28workingDir%20string%2C%20svc%20composetypes.ServiceConfig%29%20%28string%2C%20error%29%20%7B%20%E2%80%A6%20%7D%0A%0A%2F%2F%20resolveDockerfilePath%20%E2%80%93%20drop%20pathMapper%20and%20serviceName%0Afunc%20resolveDockerfilePath%28svc%20composetypes.ServiceConfig%29%20%28string%2C%20error%29%20%7B%20%E2%80%A6%20%7D%0A%60%60%60%0A%0ARemove%20the%20corresponding%20%60_%20%3D%20pathMapper%60%20%2F%20%60_%20%3D%20serviceName%60%20tombstones%20and%20update%20call%20sites.%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<sub>Last reviewed commit: 2b19233</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
- Rule used - JavaScript/TypeScript Best Practices

Use const/le... ([source](https://app.greptile.com/review/custom-context?memory=68c6ab5b-40de-4e3c-a803-95d60efb41a6))

<!-- /greptile_comment -->