### PR TITLE
fix: unable to create users with rfc compliant emails

### DIFF
--- a/backend/internal/huma/handlers/users.go
+++ b/backend/internal/huma/handlers/users.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -9,6 +11,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/getarcaneapp/arcane/backend/internal/services"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/mapper"
+	"github.com/getarcaneapp/arcane/backend/internal/utils/validation"
 	"github.com/getarcaneapp/arcane/types/base"
 	"github.com/getarcaneapp/arcane/types/user"
 )
@@ -194,6 +197,12 @@ func (h *UserHandler) CreateUser(ctx context.Context, input *CreateUserInput) (*
 		return nil, err
 	}
 
+	normalizedEmail, err := normalizeOptionalEmailInternal(input.Body.Email)
+	if err != nil {
+		return nil, huma.Error400BadRequest(err.Error())
+	}
+	input.Body.Email = normalizedEmail
+
 	hashedPassword, err := h.userService.HashPassword(input.Body.Password)
 	if err != nil {
 		return nil, huma.Error500InternalServerError((&common.PasswordHashError{Err: err}).Error())
@@ -276,6 +285,12 @@ func (h *UserHandler) UpdateUser(ctx context.Context, input *UpdateUserInput) (*
 		return nil, huma.Error404NotFound((&common.UserNotFoundError{}).Error())
 	}
 
+	normalizedEmail, err := normalizeOptionalEmailInternal(input.Body.Email)
+	if err != nil {
+		return nil, huma.Error400BadRequest(err.Error())
+	}
+	input.Body.Email = normalizedEmail
+
 	if input.Body.Username != nil {
 		userModel.Username = *input.Body.Username
 	}
@@ -343,4 +358,21 @@ func (h *UserHandler) DeleteUser(ctx context.Context, input *DeleteUserInput) (*
 			},
 		},
 	}, nil
+}
+
+func normalizeOptionalEmailInternal(email *string) (*string, error) {
+	if email == nil {
+		return nil, nil
+	}
+
+	trimmedEmail := strings.TrimSpace(*email)
+	if trimmedEmail == "" {
+		return nil, nil
+	}
+
+	if !validation.IsValidUserEmail(trimmedEmail) {
+		return nil, errors.New("must be a valid email")
+	}
+
+	return &trimmedEmail, nil
 }

