### PR TITLE
fix: incorrect volume mount in agent snippets

### DIFF
--- a/backend/internal/services/environment_service.go
+++ b/backend/internal/services/environment_service.go
@@ -695,40 +695,46 @@ type DeploymentSnippets struct {
 	DockerCompose string
 }
 
+const deploymentSnippetsDataPath = "/app/data"
+
 // GenerateDeploymentSnippets generates Docker deployment snippets for an environment.
 func (s *EnvironmentService) GenerateDeploymentSnippets(ctx context.Context, envID string, envAddress string, apiKey string) (*DeploymentSnippets, error) {
 	managerURL := strings.TrimRight(envAddress, "/")
 
-	dockerRun := fmt.Sprintf(`docker run -d \
-  --name arcane-agent \
-  --restart unless-stopped \
-  -e AGENT_MODE=true \
-	-e EDGE_TRANSPORT=poll \
-  -e AGENT_TOKEN=%s \
-  -e MANAGER_API_URL=%s \
-  -p 3553:3553 \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v arcane-data:/data \
-  ghcr.io/getarcaneapp/arcane-headless:latest`, apiKey, managerURL)
+	dockerRun := strings.Join([]string{
+		"docker run -d \\",
+		"  --name arcane-agent \\",
+		"  --restart unless-stopped \\",
+		"  -e AGENT_MODE=true \\",
+		"  -e EDGE_TRANSPORT=poll \\",
+		fmt.Sprintf("  -e AGENT_TOKEN=%s \\", apiKey),
+		fmt.Sprintf("  -e MANAGER_API_URL=%s \\", managerURL),
+		"  -p 3553:3553 \\",
+		"  -v /var/run/docker.sock:/var/run/docker.sock \\",
+		fmt.Sprintf("  -v arcane-data:%s \\", deploymentSnippetsDataPath),
+		"  ghcr.io/getarcaneapp/arcane-headless:latest",
+	}, "\n")
 
-	dockerCompose := fmt.Sprintf(`services:
-  arcane-agent:
-    image: ghcr.io/getarcaneapp/arcane-headless:latest
-    container_name: arcane-agent
-    restart: unless-stopped
-    environment:
-      - AGENT_MODE=true
-		  - EDGE_TRANSPORT=poll
-      - AGENT_TOKEN=%s
-      - MANAGER_API_URL=%s
-    ports:
-      - "3553:3553"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - arcane-data:/app/data
-
-volumes:
-  arcane-data:`, apiKey, managerURL)
+	dockerCompose := strings.Join([]string{
+		"services:",
+		"  arcane-agent:",
+		"    image: ghcr.io/getarcaneapp/arcane-headless:latest",
+		"    container_name: arcane-agent",
+		"    restart: unless-stopped",
+		"    environment:",
+		"      - AGENT_MODE=true",
+		"      - EDGE_TRANSPORT=poll",
+		fmt.Sprintf("      - AGENT_TOKEN=%s", apiKey),
+		fmt.Sprintf("      - MANAGER_API_URL=%s", managerURL),
+		"    ports:",
+		"      - \"3553:3553\"",
+		"    volumes:",
+		"      - /var/run/docker.sock:/var/run/docker.sock",
+		fmt.Sprintf("      - arcane-data:%s", deploymentSnippetsDataPath),
+		"",
+		"volumes:",
+		"  arcane-data:",
+	}, "\n")
 
 	return &DeploymentSnippets{
 		DockerRun:     dockerRun,
@@ -741,34 +747,38 @@ volumes:
 func (s *EnvironmentService) GenerateEdgeDeploymentSnippets(ctx context.Context, envID string, managerURL string, apiKey string) (*DeploymentSnippets, error) {
 	managerURL = strings.TrimRight(managerURL, "/")
 
-	dockerRun := fmt.Sprintf(`docker run -d \
-  --name arcane-edge-agent \
-  --restart unless-stopped \
-  -e EDGE_AGENT=true \
-	-e EDGE_TRANSPORT=poll \
-  -e AGENT_TOKEN=%s \
-  -e MANAGER_API_URL=%s \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v arcane-data:/app/data \
-  ghcr.io/getarcaneapp/arcane-headless:latest`, apiKey, managerURL)
+	dockerRun := strings.Join([]string{
+		"docker run -d \\",
+		"  --name arcane-edge-agent \\",
+		"  --restart unless-stopped \\",
+		"  -e EDGE_AGENT=true \\",
+		"  -e EDGE_TRANSPORT=poll \\",
+		fmt.Sprintf("  -e AGENT_TOKEN=%s \\", apiKey),
+		fmt.Sprintf("  -e MANAGER_API_URL=%s \\", managerURL),
+		"  -v /var/run/docker.sock:/var/run/docker.sock \\",
+		fmt.Sprintf("  -v arcane-data:%s \\", deploymentSnippetsDataPath),
+		"  ghcr.io/getarcaneapp/arcane-headless:latest",
+	}, "\n")
 
-	dockerCompose := fmt.Sprintf(`# Edge agent - connects outbound, no exposed ports required
-services:
-  arcane-edge-agent:
-    image: ghcr.io/getarcaneapp/arcane-headless:latest
-    container_name: arcane-edge-agent
-    restart: unless-stopped
-    environment:
-      - EDGE_AGENT=true
-		  - EDGE_TRANSPORT=poll
-      - AGENT_TOKEN=%s
-      - MANAGER_API_URL=%s
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - arcane-data:/app/data
-
-volumes:
-  arcane-data:`, apiKey, managerURL)
+	dockerCompose := strings.Join([]string{
+		"# Edge agent - connects outbound, no exposed ports required",
+		"services:",
+		"  arcane-edge-agent:",
+		"    image: ghcr.io/getarcaneapp/arcane-headless:latest",
+		"    container_name: arcane-edge-agent",
+		"    restart: unless-stopped",
+		"    environment:",
+		"      - EDGE_AGENT=true",
+		"      - EDGE_TRANSPORT=poll",
+		fmt.Sprintf("      - AGENT_TOKEN=%s", apiKey),
+		fmt.Sprintf("      - MANAGER_API_URL=%s", managerURL),
+		"    volumes:",
+		"      - /var/run/docker.sock:/var/run/docker.sock",
+		fmt.Sprintf("      - arcane-data:%s", deploymentSnippetsDataPath),
+		"",
+		"volumes:",
+		"  arcane-data:",
+	}, "\n")
 
 	return &DeploymentSnippets{
 		DockerRun:     dockerRun,

--- a/backend/internal/services/environment_service_test.go
+++ b/backend/internal/services/environment_service_test.go
@@ -354,6 +354,9 @@ func TestEnvironmentService_GenerateDeploymentSnippets_ExplicitlyUsePollTranspor
 	require.Contains(t, standard.DockerRun, "EDGE_TRANSPORT=poll")
 	require.Contains(t, standard.DockerCompose, "EDGE_TRANSPORT=poll")
 	require.True(t, strings.Contains(standard.DockerRun, "AGENT_TOKEN=token-123"))
+	require.Contains(t, standard.DockerRun, "-v arcane-data:/app/data")
+	require.Contains(t, standard.DockerCompose, "- arcane-data:/app/data")
+	require.NotContains(t, standard.DockerRun, "-v arcane-data:/data")
 
 	edgeSnippets, err := svc.GenerateEdgeDeploymentSnippets(context.Background(), "env-2", "https://manager.example.com", "token-456")
 	require.NoError(t, err)
@@ -363,4 +366,7 @@ func TestEnvironmentService_GenerateDeploymentSnippets_ExplicitlyUsePollTranspor
 	require.Contains(t, edgeSnippets.DockerRun, "EDGE_TRANSPORT=poll")
 	require.Contains(t, edgeSnippets.DockerCompose, "EDGE_TRANSPORT=poll")
 	require.True(t, strings.Contains(edgeSnippets.DockerRun, "AGENT_TOKEN=token-456"))
+	require.Contains(t, edgeSnippets.DockerRun, "-v arcane-data:/app/data")
+	require.Contains(t, edgeSnippets.DockerCompose, "- arcane-data:/app/data")
+	require.NotContains(t, edgeSnippets.DockerRun, "-v arcane-data:/data")
 }


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/2020

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an inconsistency in the Docker run snippet produced by `GenerateDeploymentSnippets`, where the volume mount target was `/data` instead of the correct `/app/data` used by the image. Both snippet-generation functions are refactored from `fmt.Sprintf` with raw multiline strings (which contained mixed-tab indentation bugs) to `strings.Join` slices, and a shared package-level constant `deploymentSnippetsDataPath` is introduced to keep the path consistent across both functions and both output formats.

- **Bug fixed**: `GenerateDeploymentSnippets`'s `dockerRun` was mounting `arcane-data:/data`; it now correctly mounts `arcane-data:/app/data`, matching the compose output and the edge agent's run snippet.
- **Constant introduced**: `deploymentSnippetsDataPath = "/app/data"` is used in all four volume-mount format strings, eliminating any future drift.
- **Refactoring**: Raw string literals with mixed tab/space indentation are replaced by `strings.Join` slices, which are more readable and immune to whitespace corruption.
- **Tests updated**: New `require.Contains` / `require.NotContains` assertions verify the correct mount path for both standard and edge snippets.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — it is a targeted, well-tested bug fix with no side-effects outside the snippet-generation helpers.
- The change is narrow in scope (two string-building functions and their test), the fix is clearly correct, the constant ensures future consistency, and the new test assertions provide direct regression coverage for the bug. No logic paths, data models, or external interfaces are affected.
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/internal/services/environment_service.go | Fixes incorrect volume mount path (`/data` → `/app/data`) in `GenerateDeploymentSnippets`'s Docker run snippet; introduces `deploymentSnippetsDataPath` constant; refactors both snippet builders from raw multiline strings to `strings.Join` (also eliminating the pre-existing tab/space indentation corruption in the raw literals). |
| backend/internal/services/environment_service_test.go | Adds assertions to verify the volume mount path is `/app/data` and explicitly not `/data` for both standard and edge agent snippets. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GenerateDeploymentSnippets / GenerateEdgeDeploymentSnippets] --> B[strings.Join lines into dockerRun]
    A --> C[strings.Join lines into dockerCompose]
    B --> D["Volume mount: -v arcane-data:/app/data\n(deploymentSnippetsDataPath constant)"]
    C --> E["Volume mount: - arcane-data:/app/data\n(deploymentSnippetsDataPath constant)"]
    D --> F[Return DeploymentSnippets]
    E --> F
```
</details>

<sub>Last reviewed commit: 3d04a56</sub>

<!-- /greptile_comment -->