### PR TITLE
docs: Update SECURITY.md to include AI submission guidelines

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,6 +32,6 @@ We value responsible disclosure and are grateful for your contribution to the se
 ---
 
 > [!IMPORTANT]
-> If you are using AI to submit vulnerability, please follow the rules documented in [AI_POLICY.MD](https://github.com/getarcaneapp/arcane/blob/main/AI_POLICY.md).  CVE farming and other low-effort submissions are disrespectful and puts the burden of validation on the volunteer maintainers of this project.
+> If you are using AI to submit a vulnerability, please follow the rules documented in [AI_POLICY.md](https://github.com/getarcaneapp/arcane/blob/main/AI_POLICY.md).  CVE farming and other low-effort submissions are disrespectful and put the burden of validation on the volunteer maintainers of this project.
 
 **Note:** For general bug reports, feature requests, or other non-security issues, please use our [GitHub issue tracker](https://github.com/getarcaneapp/arcane/issues).


### PR DESCRIPTION
## What This PR Implements

Added a note regarding AI submissions for vulnerabilities.

## Changes Made

Updated SECURITY.md to clarify rules around AI vulnerability submissions.

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [x] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool: Greptile
Assistance Level: Minor
What AI helped with:
Spelling/grammar

## Additional Context

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a single callout block to `SECURITY.md` advising reporters who use AI tools to follow the project's `AI_POLICY.md` and discouraging low-effort/CVE-farming submissions.

**Key findings:**
- The link to `AI_POLICY.md` uses an uppercase extension (`AI_POLICY.MD`), which will 404 on GitHub's case-sensitive Linux filesystem. The actual file in the repo is `AI_POLICY.md`.
- Minor grammar: "submit vulnerability" should be "submit a vulnerability" (missing article), and "puts the burden" should be "put the burden" (subject-verb agreement with "submissions").

Both fixes are captured in the single suggestion on line 35.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge after fixing the broken AI_POLICY.MD link casing.
- This is a documentation-only change with no code impact. The one concrete issue — the broken link due to incorrect file extension casing — is easy to fix and low risk. Grammar nits are minor and don't affect functionality.
- SECURITY.md — verify the AI_POLICY link casing before merging.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| SECURITY.md | Adds an AI submission guideline callout block; contains a broken link (AI_POLICY.MD vs AI_POLICY.md) and minor grammar issues ("submit vulnerability" → "submit a vulnerability", "puts" → "put"). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant R as Reporter
    participant AI as AI Tool (optional)
    participant P as AI_POLICY.md
    participant T as Security Team (info@getarcane.app)

    R->>R: Discover potential vulnerability
    alt Used AI assistance
        R->>P: Review AI_POLICY.md guidelines
        P-->>R: Confirm submission meets policy
    end
    R->>T: Email vulnerability report
    T-->>R: Acknowledge within 48 hours
    T->>T: Investigate & validate
    T-->>R: Progress updates & fix release
```
</details>

<sub>Last reviewed commit: c64524d</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->