--- a/backend/internal/utils/validation/email.go
+++ b/backend/internal/utils/validation/email.go
@@ -1,0 +1,89 @@
+package validation
+
+import (
+	"net"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/idna"
+)
+
+var localPartPattern = regexp.MustCompile(`^[A-Za-z0-9!#$%&'*+/=?^_` + "`" + `{|}~.-]+$`)
+
+func IsValidUserEmail(email string) bool {
+	trimmedEmail := strings.TrimSpace(email)
+	if trimmedEmail == "" || strings.Contains(trimmedEmail, " ") {
+		return false
+	}
+
+	localPart, domainPart, ok := strings.Cut(trimmedEmail, "@")
+	if !ok || strings.Contains(domainPart, "@") {
+		return false
+	}
+
+	return isValidLocalPartInternal(localPart) && isValidDomainPartInternal(domainPart)
+}
+
+func isValidLocalPartInternal(localPart string) bool {
+	if localPart == "" || len(localPart) > 64 {
+		return false
+	}
+
+	if strings.HasPrefix(localPart, ".") || strings.HasSuffix(localPart, ".") || strings.Contains(localPart, "..") {
+		return false
+	}
+
+	return localPartPattern.MatchString(localPart)
+}
+
+func isValidDomainPartInternal(domainPart string) bool {
+	if domainPart == "" || len(domainPart) > 255 {
+		return false
+	}
+
+	if ip := net.ParseIP(domainPart); ip != nil && ip.To4() != nil {
+		return true
+	}
+
+	if strings.HasPrefix(domainPart, "[") && strings.HasSuffix(domainPart, "]") {
+		return isValidAddressLiteralInternal(domainPart)
+	}
+
+	asciiDomain, err := idna.Lookup.ToASCII(domainPart)
+	if err != nil || asciiDomain == "" {
+		return false
+	}
+
+	labels := strings.Split(asciiDomain, ".")
+	if len(labels) == 4 {
+		allNumeric := true
+		for _, label := range labels {
+			if label == "" || strings.Trim(label, "0123456789") != "" {
+				allNumeric = false
+				break
+			}
+		}
+		if allNumeric {
+			return false
+		}
+	}
+
+	for _, label := range labels {
+		if label == "" || len(label) > 63 || strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isValidAddressLiteralInternal(domainPart string) bool {
+	literal := strings.TrimSuffix(strings.TrimPrefix(domainPart, "["), "]")
+	if strings.HasPrefix(strings.ToLower(literal), "ipv6:") {
+		ip := net.ParseIP(literal[5:])
+		return ip != nil && ip.To4() == nil
+	}
+
+	ip := net.ParseIP(literal)
+	return ip != nil && ip.To4() != nil && !strings.Contains(literal, ":")
+}

--- a/backend/internal/utils/validation/email_test.go
+++ b/backend/internal/utils/validation/email_test.go
@@ -1,0 +1,53 @@
+package validation
+
+import "testing"
+
+func TestIsValidUserEmail_AllowsReportedFormats(t *testing.T) {
+	t.Parallel()
+
+	validEmails := []string{
+		"user@198.51.100.32",
+		"user@[IPv6:3ffe::32]",
+		"user@localdomain",
+		"user@website.日本",
+	}
+
+	for _, email := range validEmails {
+		email := email
+		t.Run(email, func(t *testing.T) {
+			t.Parallel()
+			if !IsValidUserEmail(email) {
+				t.Fatalf("expected %q to be valid", email)
+			}
+		})
+	}
+}
+
+func TestIsValidUserEmail_RejectsMalformedAddresses(t *testing.T) {
+	t.Parallel()
+
+	invalidEmails := []string{
+		"",
+		"user",
+		"user@",
+		"@example.com",
+		"user@@example.com",
+		"user..dots@example.com",
+		"user@-example.com",
+		"user@example..com",
+		"user@[::1]",
+		"user@[::ffff:1.2.3.4]",
+		"user@[IPv6:not-an-ip]",
+		"user@256.256.256.256",
+	}
+
+	for _, email := range invalidEmails {
+		email := email
+		t.Run(email, func(t *testing.T) {
+			t.Parallel()
+			if IsValidUserEmail(email) {
+				t.Fatalf("expected %q to be invalid", email)
+			}
+		})
+	}
+}

--- a/frontend/src/lib/components/sheets/user-form-sheet.svelte
+++ b/frontend/src/lib/components/sheets/user-form-sheet.svelte
@@ -6,6 +6,7 @@
 	import type { User } from '$lib/types/user.type';
 	import { z } from 'zod/v4';
 	import { createForm, preventDefault } from '$lib/utils/form.utils';
+	import { isValidUserEmail } from '$lib/utils/email.utils';
 	import { m } from '$lib/paraglide/messages';
 	import { AddIcon, SaveIcon } from '$lib/icons';
 
@@ -36,7 +37,10 @@
 		username: z.string().min(1, m.common_username_required()),
 		password: z.string().optional(),
 		displayName: z.string().optional(),
-		email: z.email(m.common_invalid_email()).optional().or(z.literal('')),
+		email: z
+			.string()
+			.trim()
+			.refine((value) => value === '' || isValidUserEmail(value), m.common_invalid_email()),
 		isAdmin: z.boolean().default(false)
 	});
 
@@ -66,9 +70,12 @@
 
 		const userData: Partial<User> & { password?: string } = {
 			displayName: data.displayName,
-			email: data.email,
 			roles: [data.isAdmin ? 'admin' : 'user']
 		};
