### PR TITLE
fix: avoid restoring offline environment on app init

### DIFF
--- a/frontend/src/lib/stores/environment.store.svelte.ts
+++ b/frontend/src/lib/stores/environment.store.svelte.ts
@@ -2,6 +2,7 @@ import { PersistedState } from 'runed';
 import { goto, invalidateAll } from '$app/navigation';
 import { page } from '$app/state';
 import type { Environment } from '$lib/types/environment.type';
+import { isEnvironmentOnline } from '$lib/utils/environment-status';
 
 export const LOCAL_DOCKER_ENVIRONMENT_ID = '0';
 
@@ -48,27 +49,36 @@ function createEnvironmentManagementStore() {
 		return sorted;
 	}
 
+	function _isAutoSelectableEnvironment(environment: Environment): boolean {
+		if (!environment.enabled) return false;
+		if (environment.id === LOCAL_DOCKER_ENVIRONMENT_ID) return true;
+		return isEnvironmentOnline(environment);
+	}
+
+	function _setSelectedEnvironment(environment: Environment): Environment {
+		_selectedEnvironment = environment;
+		selectedEnvironmentId.current = environment.id;
+		return environment;
+	}
+
 	function _selectInitialEnvironment(available: Environment[]): Environment | null {
 		const savedId = selectedEnvironmentId.current;
 
 		if (savedId) {
 			const found = available.find((env) => env.id === savedId);
-			if (found && found.enabled) {
-				_selectedEnvironment = found;
-				return found;
+			if (found && _isAutoSelectableEnvironment(found)) {
+				return _setSelectedEnvironment(found);
 			}
 		}
 
 		const localEnv = available.find((env) => env.id === LOCAL_DOCKER_ENVIRONMENT_ID);
-		if (localEnv && localEnv.enabled) {
-			_selectedEnvironment = localEnv;
-			return localEnv;
+		if (localEnv && _isAutoSelectableEnvironment(localEnv)) {
+			return _setSelectedEnvironment(localEnv);
 		}
 
-		const firstEnabled = available.find((env) => env.enabled);
-		if (firstEnabled) {
-			_selectedEnvironment = firstEnabled;
-			return firstEnabled;
+		const firstReachable = available.find((env) => _isAutoSelectableEnvironment(env));
+		if (firstReachable) {
+			return _setSelectedEnvironment(firstReachable);
 		}
 
 		_selectedEnvironment = null;


### PR DESCRIPTION
## What This PR Implements

When a previously selected remote environment goes offline, the persisted selectedEnvironmentId was still auto-restored after login. Initial authenticated layout fetches then targeted that offline environment, causing startup to stall.

Update environment auto-selection to only restore reachable environments (enabled + local env 0 or online remote env). If the saved environment is not reachable, fall back to local/first reachable and persist that fallback ID.

## Related Issue

Fixes #1862

## Changes Made

- Adjusted frontend `environment` store to smartly select online local or online environments, falling back to local or `0` environment

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [x] Development environment started: `./scripts/development/dev.sh start`
- [x] Frontend verified at http://localhost:3000
- [x] Backend verified at http://localhost:3552
- [x] Manual testing completed (describe): Ran Arcane locally, created a remote environment, took it offline, confirmed that the UI correctly falls back to the local environment
- [x] No linting errors (e.g., `just lint all`)
- [x] Backend tests pass: `just test backend`

## Checklist

- [x] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool: OpenAI Codex
Assistance Level: Moderate
What AI helped with: Exploring the codebase and identifying the affected files for this changeset
I reviewed and edited all AI-generated output: Yes
I ran all required tests and manually verified changes: Yes

## Additional Context
N/A

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a startup stall caused by the persisted `selectedEnvironmentId` restoring an offline remote environment after login. It introduces two helper functions — `_isAutoSelectableEnvironment` and `_setSelectedEnvironment` — and updates `_selectInitialEnvironment` to skip environments that are unreachable (enabled but offline), falling back to the local env or the first reachable environment and persisting that fallback ID.

Key changes:
- `_isAutoSelectableEnvironment`: gates auto-selection on `enabled` + (local env OR `isEnvironmentOnline`), preventing offline remote envs from being auto-restored at startup.
- `_setSelectedEnvironment`: extracted helper that both sets the reactive state and persists the ID, removing duplicated assignments.
- `_selectInitialEnvironment`: now uses both helpers, so fallback selections also persist their chosen ID to `PersistedState`.
- **Logic gap (live-refresh path)**: the existing `else` branch in `initialize` still only calls `_selectInitialEnvironment` when `!updated.enabled`, not when `!_isAutoSelectableEnvironment(updated)`. A remote environment that goes offline mid-session (while remaining enabled) will still be held as the selected environment on subsequent refreshes, which is inconsistent with the new startup behaviour.
- **Local env bypass**: `_isAutoSelectableEnvironment` unconditionally returns `true` for the local Docker env (id `'0'`) when enabled, skipping the online check. This is a reasonable design choice but is not documented in-code.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- The PR fixes the described startup bug, but leaves a related reachability gap in the live-refresh path that could cause similar offline-selection issues during an active session.
- The startup path fix is clean and correct. The extracted helpers improve clarity. However, the live-refresh branch still uses only `!updated.enabled` rather than `!_isAutoSelectableEnvironment(updated)`, meaning the offline-env problem can resurface during a session after environments refresh. This is a real, reproducible logic gap directly related to the stated fix.
- `frontend/src/lib/stores/environment.store.svelte.ts` — specifically the live-refresh `else` branch at line 116.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/stores/environment.store.svelte.ts | Adds `_isAutoSelectableEnvironment` and `_setSelectedEnvironment` helpers; fixes startup auto-selection to avoid offline environments. The live-refresh branch still only falls back on `!enabled`, not on offline status, leaving a logic gap that the PR's own new helper could close. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[initialize called] --> B{Already initialized?}
    B -- No --> C[_selectInitialEnvironment]
    B -- Yes, no data yet --> C
    B -- Yes, has data --> D{_selectedEnvironment set?}

    D -- No, but envs available --> C
    D -- Yes --> E[Find updated env in available]
    E -- Not found --> C
    E -- Found --> F[_selectedEnvironment = updated]
    F --> G{updated.enabled?}
    G -- No --> C
    G -- Yes --> H[Keep current selection\neven if OFFLINE ⚠️]

    C --> I{savedId reachable?\nenabled + local OR online}
    I -- Yes --> J[_setSelectedEnvironment\npersist ID]
    I -- No --> K{Local env reachable?}
    K -- Yes --> J
    K -- No --> L{First reachable env?}
    L -- Yes --> J
    L -- No --> M[_selectedEnvironment = null\nsavedId NOT cleared]

    style H fill:#f96,stroke:#c33
    style M fill:#ff9,stroke:#996
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/lib/stores/environment.store.svelte.ts`, line 116-118 ([link](https://github.com/getarcaneapp/arcane/blob/ead05b405e39f276d687dc7f29cc3c251ec92a0f/frontend/src/lib/stores/environment.store.svelte.ts#L116-L118)) 

   **Live-refresh path doesn't check reachability — only `enabled`**

   The new `_isAutoSelectableEnvironment` logic ensures that offline environments are avoided on startup, but the live-refresh branch (reached after the store is already initialized) only falls back when `!updated.enabled`. If a currently-selected remote environment goes offline mid-session (enabled=true, but `isEnvironmentOnline` → false), subsequent `initialize` calls will assign the now-offline env to `_selectedEnvironment` without triggering `_selectInitialEnvironment`. This means the same offline-env problem that was fixed at startup can still occur during the session on refreshes.

   Aligning this branch with the new `_isAutoSelectableEnvironment` helper would make the behaviour consistent:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/lib/stores/environment.store.svelte.ts
   Line: 116-118

   Comment:
   **Live-refresh path doesn't check reachability — only `enabled`**

   The new `_isAutoSelectableEnvironment` logic ensures that offline environments are avoided on startup, but the live-refresh branch (reached after the store is already initialized) only falls back when `!updated.enabled`. If a currently-selected remote environment goes offline mid-session (enabled=true, but `isEnvironmentOnline` → false), subsequent `initialize` calls will assign the now-offline env to `_selectedEnvironment` without triggering `_selectInitialEnvironment`. This means the same offline-env problem that was fixed at startup can still occur during the session on refreshes.

   Aligning this branch with the new `_isAutoSelectableEnvironment` helper would make the behaviour consistent:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: ead05b4</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->