### PR TITLE
fix: allow yaml merge syntax

### DIFF
--- a/frontend/src/lib/components/code-editor/analysis/compose-analysis.ts
+++ b/frontend/src/lib/components/code-editor/analysis/compose-analysis.ts
@@ -143,7 +143,7 @@ function findContextInNode(
 }
 
 export function findYamlPositionContext(source: string, position: number): YamlPositionContext | null {
-	const doc = parseDocument(source, { strict: true, uniqueKeys: false });
+	const doc = parseDocument(source, { strict: true, uniqueKeys: false, merge: true });
 	return findContextInNode((doc.contents as ParsedNode | null) ?? null, position, []);
 }
 
@@ -171,7 +171,7 @@ function findKeyRangeInSource(source: string, key: string): { from: number; to: 
 	};
 }
 
-function toSchemaDiagnostic(error: ErrorObject, doc: YamlDocLike, source: string): Diagnostic {
+function toSchemaDiagnostic(error: ErrorObject, doc: YamlDocLike, source: string): Diagnostic | null {
 	const path = pointerToPath(error.instancePath || '');
 	const params = error.params as Record<string, unknown>;
 	const missingProperty = typeof params.missingProperty === 'string' ? params.missingProperty : null;
@@ -189,6 +189,7 @@ function toSchemaDiagnostic(error: ErrorObject, doc: YamlDocLike, source: string
 		message = `Missing required property "${missingProperty}"`;
 	}
 	if (error.keyword === 'additionalProperties' && additionalProperty) {
+		if (additionalProperty === '<<') return null;
 		message = `Unsupported property "${additionalProperty}"`;
 	}
 
@@ -211,7 +212,7 @@ function collectDuplicateKeyDiagnostics(node: ParsedNode | null | undefined, dia
 			const key = scalarToKey(item.key);
 			if (key) {
 				const keyRange = getRange(item.key);
-				if (seen.has(key)) {
+				if (seen.has(key) && key !== '<<') {
 					duplicateCount += 1;
 					diagnostics.push({
 						from: keyRange?.[0] ?? 0,
@@ -473,7 +474,8 @@ export async function analyzeComposeContent(
 	const doc = parseDocument(source, {
 		lineCounter,
 		strict: true,
-		uniqueKeys: false
+		uniqueKeys: false,
+		merge: true
 	}) as unknown as YamlDocLike;
 
 	const diagnostics: Diagnostic[] = [];
@@ -505,7 +507,8 @@ export async function analyzeComposeContent(
 				const isValid = schemaContext.validate(parsedValue);
 				if (!isValid) {
 					for (const error of (schemaContext.validate.errors || []).slice(0, maxSchemaDiagnostics)) {
-						diagnostics.push(toSchemaDiagnostic(error, doc, source));
+						const diag = toSchemaDiagnostic(error, doc, source);
+						if (diag) diagnostics.push(diag);
 					}
 				}
 			}

--- a/frontend/src/lib/components/code-editor/analysis/env-analysis.ts
+++ b/frontend/src/lib/components/code-editor/analysis/env-analysis.ts
@@ -1,6 +1,7 @@
 import type { EditorView } from '@codemirror/view';
 import type { Diagnostic } from '@codemirror/lint';
 import type { AnalysisResult, EditorContext, OutlineItem } from './types';
+import { isOpenQuote } from './parse-env-utils';
 import { extractComposeVariables } from './vars-analysis';
 
 const ENV_KEY_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
@@ -32,6 +33,70 @@ function parseEnv(source: string): {
 	const lines = source.split('\n');
 	let offset = 0;
 
+	let multiLineKey: string | null = null;
+	let multiLineQuote: string | null = null;
+	let multiLineFrom = 0;
+	let multiLineTo = 0;
+	let multiLineKeyFrom = 0;
+	let multiLineKeyTo = 0;
+	let multiLineLineNumber = 0;
+	let multiLineParts: string[] = [];
+
+	function finalizeEntry(
+		key: string,
+		value: string,
+		lineNumber: number,
+		from: number,
+		to: number,
+		keyFrom: number,
+		keyTo: number
+	): void {
+		const parsed: ParsedEnvLine = { lineNumber, from, to: Math.max(from + 1, to), key, value, keyFrom, keyTo };
+
+		if (seen.has(key)) {
+			const previous = seen.get(key);
+			duplicateKeys += 1;
+			diagnostics.push({
+				from: keyFrom,
+				to: keyTo,
+				severity: 'warning',
+				message: `Duplicate variable "${key}". Last value wins.`,
+				actions: [
+					{
+						name: 'Remove earlier duplicate',
+						apply(view: EditorView) {
+							const doc = view.state.doc;
+							const target = previous ?? parsed;
+							let removeTo = target.to;
+							const nextChars = doc.sliceString(removeTo, Math.min(doc.length, removeTo + 2));
+							if (nextChars.startsWith('\r\n')) {
+								removeTo += 2;
+							} else if (nextChars.startsWith('\n')) {
+								removeTo += 1;
+							}
+							view.dispatch({
+								changes: { from: target.from, to: removeTo, insert: '' }
+							});
+						}
+					}
+				]
+			});
+		}
+
+		seen.set(key, parsed);
+		entries.push(parsed);
+
+		if (SECRET_NAME_REGEX.test(key) || SECRET_VALUE_REGEX.test(value)) {
+			secretWarnings += 1;
+			diagnostics.push({
+				from: keyFrom,
+				to: keyTo,
+				severity: 'warning',
+				message: `"${key}" looks like a secret. Consider using Docker secrets or external secret management.`
+			});
+		}
+	}
+
 	for (let index = 0; index < lines.length; index += 1) {
 		const rawLine = lines[index] ?? '';
 		const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
@@ -40,6 +105,23 @@ function parseEnv(source: string): {
 		const lineTo = offset + line.length;
 
 		offset += rawLine.length + 1;
+
+		// Inside a multi-line quoted value — accumulate until closing quote
+		if (multiLineQuote !== null && multiLineKey !== null) {
+			multiLineParts.push(rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine);
+			multiLineTo = lineTo;
+
+			const trimmedEnd = line.trimEnd();
+			const isEscaped = trimmedEnd.length >= 2 && trimmedEnd[trimmedEnd.length - 2] === '\\';
+			if (trimmedEnd.endsWith(multiLineQuote) && !isEscaped) {
+				const fullValue = multiLineParts.join('\n');
+				finalizeEntry(multiLineKey, fullValue, multiLineLineNumber, multiLineFrom, multiLineTo, multiLineKeyFrom, multiLineKeyTo);
+				multiLineKey = null;
+				multiLineQuote = null;
+				multiLineParts = [];
+			}
+			continue;
+		}
 
 		const trimmed = line.trim();
 		if (!trimmed || trimmed.startsWith('#')) continue;
@@ -73,54 +155,31 @@ function parseEnv(source: string): {
 			continue;
 		}
 
-		const parsed: ParsedEnvLine = {
-			lineNumber,
-			from: lineFrom,
-			to: Math.max(lineFrom + 1, lineTo),
-			key,
-			value,
-			keyFrom,
-			keyTo
-		};
-
-		if (seen.has(key)) {
-			const previous = seen.get(key);
-			duplicateKeys += 1;
-			diagnostics.push({
-				from: keyFrom,
-				to: keyTo,
-				severity: 'warning',
-				message: `Duplicate variable "${key}". Last value wins.`,
-				actions: [
-					{
-						name: 'Remove earlier duplicate',
-						apply(view: EditorView) {
-							const doc = view.state.doc;
-							const targetLineNumber = previous?.lineNumber ?? lineNumber;
-							if (targetLineNumber < 1 || targetLineNumber > doc.lines) return;
-							const lineInfo = doc.line(targetLineNumber);
-							const removeTo = lineInfo.number < doc.lines ? doc.line(targetLineNumber + 1).from : lineInfo.to;
-							view.dispatch({
-								changes: { from: lineInfo.from, to: removeTo, insert: '' }
-							});
-						}
-					}
-				]
-			});
+		// Check for multi-line quoted value
+		const openQuote = isOpenQuote(value);
+		if (openQuote) {
+			multiLineKey = key;
+			multiLineQuote = openQuote;
+			multiLineFrom = lineFrom;
+			multiLineTo = lineTo;
+			multiLineKeyFrom = keyFrom;
+			multiLineKeyTo = keyTo;
+			multiLineLineNumber = lineNumber;
+			multiLineParts = [value];
+			continue;
 		}
 
-		seen.set(key, parsed);
-		entries.push(parsed);
+		finalizeEntry(key, value, lineNumber, lineFrom, lineTo, keyFrom, keyTo);
+	}
 
-		if (SECRET_NAME_REGEX.test(key) || SECRET_VALUE_REGEX.test(value)) {
-			secretWarnings += 1;
-			diagnostics.push({
-				from: keyFrom,
-				to: keyTo,
-				severity: 'warning',
-				message: `"${key}" looks like a secret. Consider using Docker secrets or external secret management.`
-			});
-		}
+	// Unterminated multi-line quoted value at EOF
+	if (multiLineQuote !== null && multiLineKey !== null) {
+		diagnostics.push({
+			from: multiLineFrom,
+			to: Math.max(multiLineFrom + 1, multiLineTo),
+			severity: 'error',
+			message: `Unterminated quoted value for "${multiLineKey}". Missing closing ${multiLineQuote}.`
+		});
 	}
 
 	return { entries, diagnostics, duplicateKeys, secretWarnings };

--- a/frontend/src/lib/components/code-editor/analysis/parse-env-utils.ts
+++ b/frontend/src/lib/components/code-editor/analysis/parse-env-utils.ts
@@ -1,0 +1,10 @@
+export function isOpenQuote(value: string): string | null {
+	// Simplification: this only detects obviously unterminated leading quotes.
+	// Values that start/end with the same quote are treated as closed, even if
+	// their internal quoting would be malformed in a stricter parser.
+	if (value.length === 0) return null;
+	const quote = value[0];
+	if (quote !== '"' && quote !== "'") return null;
+	if (value.length >= 2 && value[value.length - 1] === quote) return null;
+	return quote;
+}

--- a/frontend/src/lib/components/code-editor/analysis/vars-analysis.ts
+++ b/frontend/src/lib/components/code-editor/analysis/vars-analysis.ts
@@ -1,4 +1,5 @@
 import type { EditorContext } from './types';
+import { isOpenQuote } from './parse-env-utils';
 
 const BRACED_VAR_REGEX = /\$\{([A-Za-z_][A-Za-z0-9_]*)(?:(?::[-?+])[^}]*)?\}/g;
 const SIMPLE_VAR_REGEX = /(^|[^$])\$([A-Za-z_][A-Za-z0-9_]*)/g;
@@ -26,7 +27,25 @@ export function parseEnvVariables(envContent: string): Map<string, string> {
 	const values = new Map<string, string>();
 	const lines = envContent.split(/\r?\n/);
 
+	let multiLineKey: string | null = null;
+	let multiLineQuote: string | null = null;
+	let multiLineParts: string[] = [];
+
 	for (const rawLine of lines) {
+		// Inside a multi-line quoted value — accumulate until closing quote
+		if (multiLineQuote !== null && multiLineKey !== null) {
+			multiLineParts.push(rawLine);
+			const trimmedEnd = rawLine.trimEnd();
+			const isEscaped = trimmedEnd.length >= 2 && trimmedEnd[trimmedEnd.length - 2] === '\\';
+			if (trimmedEnd.endsWith(multiLineQuote) && !isEscaped) {
+				values.set(multiLineKey, multiLineParts.join('\n'));
+				multiLineKey = null;
+				multiLineQuote = null;
+				multiLineParts = [];
+			}
+			continue;
+		}
+
 		const trimmed = rawLine.trim();
 		if (!trimmed || trimmed.startsWith('#')) continue;
 
@@ -38,7 +57,20 @@ export function parseEnvVariables(envContent: string): Map<string, string> {
 		if (!ENV_KEY_REGEX.test(key)) continue;
 
 		const value = line.slice(separator + 1).trim();
+
+		const openQuote = isOpenQuote(value);
+		if (openQuote) {
+			multiLineKey = key;
+			multiLineQuote = openQuote;
+			multiLineParts = [value];
+			continue;
+		}
+
 		values.set(key, value);
+	}
+
+	if (multiLineKey !== null && multiLineParts.length > 0) {
+		values.set(multiLineKey, multiLineParts.join('\n'));
 	}
 
 	return values;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2789,7 +2789,6 @@ packages:
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@14.0.0:


### PR DESCRIPTION
## What This PR Implements

**Related issue**
<!-- If this is a bug fix, include “Fixes #1234” or “Closes #1234” -->
<!-- Briefly describe what this PR accomplishes -->

## Related Issue

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes # https://github.com/getarcaneapp/arcane/issues/2005

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes false-positive diagnostics that appeared when Docker Compose files used YAML merge syntax (`<<: *anchor`). The changes enable `merge: true` on all `parseDocument` calls, suppress `additionalProperties` schema errors for `<<` keys, and skip duplicate-key warnings for `<<` keys. As a companion fix it also introduces proper multi-line quoted-value parsing for `.env` files (accumulating continuation lines until the closing quote) and extracts the shared `isOpenQuote` helper into `parse-env-utils.ts`.

- **`compose-analysis.ts`** — `merge: true` added to both `parseDocument` invocations; `toSchemaDiagnostic` return type widened to `Diagnostic | null` and returns `null` for `<<` additional-property errors; call-site null-guards the result before pushing; `collectDuplicateKeyDiagnostics` skips `key === '<<'` pairs.
- **`env-analysis.ts`** — New `finalizeEntry` inner function centralises the duplicate/secret-detection logic; multi-line quoted-value accumulator added with an EOF guard that emits an `error` diagnostic for unterminated values; imports `isOpenQuote` from the new shared utility.
- **`vars-analysis.ts`** — Mirrors the multi-line accumulation logic; EOF guard **stores** the partial value so that unterminated keys are still present in the resolution map, preventing the previously-flagged false-positive "variable not defined" warning.
- **`parse-env-utils.ts`** (new) — Exports the shared `isOpenQuote` helper, addressing the prior review's concern about duplicated logic.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge; changes are targeted, well-scoped, and address a clear user-facing false-positive without touching unrelated paths.
- The compose-side fix is minimal and correct — `merge: true` eliminates `<<` from the JS-validated value, the null-guard on `toSchemaDiagnostic` is defensive, and the duplicate-key skip is properly conditioned. The env multi-line parsing is a larger addition but mirrors a consistent pattern across both analysis files and correctly adds the EOF guard that resolves the previously flagged false-positive. Known edge-cases (intermediate lines ending with the quote char, double-backslash before a closing quote) are acknowledged in comments/prior threads and represent pre-existing simplification trade-offs rather than regressions. Score withheld from 5 due to the known escape-detection limitation in the new multi-line accumulator remaining unresolved.
- `env-analysis.ts` and `vars-analysis.ts` — the `isEscaped` heuristic (single-backslash look-behind) can misclassify `\\"` (escaped backslash + real closing quote) as still-open; low probability in practice but worth noting.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/components/code-editor/analysis/compose-analysis.ts | Core fix: adds `merge: true` to both `parseDocument` calls, filters `<<` from schema `additionalProperties` errors (returning `null`), skips duplicate-key diagnostics for `<<` keys, and null-guards the `toSchemaDiagnostic` call-site. Changes are minimal and targeted. |
| frontend/src/lib/components/code-editor/analysis/env-analysis.ts | Substantial refactor: extracts `finalizeEntry` inner function, adds multi-line quoted-value accumulation, imports shared `isOpenQuote` helper, and adds EOF guard that emits an error diagnostic for unterminated values. Logic is sound; known edge-cases (intermediate lines ending with the quote char, double-backslash before closing quote) are pre-existing and documented/flagged in prior review threads. |
| frontend/src/lib/components/code-editor/analysis/vars-analysis.ts | Multi-line quoted-value support mirroring env-analysis.ts; EOF guard now stores partial value so unterminated multi-line keys are still recognised during variable-resolution, fixing the previously-flagged false-positive "variable undefined" warning. |
| frontend/src/lib/components/code-editor/analysis/parse-env-utils.ts | New shared utility exporting `isOpenQuote`; extracts the previously duplicated helper into one place with an explicit return-type annotation and a comment documenting the known simplification. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["analyzeComposeContent(source)"] --> B["parseDocument(source,\n{ merge: true, uniqueKeys: false })"]
    B --> C["doc.toJS() — merge keys resolved,\n'<<' absent from JS value"]
    C --> D["schemaContext.validate(parsedValue)"]
    D --> E{"Validation errors?"}
    E -- Yes --> F["toSchemaDiagnostic(error, doc, source)"]
    F --> G{"additionalProperty\n=== '<<'?"}
    G -- Yes --> H["return null — suppressed"]
    G -- No --> I["return Diagnostic"]
    I --> J["diagnostics.push(diag)"]
    H --> K["skipped"]
    E -- No --> L["collectDuplicateKeyDiagnostics\n(AST walk)"]
    L --> M{"key === '<<'?"}
    M -- Yes --> N["skip — merge keys\nallowed multiple times"]
    M -- No --> O{"seen.has(key)?"}
    O -- Yes --> P["push duplicate\nkey diagnostic"]
    O -- No --> Q["seen.add(key)"]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/lib/components/code-editor/analysis/compose-analysis.ts`, line 204-238 ([link](https://github.com/getarcaneapp/arcane/blob/4256bd36f956eed48b1635d80ba9fc1c7b7b94cf/frontend/src/lib/components/code-editor/analysis/compose-analysis.ts#L204-L238)) 

   **`collectDuplicateKeyDiagnostics` doesn't special-case `<<` merge keys**

   The PR correctly enables `merge: true` in the parser and suppresses the AJV "Unsupported property" error for `<<`. However, `collectDuplicateKeyDiagnostics` iterates raw AST items and uses a `Set` to detect duplicate keys — it has no awareness of YAML merge key semantics.

   If a user writes a compose file with multiple merge anchors in the same map (a valid YAML 1.1 pattern):

   ```yaml
   services:
     web:
       <<: *base
       <<: *extra   # ← flagged as "Duplicate YAML key '<<'"
       image: nginx
   ```

   The second `<<` will still produce a false-positive "Duplicate YAML key" error diagnostic, even though both the parser (`merge: true`) and the schema validator (the `<<` null-guard) now accept this as valid.

   Consider adding a guard to skip `<<` in the duplicate-key check:

   ```ts
   if (seen.has(key)) {
       if (key === '<<') {
           seen.add(key);
           continue; // merge keys are allowed multiple times
       }
       duplicateCount += 1;
       diagnostics.push({ ... });
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/lib/components/code-editor/analysis/compose-analysis.ts
   Line: 204-238

   Comment:
   **`collectDuplicateKeyDiagnostics` doesn't special-case `<<` merge keys**

   The PR correctly enables `merge: true` in the parser and suppresses the AJV "Unsupported property" error for `<<`. However, `collectDuplicateKeyDiagnostics` iterates raw AST items and uses a `Set` to detect duplicate keys — it has no awareness of YAML merge key semantics.

   If a user writes a compose file with multiple merge anchors in the same map (a valid YAML 1.1 pattern):

   ```yaml
   services:
     web:
       <<: *base
       <<: *extra   # ← flagged as "Duplicate YAML key '<<'"
       image: nginx
   ```

   The second `<<` will still produce a false-positive "Duplicate YAML key" error diagnostic, even though both the parser (`merge: true`) and the schema validator (the `<<` null-guard) now accept this as valid.

   Consider adding a guard to skip `<<` in the duplicate-key check:

   ```ts
   if (seen.has(key)) {
       if (key === '<<') {
           seen.add(key);
           continue; // merge keys are allowed multiple times
       }
       duplicateCount += 1;
       diagnostics.push({ ... });
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20frontend%2Fsrc%2Flib%2Fcomponents%2Fcode-editor%2Fanalysis%2Fcompose-analysis.ts%0ALine%3A%20204-238%0A%0AComment%3A%0A**%60collectDuplicateKeyDiagnostics%60%20doesn't%20special-case%20%60%3C%3C%60%20merge%20keys**%0A%0AThe%20PR%20correctly%20enables%20%60merge%3A%20true%60%20in%20the%20parser%20and%20suppresses%20the%20AJV%20%22Unsupported%20property%22%20error%20for%20%60%3C%3C%60.%20However%2C%20%60collectDuplicateKeyDiagnostics%60%20iterates%20raw%20AST%20items%20and%20uses%20a%20%60Set%60%20to%20detect%20duplicate%20keys%20%E2%80%94%20it%20has%20no%20awareness%20of%20YAML%20merge%20key%20semantics.%0A%0AIf%20a%20user%20writes%20a%20compose%20file%20with%20multiple%20merge%20anchors%20in%20the%20same%20map%20%28a%20valid%20YAML%201.1%20pattern%29%3A%0A%0A%60%60%60yaml%0Aservices%3A%0A%20%20web%3A%0A%20%20%20%20%3C%3C%3A%20*base%0A%20%20%20%20%3C%3C%3A%20*extra%20%20%20%23%20%E2%86%90%20flagged%20as%20%22Duplicate%20YAML%20key%20'%3C%3C'%22%0A%20%20%20%20image%3A%20nginx%0A%60%60%60%0A%0AThe%20second%20%60%3C%3C%60%20will%20still%20produce%20a%20false-positive%20%22Duplicate%20YAML%20key%22%20error%20diagnostic%2C%20even%20though%20both%20the%20parser%20%28%60merge%3A%20true%60%29%20and%20the%20schema%20validator%20%28the%20%60%3C%3C%60%20null-guard%29%20now%20accept%20this%20as%20valid.%0A%0AConsider%20adding%20a%20guard%20to%20skip%20%60%3C%3C%60%20in%20the%20duplicate-key%20check%3A%0A%0A%60%60%60ts%0Aif%20%28seen.has%28key%29%29%20%7B%0A%20%20%20%20if%20%28key%20%3D%3D%3D%20'%3C%3C'%29%20%7B%0A%20%20%20%20%20%20%20%20seen.add%28key%29%3B%0A%20%20%20%20%20%20%20%20continue%3B%20%2F%2F%20merge%20keys%20are%20allowed%20multiple%20times%0A%20%20%20%20%7D%0A%20%20%20%20duplicateCount%20%2B%3D%201%3B%0A%20%20%20%20diagnostics.push%28%7B%20...%20%7D%29%3B%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: f9faa87</sub>

<!-- /greptile_comment -->