### PR TITLE
fix: containers on user created networks not restarted when updated

### DIFF
--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -759,27 +760,16 @@ func (s *UpdaterService) updateContainer(ctx context.Context, cnt container.Summ
 		inspect.HostConfig.PublishAllPorts = false
 	}
 
-	var networkingConfig *network.NetworkingConfig
-	if !nm.IsContainer() {
-		apiVersion := libarcane.DetectDockerAPIVersion(ctx, dcli)
-		if apiVersion != "" && !libarcane.SupportsDockerCreatePerNetworkMACAddress(apiVersion) {
-			slog.InfoContext(ctx,
-				"updateContainer: daemon API does not support per-network mac-address on create; stripping endpoint mac addresses",
-				"containerId", cnt.ID,
-				"containerName", name,
-				"dockerAPIVersion", apiVersion,
-				"minimumRequiredAPIVersion", libarcane.NetworkScopedMacAddressMinAPIVersion,
-			)
-		}
-
-		var endpoints map[string]*network.EndpointSettings
-		if inspect.NetworkSettings != nil {
-			endpoints = inspect.NetworkSettings.Networks
-		}
-
-		networkingConfig = &network.NetworkingConfig{
-			EndpointsConfig: libarcane.SanitizeContainerCreateEndpointSettingsForDockerAPI(endpoints, apiVersion),
-		}
+	apiVersion := libarcane.DetectDockerAPIVersion(ctx, dcli)
+	networkingConfig := buildUpdaterRecreateNetworkingConfigInternal(nm, inspect.NetworkSettings, apiVersion)
+	if networkingConfig != nil && apiVersion != "" && !libarcane.SupportsDockerCreatePerNetworkMACAddress(apiVersion) {
+		slog.InfoContext(ctx,
+			"updateContainer: daemon API does not support per-network mac-address on create; stripping endpoint mac addresses",
+			"containerId", cnt.ID,
+			"containerName", name,
+			"dockerAPIVersion", apiVersion,
+			"minimumRequiredAPIVersion", libarcane.NetworkScopedMacAddressMinAPIVersion,
+		)
 	}
 
 	// Use original name for new container
@@ -811,6 +801,36 @@ func (s *UpdaterService) updateContainer(ctx context.Context, cnt container.Summ
 
 	slog.DebugContext(ctx, "updateContainer: update complete", "oldContainerId", cnt.ID, "newContainerId", resp.ID)
 	return nil
+}
+
+func buildUpdaterRecreateNetworkingConfigInternal(networkMode container.NetworkMode, settings *container.NetworkSettings, apiVersion string) *network.NetworkingConfig {
+	if networkMode.IsContainer() || settings == nil || len(settings.Networks) == 0 {
+		return nil
+	}
+
+	rawEndpointsConfig := make(map[string]*network.EndpointSettings, len(settings.Networks))
+	for networkName, endpoint := range settings.Networks {
+		if endpoint == nil {
+			rawEndpointsConfig[networkName] = &network.EndpointSettings{}
+			continue
+		}
+
+		rawEndpointsConfig[networkName] = &network.EndpointSettings{
+			IPAMConfig: endpoint.IPAMConfig.Copy(),
+			Links:      slices.Clone(endpoint.Links),
+			Aliases:    slices.Clone(endpoint.Aliases),
+			DriverOpts: maps.Clone(endpoint.DriverOpts),
+			GwPriority: endpoint.GwPriority,
+			MacAddress: endpoint.MacAddress,
+		}
+	}
+
+	sanitizedEndpointsConfig := libarcane.SanitizeContainerCreateEndpointSettingsForDockerAPI(rawEndpointsConfig, apiVersion)
+	if len(sanitizedEndpointsConfig) == 0 {
+		return nil
+	}
+
+	return &network.NetworkingConfig{EndpointsConfig: sanitizedEndpointsConfig}
 }
 
 // normalizeRef returns a canonical "registry/repository:tag" without digest.

--- a/backend/internal/services/updater_service_test.go
+++ b/backend/internal/services/updater_service_test.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 	"errors"
+	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	glsqlite "github.com/glebarez/sqlite"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
@@ -276,6 +279,152 @@ func TestCollectUsedImagesFromContainers_FastPathSkipsInspectLikeRefs(t *testing
 	assert.Contains(t, out, svc.normalizeRef("nginx:latest"))
 	assert.Contains(t, out, svc.normalizeRef("redis:7"))
 	assert.NotContains(t, out, svc.normalizeRef("sha256:abcdef"))
+}
+
+func mustHardwareAddr(t *testing.T, value string) network.HardwareAddr {
+	t.Helper()
+
+	hw, err := net.ParseMAC(value)
+	require.NoError(t, err)
+
+	return network.HardwareAddr(hw)
+}
+
+func TestBuildUpdaterRecreateNetworkingConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		networkMode container.NetworkMode
+		settings    *container.NetworkSettings
+		apiVersion  string
+		assertions  func(t *testing.T, got *network.NetworkingConfig)
+	}{
+		{
+			name:        "skips container network mode",
+			networkMode: container.NetworkMode("container:db"),
+			apiVersion:  "1.44",
+			settings: &container.NetworkSettings{
+				Networks: map[string]*network.EndpointSettings{
+					"custom": {Aliases: []string{"app"}},
+				},
+			},
+			assertions: func(t *testing.T, got *network.NetworkingConfig) {
+				require.Nil(t, got)
+			},
+		},
+		{
+			name:        "returns nil for empty settings",
+			networkMode: container.NetworkMode("bridge"),
+			apiVersion:  "1.44",
+			settings:    &container.NetworkSettings{},
+			assertions: func(t *testing.T, got *network.NetworkingConfig) {
+				require.Nil(t, got)
+			},
+		},
+		{
+			name:        "preserves recreate-safe endpoint config and strips runtime fields",
+			networkMode: container.NetworkMode("bridge"),
+			apiVersion:  "1.43",
+			settings: &container.NetworkSettings{
+				Networks: map[string]*network.EndpointSettings{
+					"bridge": {
+						IPAMConfig: &network.EndpointIPAMConfig{
+							IPv4Address:  netip.MustParseAddr("172.18.0.50"),
+							LinkLocalIPs: []netip.Addr{netip.MustParseAddr("169.254.10.10")},
+						},
+						Links:       []string{"db:db"},
+						Aliases:     []string{"app", "app-1"},
+						DriverOpts:  map[string]string{"l2proxy": "true"},
+						GwPriority:  42,
+						MacAddress:  mustHardwareAddr(t, "02:42:ac:11:00:02"),
+						IPAddress:   netip.MustParseAddr("172.18.0.20"),
+						Gateway:     netip.MustParseAddr("172.18.0.1"),
+						IPPrefixLen: 16,
+					},
+					"synobridge": nil,
+				},
+			},
+			assertions: func(t *testing.T, got *network.NetworkingConfig) {
+				require.NotNil(t, got)
+				require.Len(t, got.EndpointsConfig, 2)
+
+				bridge := got.EndpointsConfig["bridge"]
+				require.NotNil(t, bridge)
+				require.NotNil(t, bridge.IPAMConfig)
+				assert.Equal(t, netip.MustParseAddr("172.18.0.50"), bridge.IPAMConfig.IPv4Address)
+				assert.Equal(t, []netip.Addr{netip.MustParseAddr("169.254.10.10")}, bridge.IPAMConfig.LinkLocalIPs)
+				assert.Equal(t, []string{"db:db"}, bridge.Links)
+				assert.Equal(t, []string{"app", "app-1"}, bridge.Aliases)
+				assert.Equal(t, map[string]string{"l2proxy": "true"}, bridge.DriverOpts)
+				assert.Equal(t, 42, bridge.GwPriority)
+				assert.Empty(t, bridge.MacAddress)
+				assert.False(t, bridge.IPAddress.IsValid())
+				assert.False(t, bridge.Gateway.IsValid())
+				assert.Zero(t, bridge.IPPrefixLen)
+
+				synobridge := got.EndpointsConfig["synobridge"]
+				require.NotNil(t, synobridge)
+				assert.Empty(t, synobridge.Aliases)
+			},
+		},
+		{
+			name:        "preserves network mac address when docker api supports it",
+			networkMode: container.NetworkMode("bridge"),
+			apiVersion:  "1.44",
+			settings: &container.NetworkSettings{
+				Networks: map[string]*network.EndpointSettings{
+					"custom": {
+						Aliases:    []string{"app"},
+						MacAddress: mustHardwareAddr(t, "02:42:ac:11:00:03"),
+					},
+				},
+			},
+			assertions: func(t *testing.T, got *network.NetworkingConfig) {
+				require.NotNil(t, got)
+				require.Len(t, got.EndpointsConfig, 1)
+
+				endpoint := got.EndpointsConfig["custom"]
+				require.NotNil(t, endpoint)
+				assert.Equal(t, []string{"app"}, endpoint.Aliases)
+				assert.Equal(t, "02:42:ac:11:00:03", endpoint.MacAddress.String())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildUpdaterRecreateNetworkingConfigInternal(tt.networkMode, tt.settings, tt.apiVersion)
+			tt.assertions(t, got)
+		})
+	}
+
+	t.Run("clones aliases slice", func(t *testing.T) {
+		settings := &container.NetworkSettings{
+			Networks: map[string]*network.EndpointSettings{
+				"custom": {
+					IPAMConfig: &network.EndpointIPAMConfig{
+						IPv4Address: netip.MustParseAddr("10.10.0.5"),
+					},
+					Links:      []string{"db:db"},
+					Aliases:    []string{"app"},
+					DriverOpts: map[string]string{"mode": "l2"},
+				},
+			},
+		}
+
+		got := buildUpdaterRecreateNetworkingConfigInternal(container.NetworkMode("bridge"), settings, "1.44")
+		require.NotNil(t, got)
+
+		got.EndpointsConfig["custom"].IPAMConfig.IPv4Address = netip.MustParseAddr("10.10.0.99")
+		got.EndpointsConfig["custom"].Links[0] = "cache:cache"
+		got.EndpointsConfig["custom"].Aliases[0] = "changed"
+		got.EndpointsConfig["custom"].DriverOpts["mode"] = "l3"
+
+		require.NotNil(t, settings.Networks["custom"].IPAMConfig)
+		assert.Equal(t, netip.MustParseAddr("10.10.0.5"), settings.Networks["custom"].IPAMConfig.IPv4Address)
+		assert.Equal(t, []string{"db:db"}, settings.Networks["custom"].Links)
+		assert.Equal(t, []string{"app"}, settings.Networks["custom"].Aliases)
+		assert.Equal(t, map[string]string{"mode": "l2"}, settings.Networks["custom"].DriverOpts)
+	})
 }
 
 func setupUpdaterServiceTestDB(t *testing.T) *database.DB {


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/1951

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where containers connected to user-created networks were not properly restarted during image updates. The root cause was that the old code passed the full runtime `EndpointSettings` (including Docker-assigned fields like `IPAddress`, `Gateway`, `IPPrefixLen`) directly to `ContainerCreate`, which the Docker daemon rejects for user-defined networks.

**Changes:**
- Extracts a new `buildUpdaterRecreateNetworkingConfigInternal` helper that manually copies only the create-time-safe endpoint fields: `IPAMConfig`, `Links`, `Aliases`, `DriverOpts`, `GwPriority`, and `MacAddress`.
- Detects the Docker API version and properly gates per-network MAC-address logging on whether a networking config will actually be generated.
- Adds comprehensive table-driven tests covering: container-mode bypass, empty settings, runtime-field stripping on API < 1.44, MAC address preservation on API ≥ 1.44, and deep-copy isolation for `Links`, `Aliases`, and `DriverOpts`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- The PR correctly implements the networking config extraction, properly gates logging conditions, and includes all necessary endpoint fields for container recreation.
- The core fix is sound and comprehensively tested. The new `buildUpdaterRecreateNetworkingConfigInternal` helper properly isolates and copies only the create-time-safe endpoint fields, avoiding Docker API rejections. API version detection and MAC address logging are correctly placed and gated. All test scenarios are covered including edge cases for container-mode bypass and API version compatibility.
- No files require special attention.
</details>

<sub>Last reviewed commit: 9462a8b</sub>

<!-- /greptile_comment -->