+
+		if (data.email) {
+			userData.email = data.email;
+		}
 
 		// Only include username if we're creating a new user or if editing is allowed
 		if (!isEditMode || canEditUsername) {
@@ -102,7 +109,7 @@
 	contentClass="sm:max-w-[500px]"
 >
 	{#snippet children()}
-		<form onsubmit={preventDefault(handleSubmit)} class="grid gap-4 py-6">
+		<form onsubmit={preventDefault(handleSubmit)} novalidate class="grid gap-4 py-6">
 			<FormInput
 				label={m.common_username()}
 				type="text"
@@ -136,9 +143,10 @@
 			/>
 			<FormInput
 				label={m.common_email()}
-				type="email"
+				type="text"
 				placeholder={m.users_email_placeholder()}
 				description={m.users_email_description()}
+				autocomplete="email"
 				disabled={isOidcUser}
 				bind:input={$inputs.email}
 			/>

--- a/frontend/src/lib/utils/email.utils.ts
+++ b/frontend/src/lib/utils/email.utils.ts
@@ -1,0 +1,115 @@
+const LOCAL_PART_PATTERN = /^[A-Za-z0-9!#$%&'*+/=?^_`{|}~.-]+$/;
+const DOMAIN_LABEL_PATTERN = /^[\p{L}\p{N}](?:[\p{L}\p{N}-]{0,61}[\p{L}\p{N}])?$/u;
+
+export function isValidUserEmail(email: string): boolean {
+	const trimmedEmail = email.trim();
+	if (!trimmedEmail || trimmedEmail.includes(' ')) {
+		return false;
+	}
+
+	const atIndex = trimmedEmail.indexOf('@');
+	if (atIndex <= 0 || atIndex !== trimmedEmail.lastIndexOf('@') || atIndex === trimmedEmail.length - 1) {
+		return false;
+	}
+
+	const localPart = trimmedEmail.slice(0, atIndex);
+	const domainPart = trimmedEmail.slice(atIndex + 1);
+
+	return isValidLocalPart(localPart) && isValidDomainPart(domainPart);
+}
+
+function isValidLocalPart(localPart: string): boolean {
+	if (!localPart || localPart.length > 64 || localPart.startsWith('.') || localPart.endsWith('.') || localPart.includes('..')) {
+		return false;
+	}
+
+	return LOCAL_PART_PATTERN.test(localPart);
+}
+
+function isValidDomainPart(domainPart: string): boolean {
+	if (!domainPart || domainPart.length > 255) {
+		return false;
+	}
+
+	if (isValidIPv4Literal(domainPart)) {
+		return true;
+	}
+
+	if (isValidIPv6Literal(domainPart)) {
+		return true;
+	}
+
+	const labels = domainPart.split('.');
+	if (labels.length === 4 && labels.every((label) => /^\d+$/.test(label))) {
+		return false;
+	}
+
+	if (labels.some((label) => !DOMAIN_LABEL_PATTERN.test(label))) {
+		return false;
+	}
+
+	return true;
+}
+
+function isValidIPv4Literal(domainPart: string): boolean {
+	const octets = domainPart.split('.');
+	if (octets.length !== 4) {
+		return false;
+	}
+
+	return octets.every((octet) => /^\d+$/.test(octet) && Number(octet) >= 0 && Number(octet) <= 255);
+}
+
+function isValidIPv6Literal(domainPart: string): boolean {
+	if (!/^\[IPv6:[0-9A-Fa-f:.]+\]$/i.test(domainPart)) {
+		return false;
+	}
+
+	const address = domainPart.slice(6, -1);
+	return isValidIPv6Address(address);
+}
+
+function isValidIPv6Address(address: string): boolean {
+	if (!address.includes(':') || address.includes(':::')) {
+		return false;
+	}
+
+	const compressionIndex = address.indexOf('::');
+	if (compressionIndex !== -1 && compressionIndex !== address.lastIndexOf('::')) {
+		return false;
+	}
+
+	if (compressionIndex === -1) {
+		return countIPv6Segments(address.split(':')) === 8;
+	}
+
+	const [left = '', right = ''] = address.split('::');
+	const leftCount = left ? countIPv6Segments(left.split(':')) : 0;
+	const rightCount = right ? countIPv6Segments(right.split(':')) : 0;
+
+	return leftCount >= 0 && rightCount >= 0 && leftCount + rightCount < 8;
+}
+
+function countIPv6Segments(segments: string[]): number {
+	let count = 0;
+
+	for (let i = 0; i < segments.length; i += 1) {
+		const segment = segments[i];
+		if (!segment) {
+			return -1;
+		}
+
+		const isLastSegment = i === segments.length - 1;
+		if (segment.includes('.')) {
+			return isLastSegment && isValidIPv4Literal(segment) ? count + 2 : -1;
+		}
+
+		if (!/^[0-9A-Fa-f]{1,4}$/.test(segment)) {
+			return -1;
+		}
+
+		count += 1;
+	}
+
+	return count;
+}

--- a/types/user/user.go
+++ b/types/user/user.go
@@ -5,7 +5,7 @@ type CreateUser struct {
 	Username    string   `json:"username" minLength:"1" maxLength:"255" doc:"Username of the user" example:"johndoe"`
 	Password    string   `json:"password" minLength:"8" doc:"Password of the user"` //nolint:gosec // API schema requires password field name
 	DisplayName *string  `json:"displayName,omitempty" maxLength:"255" doc:"Display name of the user" example:"John Doe"`
-	Email       *string  `json:"email,omitempty" format:"email" doc:"Email address of the user" example:"john@example.com"`
+	Email       *string  `json:"email,omitempty" doc:"Email address of the user" example:"john@example.com"`
 	Roles       []string `json:"roles,omitempty" doc:"Roles assigned to the user" example:"[\"user\"]"`
 	Locale      *string  `json:"locale,omitempty" doc:"Locale preference of the user" example:"en-US"`
 }
@@ -14,7 +14,7 @@ type CreateUser struct {
 type UpdateUser struct {
 	Username    *string  `json:"username,omitempty" minLength:"1" maxLength:"255" doc:"Username of the user"`
 	DisplayName *string  `json:"displayName,omitempty" maxLength:"255" doc:"Display name of the user"`
-	Email       *string  `json:"email,omitempty" format:"email" doc:"Email address of the user"`
+	Email       *string  `json:"email,omitempty" doc:"Email address of the user"`
 	Roles       []string `json:"roles,omitempty" doc:"Roles assigned to the user"`
 	Locale      *string  `json:"locale,omitempty" doc:"Locale preference of the user"`
 	Password    *string  `json:"password,omitempty" minLength:"8" doc:"New password for the user"` //nolint:gosec // API schema requires password field name


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2035

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where users with RFC 5321-compliant email addresses (IP address literals, IDN domains, single-label domains, etc.) could not be created because Huma's built-in `format:"email"` validator was too restrictive. The fix replaces that framework-level validation with a custom `IsValidUserEmail` function implemented in both Go (`backend/internal/utils/validation/email.go`) and TypeScript (`frontend/src/lib/utils/email.utils.ts`), and updates the Svelte user form to use the new TypeScript validator via a Zod `refine`.

Key changes:
- New Go email validator with proper handling of IPv4 literals, bracketed address-literals (`[IPv6:...]`), IDN domains via `idna.Lookup.ToASCII`, and domain label constraints
- New TypeScript validator mirroring the Go logic, including thorough IPv6 structural validation (segment counting, embedded IPv4, double-colon expansion rules)
- `normalizeOptionalEmailInternal` added to both `CreateUser` and `UpdateUser` handlers to trim, validate, and normalize the email before processing
- `format:"email"` struct tag removed from `CreateUser` and `UpdateUser` in `types/user/user.go` to bypass Huma's built-in check
- Svelte form updated to use `type="text"` + `novalidate` + `autocomplete="email"` so the browser's native email input doesn't reject valid RFC-compliant addresses
- One minor inconsistency: the TypeScript `isValidIPv6Literal` regex is case-sensitive (only `IPv6:`), while the Go `isValidAddressLiteralInternal` is case-insensitive (accepts `ipv6:`, `IPV6:`, etc.) — an API client could store a non-canonical casing that the UI would then refuse to validate
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with one minor fix recommended — the IPv6 tag case-sensitivity discrepancy between the TypeScript and Go validators.
- The core fix is well-implemented: both the Go and TypeScript validators are thorough, the naming conventions are followed, tests cover the reported failure cases, and the frontend UX changes (novalidate, type=text, autocomplete) are correct. The only issue is the case-insensitive/case-sensitive split on the `IPv6:` tag prefix, which could allow non-canonical email addresses to be stored via the API that the UI cannot then handle without validation errors.
- frontend/src/lib/utils/email.utils.ts — `isValidIPv6Literal` should use a case-insensitive regex flag to match the backend's case-insensitive behaviour.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/internal/utils/validation/email.go | New RFC 5321-aware email validator; correctly handles IPv4 literals, bracketed address-literals, IDN domains, and IPv6 tagged with `IPv6:`. Case-insensitive IPv6 tag matching (via `strings.ToLower`) diverges slightly from the frontend which only accepts the canonical `IPv6:` casing. |
| backend/internal/utils/validation/email_test.go | Good parallel table-driven tests covering the key valid and invalid formats reported in the issue, including IDN domains, IPv4 literals, bracketed IPv6, and malformed addresses. |
| backend/internal/huma/handlers/users.go | Adds `normalizeOptionalEmailInternal` (correctly named per convention) called in both `CreateUser` and `UpdateUser`; trims whitespace, treats empty string as absent, and returns a 400 on invalid format. |
| frontend/src/lib/utils/email.utils.ts | New TypeScript email validator mirroring the Go logic; IPv6 structural validation is now thorough (counts segments, handles embedded IPv4, rejects multiple `::` expansions). Minor case-sensitivity inconsistency with the Go backend for the `IPv6:` tag. |
| frontend/src/lib/components/sheets/user-form-sheet.svelte | Replaces Zod's built-in `z.email()` with a `refine` call to `isValidUserEmail`; switches the input from `type="email"` to `type="text"` (preventing browser-native rejection of RFC-compliant addresses) and adds `novalidate` + `autocomplete="email"` appropriately. |
| types/user/user.go | Removes the `format:"email"` Huma/OpenAPI struct tag from both `CreateUser` and `UpdateUser` to bypass the framework's built-in email validation in favour of the new custom validator; intentional and necessary for the fix to work. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[API Request: Create/Update User] --> B{email field present\nand non-empty?}
    B -- No / null / empty string --> C[Email set to nil\nskip email update]
    B -- Yes --> D[normalizeOptionalEmailInternal\ntrim whitespace]
    D --> E[IsValidUserEmail]
    E --> F{Valid local part?}
    F -- No --> G[Return 400 Bad Request]
    F -- Yes --> H{Valid domain part?}
    H -- Bare IPv4\nnet.ParseIP + To4 --> I[✓ Accept]
    H -- Bracketed literal\nstarts with '[' --> J{isValidAddressLiteralInternal}
    J -- IPv6 tag\ncase-insensitive --> K{net.ParseIP + To4==nil}
    K -- Valid --> I
    K -- Invalid --> G
    J -- No IPv6 tag --> L{net.ParseIP + To4!=nil\nno colon}
    L -- Valid IPv4 literal --> I
    L -- Invalid --> G
    H -- Hostname/IDN --> M[idna.Lookup.ToASCII]
    M --> N{Label checks:\nno empty, len≤63,\nno leading/trailing hyphen,\nnot all-numeric 4-label}
    N -- Valid --> I
    N -- Invalid --> G
    I --> O[Store normalized email]

    subgraph Frontend [Frontend - Svelte + Zod refine]
    P[User types email] --> Q[isValidUserEmail TS]
    Q --> R{isValidIPv6Literal\ncase-sensitive regex}
    R -- Passes --> S[Form submits]
    R -- Fails --> T[Show validation error]
    end
```
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Flib%2Futils%2Femail.utils.ts%3A63-69%0A**IPv6%20tag%20case-sensitivity%20mismatch%20with%20backend**%0A%0AThe%20TypeScript%20regex%20%60%5E%5C%5BIPv6%3A%5B0-9A-Fa-f%3A.%5D%2B%5C%5D%24%60%20is%20case-sensitive%20and%20only%20accepts%20the%20canonical%20%60IPv6%3A%60%20prefix.%20However%2C%20the%20Go%20backend%20uses%20%60strings.ToLower%28literal%29%60%20before%20checking%20the%20prefix%2C%20making%20it%20case-insensitive%20%E2%80%94%20so%20%60%5BIPV6%3A%3A%3A1%5D%60%2C%20%60%5Bipv6%3A%3A%3A1%5D%60%2C%20etc.%20are%20all%20accepted%20by%20the%20backend%20but%20rejected%20here.%0A%0AIn%20practice%20an%20API%20client%20%28e.g.%20a%20script%20or%20third-party%20integration%29%20can%20%60POST%60%20an%20email%20like%20%60user%40%5BIPV6%3A%3A%3A1%5D%60%20and%20the%20backend%20will%20store%20it%2C%20even%20though%20the%20same%20address%20can%20never%20be%20entered%20through%20the%20UI.%20The%20front-end%20will%20then%20be%20unable%20to%20display%20it%20in%20a%20validated%20field%20or%20let%20the%20user%20edit%20it%20without%20an%20error.%0A%0ATo%20avoid%20the%20inconsistency%2C%20update%20the%20regex%20to%20be%20case-insensitive%3A%0A%0A%60%60%60suggestion%0Afunction%20isValidIPv6Literal%28domainPart%3A%20string%29%3A%20boolean%20%7B%0A%09if%20%28!%2F%5E%5C%5BIPv6%3A%5B0-9A-Fa-f%3A.%5D%2B%5C%5D%24%2Fi.test%28domainPart%29%29%20%7B%0A%09%09return%20false%3B%0A%09%7D%0A%0A%09const%20address%20%3D%20domainPart.slice%286%2C%20-1%29%3B%0A%09return%20isValidIPv6Address%28address%29%3B%0A%7D%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/lib/utils/email.utils.ts
Line: 63-69

Comment:
**IPv6 tag case-sensitivity mismatch with backend**

The TypeScript regex `^\[IPv6:[0-9A-Fa-f:.]+\]$` is case-sensitive and only accepts the canonical `IPv6:` prefix. However, the Go backend uses `strings.ToLower(literal)` before checking the prefix, making it case-insensitive — so `[IPV6:::1]`, `[ipv6:::1]`, etc. are all accepted by the backend but rejected here.

In practice an API client (e.g. a script or third-party integration) can `POST` an email like `user@[IPV6:::1]` and the backend will store it, even though the same address can never be entered through the UI. The front-end will then be unable to display it in a validated field or let the user edit it without an error.

To avoid the inconsistency, update the regex to be case-insensitive:

```suggestion
function isValidIPv6Literal(domainPart: string): boolean {
	if (!/^\[IPv6:[0-9A-Fa-f:.]+\]$/i.test(domainPart)) {
		return false;
	}

	const address = domainPart.slice(6, -1);
	return isValidIPv6Address(address);
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 6d6e5f7</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->