### PR TITLE
fix: volume size usage not showing on docker api >1.52

### DIFF
--- a/backend/internal/utils/docker/volume_utils.go
+++ b/backend/internal/utils/docker/volume_utils.go
@@ -38,6 +38,7 @@ func GetVolumeUsageData(ctx context.Context, dockerClient *client.Client) ([]vol
 	}
 	diskUsage, err := dockerClient.DiskUsage(ctx, client.DiskUsageOptions{
 		Volumes: true,
+		Verbose: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get disk usage: %w", err)

--- a/frontend/src/routes/(app)/volumes/volume-table.svelte
+++ b/frontend/src/routes/(app)/volumes/volume-table.svelte
@@ -21,6 +21,7 @@
 	import { Spinner } from '$lib/components/ui/spinner';
 	import settingsStore from '$lib/stores/config-store';
 	import { onMount } from 'svelte';
+	import { SvelteMap } from 'svelte/reactivity';
 
 	let {
 		volumes = $bindable(),
@@ -45,9 +46,10 @@
 	async function refreshVolumes(options: SearchPaginationSortRequest = requestOptions) {
 		if (onRefreshData) {
 			await onRefreshData(options);
-			return;
+		} else {
+			volumes = await volumeService.getVolumes(options);
 		}
-		volumes = await volumeService.getVolumes(options);
+		void loadVolumeSizes();
 	}
 
 	function getCurrentLimit() {
@@ -74,18 +76,22 @@
 	const isBackupVolume = (item: VolumeSummaryDto) => isBackupVolumeName(item.name);
 
 	// Lazy load volume sizes - this is a slow operation
-	let volumeSizesPromise = $state<Promise<Map<string, VolumeSizeInfo>> | null>(null);
+	let sizesMap = new SvelteMap<string, VolumeSizeInfo>();
+	let sizesLoading = $state(false);
 
-	// Start loading sizes when component mounts or volumes change
-	$effect(() => {
-		if (volumes.data.length > 0) {
-			volumeSizesPromise = loadVolumeSizes();
+	async function loadVolumeSizes(): Promise<void> {
+		sizesLoading = true;
+		try {
+			const sizes = await volumeService.getVolumeSizes();
+			sizesMap.clear();
+			for (const s of sizes) {
+				sizesMap.set(s.name, s);
+			}
+		} catch (error) {
+			console.error('Failed to load volume sizes:', error);
+		} finally {
+			sizesLoading = false;
 		}
-	});
-
-	async function loadVolumeSizes(): Promise<Map<string, VolumeSizeInfo>> {
-		const sizes = await volumeService.getVolumeSizes();
-		return new Map(sizes.map((s) => [s.name, s]));
 	}
 
 	async function handleRemoveVolumeConfirm(name: string) {
@@ -207,6 +213,9 @@
 		const currentInternal = requestOptions?.includeInternal ?? false;
 		if (persistedInternal !== currentInternal) {
 			setShowInternal(persistedInternal);
+			// refreshVolumes (called by setShowInternal) already calls loadVolumeSizes
+		} else {
+			void loadVolumeSizes();
 		}
 	});
 </script>
@@ -226,31 +235,17 @@
 {/snippet}
 
 {#snippet SizeCell({ item }: { item: VolumeSummaryDto })}
-	{#if volumeSizesPromise}
-		{#await volumeSizesPromise}
-			{#if item.size > 0}
-				<span class="text-sm tabular-nums">{bytes.format(item.size)}</span>
-			{:else}
-				<span class="text-muted-foreground flex items-center gap-1 text-sm">
-					<Spinner class="size-4" />
-				</span>
-			{/if}
-		{:then sizesMap}
-			{@const sizeInfo = sizesMap.get(item.name)}
-			{#if sizeInfo && sizeInfo.size >= 0}
-				<span class="text-sm tabular-nums">{bytes.format(sizeInfo.size)}</span>
-			{:else if item.size > 0}
-				<span class="text-sm tabular-nums">{bytes.format(item.size)}</span>
-			{:else}
-				<span class="text-muted-foreground text-sm">-</span>
-			{/if}
-		{:catch}
-			{#if item.size > 0}
-				<span class="text-sm tabular-nums">{bytes.format(item.size)}</span>
-			{:else}
-				<span class="text-muted-foreground text-sm">-</span>
-			{/if}
-		{/await}
+	{@const sizeInfo = sizesMap.get(item.name)}
+	{#if sizeInfo && sizeInfo.size >= 0}
+		<span class="text-sm tabular-nums">{bytes.format(sizeInfo.size)}</span>
+	{:else if sizesLoading && sizesMap.size === 0}
+		{#if item.size > 0}
+			<span class="text-sm tabular-nums">{bytes.format(item.size)}</span>
+		{:else}
+			<span class="text-muted-foreground flex items-center gap-1 text-sm">
+				<Spinner class="size-4" />
+			</span>
+		{/if}
 	{:else if item.size > 0}
 		<span class="text-sm tabular-nums">{bytes.format(item.size)}</span>
 	{:else}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes volume size data not appearing in Arcane when connected to a Docker daemon running API version >1.52. The root cause was that newer Docker API versions require `Verbose: true` in `DiskUsageOptions` to return per-volume size information — a single-line backend fix addresses this.

On the frontend, the PR replaces the previous `$effect`/`{#await volumeSizesPromise}` pattern (which violated the "no `$state` updates inside `$effect`" rule) with a `SvelteMap<string, VolumeSizeInfo>` plus a `sizesLoading` boolean, updating the template to read reactively from the map. Error handling (a `catch` block) and the `onRefresh` delegation back to `refreshVolumes` are also improved.

Key changes:
- `backend/internal/utils/docker/volume_utils.go`: Adds `Verbose: true` to `client.DiskUsageOptions` — the core fix for Docker API >1.52
- `frontend/src/routes/(app)/volumes/volume-table.svelte`: Refactors size-loading state from a promise-based approach to a `SvelteMap` reactive pattern; adds error handling; simplifies `onRefresh` callback to delegate to `refreshVolumes`
- One logic issue found: `onMount` unconditionally calls `void loadVolumeSizes()` even in the branch where `setShowInternal` is invoked, which already schedules a `loadVolumeSizes()` call through `refreshVolumes`, resulting in two concurrent size-fetch requests on startup when the persisted internal-volumes setting differs from the current request options
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge after addressing the duplicate `loadVolumeSizes()` call in `onMount`; the backend fix is correct and low-risk.
- The backend change is a minimal, well-contained one-liner that directly targets the Docker API regression. The frontend refactor is mostly correct and an improvement over the old `$effect` pattern, but the `onMount` logic has a branch that fires two concurrent API calls for volume sizes, creating an unnecessary race condition that should be fixed before merging.
- frontend/src/routes/(app)/volumes/volume-table.svelte — review the `onMount` branch where `setShowInternal` and `loadVolumeSizes` are both called
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/utils/docker/volume_utils.go | Adds `Verbose: true` to `DiskUsageOptions` so that Docker API ≥1.52 returns per-volume size data; the one-line change is minimal and correctly scoped. |
| frontend/src/routes/(app)/volumes/volume-table.svelte | Replaces the promise-based `$effect`/`{#await}` pattern with a `SvelteMap` + `sizesLoading` state pair; the refactor is largely correct but `onMount` unconditionally fires `loadVolumeSizes()` even when `setShowInternal` has already queued a `loadVolumeSizes()` call via `refreshVolumes`, leading to duplicate concurrent requests in some startup paths. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Component (onMount)
    participant RS as refreshVolumes()
    participant LS as loadVolumeSizes()
    participant API as Backend API

    C->>RS: setShowInternal() → refreshVolumes() [if settings differ]
    C->>LS: void loadVolumeSizes() [always called]
    LS->>API: GET /volumes/sizes (call #1)
    RS->>API: GET /volumes (await)
    API-->>RS: volumes list
    RS->>LS: void loadVolumeSizes() (call #2 — duplicate)
    LS->>API: GET /volumes/sizes (call #2 races call #1)
    API-->>LS: sizes data (call #1 or #2 — last writer wins)
    Note over C,API: Normal path (settings match): only one loadVolumeSizes() call
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `frontend/src/routes/(app)/volumes/volume-table.svelte`, line 211-218 ([link](https://github.com/getarcaneapp/arcane/blob/0b4b994fb84c41f5aa575df3bee5aa06f246a45e/frontend/src/routes/(app)/volumes/volume-table.svelte#L211-L218)) 

   **Double `loadVolumeSizes()` call on mount**

   When `persistedInternal !== currentInternal` is true, `setShowInternal` is called, which synchronously triggers `refreshVolumes(nextOptions)` (fire-and-forget), and `refreshVolumes` calls `void loadVolumeSizes()` on line 52. The unconditional `void loadVolumeSizes()` at line 217 then fires a **second** concurrent call. Because the backend has a 30-second TTL cache both calls will return the same data harmlessly, but it is a redundant network round-trip and makes the loading state flicker.

   Consider guarding the direct call so it only runs when `setShowInternal` was not invoked:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/routes/(app)/volumes/volume-table.svelte
   Line: 211-218

   Comment:
   **Double `loadVolumeSizes()` call on mount**

   When `persistedInternal !== currentInternal` is true, `setShowInternal` is called, which synchronously triggers `refreshVolumes(nextOptions)` (fire-and-forget), and `refreshVolumes` calls `void loadVolumeSizes()` on line 52. The unconditional `void loadVolumeSizes()` at line 217 then fires a **second** concurrent call. Because the backend has a 30-second TTL cache both calls will return the same data harmlessly, but it is a redundant network round-trip and makes the loading state flicker.

   Consider guarding the direct call so it only runs when `setShowInternal` was not invoked:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20frontend%2Fsrc%2Froutes%2F%28app%29%2Fvolumes%2Fvolume-table.svelte%0ALine%3A%20211-218%0A%0AComment%3A%0A**Double%20%60loadVolumeSizes%28%29%60%20call%20on%20mount**%0A%0AWhen%20%60persistedInternal%20!%3D%3D%20currentInternal%60%20is%20true%2C%20%60setShowInternal%60%20is%20called%2C%20which%20synchronously%20triggers%20%60refreshVolumes%28nextOptions%29%60%20%28fire-and-forget%29%2C%20and%20%60refreshVolumes%60%20calls%20%60void%20loadVolumeSizes%28%29%60%20on%20line%2052.%20The%20unconditional%20%60void%20loadVolumeSizes%28%29%60%20at%20line%20217%20then%20fires%20a%20**second**%20concurrent%20call.%20Because%20the%20backend%20has%20a%2030-second%20TTL%20cache%20both%20calls%20will%20return%20the%20same%20data%20harmlessly%2C%20but%20it%20is%20a%20redundant%20network%20round-trip%20and%20makes%20the%20loading%20state%20flicker.%0A%0AConsider%20guarding%20the%20direct%20call%20so%20it%20only%20runs%20when%20%60setShowInternal%60%20was%20not%20invoked%3A%0A%0A%60%60%60suggestion%0A%09onMount%28%28%29%20%3D%3E%20%7B%0A%09%09const%20persistedInternal%20%3D%20%28customSettings.showInternalVolumes%20as%20boolean%29%20%3F%3F%20false%3B%0A%09%09const%20currentInternal%20%3D%20requestOptions%3F.includeInternal%20%3F%3F%20false%3B%0A%09%09if%20%28persistedInternal%20!%3D%3D%20currentInternal%29%20%7B%0A%09%09%09setShowInternal%28persistedInternal%29%3B%0A%09%09%09%2F%2F%20setShowInternal%20%E2%86%92%20refreshVolumes%20already%20calls%20loadVolumeSizes%0A%09%09%7D%20else%20%7B%0A%09%09%09void%20loadVolumeSizes%28%29%3B%0A%09%09%7D%0A%09%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

2. `frontend/src/routes/(app)/volumes/volume-table.svelte`, line 211-218 ([link](https://github.com/getarcaneapp/arcane/blob/b23abfa081a460e4710f660e36b87e61ab44255f/frontend/src/routes/(app)/volumes/volume-table.svelte#L211-L218)) 

   **Duplicate `loadVolumeSizes()` call when settings differ on mount**

   When `persistedInternal !== currentInternal`, `setShowInternal` fires `refreshVolumes(nextOptions)` (not awaited), which itself ends with `void loadVolumeSizes()`. At the same time, `void loadVolumeSizes()` is also called unconditionally at the bottom of the same `onMount` block. This means two concurrent requests for volume sizes are issued on mount in that scenario.

   Both requests race to overwrite `sizesMap` — the one that finishes last wins. While the data is likely identical, the duplicate network request is wasteful and the `clear()` + re-population from the lagging call can momentarily blank the map.

   A simple guard fixes this:

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fvolumes%2Fvolume-table.svelte%3A211-218%0A**Duplicate%20%60loadVolumeSizes%28%29%60%20call%20when%20settings%20differ%20on%20mount**%0A%0AWhen%20%60persistedInternal%20!%3D%3D%20currentInternal%60%2C%20%60setShowInternal%60%20fires%20%60refreshVolumes%28nextOptions%29%60%20%28not%20awaited%29%2C%20which%20itself%20ends%20with%20%60void%20loadVolumeSizes%28%29%60.%20At%20the%20same%20time%2C%20%60void%20loadVolumeSizes%28%29%60%20is%20also%20called%20unconditionally%20at%20the%20bottom%20of%20the%20same%20%60onMount%60%20block.%20This%20means%20two%20concurrent%20requests%20for%20volume%20sizes%20are%20issued%20on%20mount%20in%20that%20scenario.%0A%0ABoth%20requests%20race%20to%20overwrite%20%60sizesMap%60%20%E2%80%94%20the%20one%20that%20finishes%20last%20wins.%20While%20the%20data%20is%20likely%20identical%2C%20the%20duplicate%20network%20request%20is%20wasteful%20and%20the%20%60clear%28%29%60%20%2B%20re-population%20from%20the%20lagging%20call%20can%20momentarily%20blank%20the%20map.%0A%0AA%20simple%20guard%20fixes%20this%3A%0A%0A%60%60%60suggestion%0A%09onMount%28%28%29%20%3D%3E%20%7B%0A%09%09const%20persistedInternal%20%3D%20%28customSettings.showInternalVolumes%20as%20boolean%29%20%3F%3F%20false%3B%0A%09%09const%20currentInternal%20%3D%20requestOptions%3F.includeInternal%20%3F%3F%20false%3B%0A%09%09if%20%28persistedInternal%20!%3D%3D%20currentInternal%29%20%7B%0A%09%09%09setShowInternal%28persistedInternal%29%3B%0A%09%09%09%2F%2F%20refreshVolumes%20%28called%20by%20setShowInternal%29%20already%20calls%20loadVolumeSizes%0A%09%09%7D%20else%20%7B%0A%09%09%09void%20loadVolumeSizes%28%29%3B%0A%09%09%7D%0A%09%7D%29%3B%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/routes/(app)/volumes/volume-table.svelte
Line: 211-218

Comment:
**Duplicate `loadVolumeSizes()` call when settings differ on mount**

When `persistedInternal !== currentInternal`, `setShowInternal` fires `refreshVolumes(nextOptions)` (not awaited), which itself ends with `void loadVolumeSizes()`. At the same time, `void loadVolumeSizes()` is also called unconditionally at the bottom of the same `onMount` block. This means two concurrent requests for volume sizes are issued on mount in that scenario.

Both requests race to overwrite `sizesMap` — the one that finishes last wins. While the data is likely identical, the duplicate network request is wasteful and the `clear()` + re-population from the lagging call can momentarily blank the map.

A simple guard fixes this:

```suggestion
	onMount(() => {
		const persistedInternal = (customSettings.showInternalVolumes as boolean) ?? false;
		const currentInternal = requestOptions?.includeInternal ?? false;
		if (persistedInternal !== currentInternal) {
			setShowInternal(persistedInternal);
			// refreshVolumes (called by setShowInternal) already calls loadVolumeSizes
		} else {
			void loadVolumeSizes();
		}
	});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: b23abfa</sub>

<!-- /greptile_comment -->