### PR TITLE
fix: containers fail to start due to cgroup oci error

### DIFF
--- a/backend/cli/upgrade/doc.go
+++ b/backend/cli/upgrade/doc.go
@@ -1,0 +1,3 @@
+// Package upgrade provides the Arcane CLI command that upgrades a running
+// Arcane container by recreating it with a newer image.
+package upgrade

--- a/backend/cli/upgrade/upgrade.go
+++ b/backend/cli/upgrade/upgrade.go
@@ -22,6 +22,8 @@ var (
 	autoDetect    bool
 )
 
+// UpgradeCmd recreates a running Arcane container with a newer image while
+// preserving its configuration.
 var UpgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Upgrade an Arcane container to the latest version",
@@ -338,11 +340,26 @@ func upgradeContainer(ctx context.Context, dockerClient *client.Client, oldConta
 	config := *oldContainer.Config
 	config.Image = newImage
 
-	hostConfig := oldContainer.HostConfig
+	hostConfig, sanitizedMemorySwappiness, engineInfo, err := libarcane.PrepareRecreateHostConfigForEngine(ctx, dockerClient, oldContainer.HostConfig)
+	if err != nil {
+		return fmt.Errorf("prepare host config: %w", err)
+	}
+	if sanitizedMemorySwappiness {
+		slog.Info("Stripped unsupported host config field for recreate",
+			"container", originalName,
+			"containerId", oldContainer.ID,
+			"engine", engineInfo.Name,
+			"cgroupVersion", engineInfo.CgroupVersion,
+			"field", "memorySwappiness",
+		)
+	}
 
 	// Fix for "conflicting options: hostname and the network mode"
 	// When network mode is "host" or "container:...", Hostname must be empty
-	nm := hostConfig.NetworkMode
+	var nm container.NetworkMode
+	if hostConfig != nil {
+		nm = hostConfig.NetworkMode
+	}
 	if nm.IsHost() || nm.IsContainer() {
 		config.Hostname = ""
 		config.Domainname = ""
@@ -359,8 +376,10 @@ func upgradeContainer(ctx context.Context, dockerClient *client.Client, oldConta
 	// When network mode is "container:...", port mappings are not allowed
 	if nm.IsContainer() {
 		config.ExposedPorts = nil
-		hostConfig.PortBindings = nil
-		hostConfig.PublishAllPorts = false
+		if hostConfig != nil {
+			hostConfig.PortBindings = nil
+			hostConfig.PublishAllPorts = false
+		}
 	}
 
 	// Build network config - preserve all network settings including IP addresses

--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -26,6 +26,8 @@ import (
 	"github.com/getarcaneapp/arcane/types/updater"
 )
 
+// UpdaterService coordinates image update checks, container recreation, and
+// project redeploy flows for Arcane's auto-update system.
 type UpdaterService struct {
 	db                  *database.DB
 	settingsService     *SettingsService
@@ -43,6 +45,8 @@ type UpdaterService struct {
 	updatingProjects   map[string]bool
 }
 
+// NewUpdaterService constructs an UpdaterService with the dependencies needed
+// to plan, execute, and record container and project updates.
 func NewUpdaterService(
 	db *database.DB,
 	settings *SettingsService,
@@ -71,6 +75,10 @@ func NewUpdaterService(
 	}
 }
 
+// ApplyPending executes the currently pending image updates and returns a
+// per-resource result summary. When dryRun is true, it reports the planned
+// actions without mutating containers or projects.
+//
 //nolint:gocognit
 func (s *UpdaterService) ApplyPending(ctx context.Context, dryRun bool) (*updater.Result, error) {
 	start := time.Now()
@@ -680,8 +688,10 @@ func (s *UpdaterService) pruneImageIDsWithInUseSetInternal(ctx context.Context, 
 	return nil
 }
 
+// GetStatus returns the current in-memory update activity snapshot.
 func (s *UpdaterService) GetStatus() updater.Status { return s.statusSnapshotInternal() }
 
+// GetHistory returns the most recent auto-update history records, newest first.
 func (s *UpdaterService) GetHistory(ctx context.Context, limit int) ([]models.AutoUpdateRecord, error) {
 	var rec []models.AutoUpdateRecord
 	q := s.db.WithContext(ctx).Order("start_time DESC")
@@ -744,9 +754,27 @@ func (s *UpdaterService) updateContainer(ctx context.Context, cnt container.Summ
 	cfg := inspect.Config
 	cfg.Image = newRef
 
+	hostConfig, sanitizedMemorySwappiness, engineInfo, err := libarcane.PrepareRecreateHostConfigForEngine(ctx, dcli, inspect.HostConfig)
+	if err != nil {
+		return fmt.Errorf("prepare host config: %w", err)
+	}
+	if sanitizedMemorySwappiness {
+		slog.InfoContext(ctx,
+			"updateContainer: stripped unsupported host config field for recreate",
+			"containerId", cnt.ID,
+			"containerName", name,
+			"engine", engineInfo.Name,
+			"cgroupVersion", engineInfo.CgroupVersion,
+			"field", "memorySwappiness",
+		)
+	}
+
 	// Fix for "conflicting options: hostname and the network mode"
 	// When network mode is "host" or "container:...", Hostname must be empty
-	nm := inspect.HostConfig.NetworkMode
+	var nm container.NetworkMode
+	if hostConfig != nil {
+		nm = hostConfig.NetworkMode
+	}
 	if nm.IsHost() || nm.IsContainer() {
 		cfg.Hostname = ""
 		cfg.Domainname = ""
@@ -756,8 +784,10 @@ func (s *UpdaterService) updateContainer(ctx context.Context, cnt container.Summ
 	// When network mode is "container:...", port mappings are not allowed
 	if nm.IsContainer() {
 		cfg.ExposedPorts = nil
-		inspect.HostConfig.PortBindings = nil
-		inspect.HostConfig.PublishAllPorts = false
+		if hostConfig != nil {
+			hostConfig.PortBindings = nil
+			hostConfig.PublishAllPorts = false
+		}
 	}
 
 	apiVersion := libarcane.DetectDockerAPIVersion(ctx, dcli)
@@ -777,7 +807,7 @@ func (s *UpdaterService) updateContainer(ctx context.Context, cnt container.Summ
 
 	resp, err := dcli.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Config:           cfg,
-		HostConfig:       inspect.HostConfig,
+		HostConfig:       hostConfig,
 		NetworkingConfig: networkingConfig,
 		Name:             containerName,
 	})

--- a/backend/pkg/libarcane/doc.go
+++ b/backend/pkg/libarcane/doc.go
@@ -1,0 +1,3 @@
+// Package libarcane contains shared compatibility helpers, setting utilities,
+// and internal resource metadata used across Arcane's backend and CLI.
+package libarcane

--- a/backend/pkg/libarcane/engine_compat.go
+++ b/backend/pkg/libarcane/engine_compat.go
@@ -1,0 +1,127 @@
+package libarcane
+
+import (
+	"context"
+	"strings"
+
+	containertypes "github.com/moby/moby/api/types/container"
+	systemtypes "github.com/moby/moby/api/types/system"
+	"github.com/moby/moby/client"
+)
+
+// EngineCompatibilityInfo describes the container engine details Arcane uses to
+// decide whether recreate-time HostConfig sanitization is required.
+type EngineCompatibilityInfo struct {
+	// Name is the normalized engine identifier, such as "docker" or "podman".
+	Name string
+	// CgroupVersion is the daemon-reported cgroup version, such as "1" or "2".
+	CgroupVersion string
+}
+
+// PrepareRecreateHostConfigForEngine clones hostConfig and removes recreate
+// options that are known to be incompatible with the connected engine.
+//
+// The returned HostConfig is a shallow copy, so field reassignment is isolated
+// from the caller's original value, but content-level mutation of shared slice
+// or map fields is not. The boolean result reports whether the helper removed
+// any incompatible fields. EngineCompatibilityInfo reports the daemon details
+// used to make that decision.
+func PrepareRecreateHostConfigForEngine(ctx context.Context, dockerClient *client.Client, hostConfig *containertypes.HostConfig) (*containertypes.HostConfig, bool, EngineCompatibilityInfo, error) {
+	if hostConfig == nil {
+		return nil, false, EngineCompatibilityInfo{}, nil
+	}
+
+	cloned := cloneContainerHostConfigInternal(hostConfig)
+	if dockerClient == nil {
+		return cloned, false, EngineCompatibilityInfo{}, nil
+	}
+
+	serverVersion, err := dockerClient.ServerVersion(ctx, client.ServerVersionOptions{})
+	if err != nil {
+		return cloned, false, EngineCompatibilityInfo{}, err
+	}
+
+	infoResult, err := dockerClient.Info(ctx, client.InfoOptions{})
+	if err != nil {
+		return cloned, false, EngineCompatibilityInfo{}, err
+	}
+
+	engineInfo := detectEngineCompatibilityInfoInternal(serverVersion, infoResult.Info)
+	sanitized := sanitizeRecreateHostConfigInternal(cloned, engineInfo)
+
+	return cloned, sanitized, engineInfo, nil
+}
+
+func cloneContainerHostConfigInternal(hostConfig *containertypes.HostConfig) *containertypes.HostConfig {
+	if hostConfig == nil {
+		return nil
+	}
+
+	cloned := *hostConfig
+	return &cloned
+}
+
+func sanitizeRecreateHostConfigInternal(hostConfig *containertypes.HostConfig, engineInfo EngineCompatibilityInfo) bool {
+	if hostConfig == nil {
+		return false
+	}
+
+	if !isPodmanEngineInternal(engineInfo.Name) || !isCgroupV2Internal(engineInfo.CgroupVersion) {
+		return false
+	}
+
+	if hostConfig.MemorySwappiness == nil {
+		return false
+	}
+
+	hostConfig.MemorySwappiness = nil
+	return true
+}
+
+func detectEngineCompatibilityInfoInternal(version client.ServerVersionResult, info systemtypes.Info) EngineCompatibilityInfo {
+	return EngineCompatibilityInfo{
+		Name:          detectEngineNameInternal(version, info),
+		CgroupVersion: strings.TrimSpace(info.CgroupVersion),
+	}
+}
+
+func detectEngineNameInternal(version client.ServerVersionResult, info systemtypes.Info) string {
+	candidates := []string{version.Platform.Name}
+	for _, component := range version.Components {
+		candidates = append(candidates, component.Name)
+		for _, value := range component.Details {
+			candidates = append(candidates, value)
+		}
+	}
+	candidates = append(candidates, info.ServerVersion, info.OperatingSystem)
+
+	for _, candidate := range candidates {
+		if name := normalizeEngineNameInternal(candidate); name != "" {
+			return name
+		}
+	}
+
+	return ""
+}
+
+func normalizeEngineNameInternal(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch {
+	case strings.Contains(normalized, "podman"):
+		return "podman"
+	case strings.Contains(normalized, "docker"):
+		return "docker"
+	default:
+		return ""
+	}
+}
+
+func isPodmanEngineInternal(engineName string) bool {
+	return strings.EqualFold(strings.TrimSpace(engineName), "podman")
+}
+
+func isCgroupV2Internal(cgroupVersion string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(cgroupVersion))
+	normalized = strings.TrimPrefix(normalized, "v")
+	return normalized == "2"
+}

--- a/backend/pkg/libarcane/engine_compat_test.go
+++ b/backend/pkg/libarcane/engine_compat_test.go
@@ -1,0 +1,145 @@
+package libarcane
+
+import (
+	"testing"
+
+	containertypes "github.com/moby/moby/api/types/container"
+	systemtypes "github.com/moby/moby/api/types/system"
+	"github.com/moby/moby/client"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareRecreateHostConfigForEngine_NilHostConfig(t *testing.T) {
+	out, sanitized, engineInfo, err := PrepareRecreateHostConfigForEngine(t.Context(), nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, out)
+	require.False(t, sanitized)
+	require.Empty(t, engineInfo.Name)
+	require.Empty(t, engineInfo.CgroupVersion)
+}
+
+func TestSanitizeRecreateHostConfigInternal(t *testing.T) {
+	swappiness := int64(60)
+
+	tests := []struct {
+		name              string
+		engineInfo        EngineCompatibilityInfo
+		wantSanitized     bool
+		wantSwappinessNil bool
+	}{
+		{
+			name: "podman cgroup v2 strips memory swappiness",
+			engineInfo: EngineCompatibilityInfo{
+				Name:          "podman",
+				CgroupVersion: "2",
+			},
+			wantSanitized:     true,
+			wantSwappinessNil: true,
+		},
+		{
+			name: "podman cgroup v1 preserves memory swappiness",
+			engineInfo: EngineCompatibilityInfo{
+				Name:          "podman",
+				CgroupVersion: "1",
+			},
+			wantSanitized:     false,
+			wantSwappinessNil: false,
+		},
+		{
+			name: "docker cgroup v2 preserves memory swappiness",
+			engineInfo: EngineCompatibilityInfo{
+				Name:          "docker",
+				CgroupVersion: "2",
+			},
+			wantSanitized:     false,
+			wantSwappinessNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &containertypes.HostConfig{
+				Resources: containertypes.Resources{
+					MemorySwappiness: &swappiness,
+					CPUShares:        1024,
+				},
+				PublishAllPorts: true,
+				ReadonlyRootfs:  true,
+				NetworkMode:     "bridge",
+				ContainerIDFile: "/tmp/id",
+				VolumeDriver:    "local",
+				Annotations:     map[string]string{"test": "value"},
+				MaskedPaths:     []string{"/proc/kcore"},
+				ReadonlyPaths:   []string{"/proc/asound"},
+			}
+
+			cloned := cloneContainerHostConfigInternal(input)
+			require.NotNil(t, cloned)
+			require.NotSame(t, input, cloned)
+
+			sanitized := sanitizeRecreateHostConfigInternal(cloned, tt.engineInfo)
+			require.Equal(t, tt.wantSanitized, sanitized)
+
+			if tt.wantSwappinessNil {
+				require.Nil(t, cloned.MemorySwappiness)
+			} else {
+				require.NotNil(t, cloned.MemorySwappiness)
+				require.Equal(t, int64(60), *cloned.MemorySwappiness)
+			}
+
+			require.NotNil(t, input.MemorySwappiness)
+			require.Equal(t, int64(60), *input.MemorySwappiness)
+			require.Equal(t, int64(1024), cloned.CPUShares)
+			require.True(t, cloned.PublishAllPorts)
+			require.True(t, cloned.ReadonlyRootfs)
+			require.Equal(t, containertypes.NetworkMode("bridge"), cloned.NetworkMode)
+			require.Equal(t, "/tmp/id", cloned.ContainerIDFile)
+			require.Equal(t, "local", cloned.VolumeDriver)
+			require.Equal(t, map[string]string{"test": "value"}, cloned.Annotations)
+			require.Equal(t, []string{"/proc/kcore"}, cloned.MaskedPaths)
+			require.Equal(t, []string{"/proc/asound"}, cloned.ReadonlyPaths)
+		})
+	}
+}
+
+func TestSanitizeRecreateHostConfigInternal_NilHostConfig(t *testing.T) {
+	sanitized := sanitizeRecreateHostConfigInternal(nil, EngineCompatibilityInfo{Name: "podman", CgroupVersion: "2"})
+	require.False(t, sanitized)
+}
+
+func TestDetectEngineCompatibilityInfoInternal(t *testing.T) {
+	t.Run("prefers platform name for podman detection", func(t *testing.T) {
+		version := client.ServerVersionResult{}
+		version.Platform.Name = "Podman Engine"
+		info := systemtypes.Info{CgroupVersion: "2"}
+
+		engineInfo := detectEngineCompatibilityInfoInternal(version, info)
+		require.Equal(t, "podman", engineInfo.Name)
+		require.Equal(t, "2", engineInfo.CgroupVersion)
+	})
+
+	t.Run("detects podman from component names", func(t *testing.T) {
+		version := client.ServerVersionResult{
+			Components: []systemtypes.ComponentVersion{
+				{Name: "Podman Engine"},
+			},
+		}
+		info := systemtypes.Info{CgroupVersion: "2"}
+
+		engineInfo := detectEngineCompatibilityInfoInternal(version, info)
+		require.Equal(t, "podman", engineInfo.Name)
+		require.Equal(t, "2", engineInfo.CgroupVersion)
+	})
+
+	t.Run("falls back to docker markers", func(t *testing.T) {
+		version := client.ServerVersionResult{}
+		info := systemtypes.Info{
+			CgroupVersion: "2",
+			ServerVersion: "Docker Engine - Community",
+		}
+
+		engineInfo := detectEngineCompatibilityInfoInternal(version, info)
+		require.Equal(t, "docker", engineInfo.Name)
+		require.Equal(t, "2", engineInfo.CgroupVersion)
+	})
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:  https://github.com/getarcaneapp/arcane/issues/1454

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes containers failing to start on Podman with cgroup v2 by introducing a new `PrepareRecreateHostConfigForEngine` helper in `pkg/libarcane` that detects the connected container engine (Docker vs Podman) and cgroup version, then strips the `MemorySwappiness` field from the `HostConfig` before recreating a container — since Podman rejects that field under cgroup v2 with an OCI error. The fix is applied consistently to both the CLI `upgrade` path and the `UpdaterService` auto-update path.

- New `engine_compat.go` introduces `PrepareRecreateHostConfigForEngine`, which clones the `HostConfig`, calls `ServerVersion` and `Info` on the Docker client to detect the engine, and conditionally nil-outs `MemorySwappiness` for Podman + cgroup v2.
- Both `upgrade.go` and `updater_service.go` are updated to use the new helper and guard `hostConfig != nil` before accessing `NetworkMode` / `PortBindings`.
- A thorough table-driven test suite is added in `engine_compat_test.go` covering sanitization logic and engine detection.
- Two new `doc.go` files add package-level documentation to `pkg/libarcane` and `cli/upgrade`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge; it fixes a real crash with a targeted, well-tested change and introduces no breaking changes.
- The core fix is correct and the helper is well-tested. The only concerns are a misleading "safe to mutate" doc comment on the shallow clone (not a runtime bug with current callers) and a duplicate doc paragraph on UpdateSingleContainer — both are style issues that don't affect correctness.
- No files require special attention beyond the style notes in `backend/pkg/libarcane/engine_compat.go` and `backend/internal/services/updater_service.go`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/pkg/libarcane/engine_compat.go | New file implementing engine-detection and HostConfig sanitization for Podman cgroup-v2; logic is correct for current callers, but the shallow clone overpromises its mutation-safety guarantee. |
| backend/pkg/libarcane/engine_compat_test.go | New test file covering sanitization, engine detection, and nil-path scenarios; table-driven and thorough for the internal helpers. |
| backend/internal/services/updater_service.go | Integrates PrepareRecreateHostConfigForEngine into the update flow correctly; contains a duplicated/redundant doc-comment paragraph on UpdateSingleContainer introduced by this PR. |
| backend/cli/upgrade/upgrade.go | Integrates PrepareRecreateHostConfigForEngine into the CLI upgrade path correctly; nil-hostConfig guard added consistently. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[upgradeContainer / updateContainer] --> B[PrepareRecreateHostConfigForEngine]
    B --> C{hostConfig == nil?}
    C -- yes --> D[return nil, false, empty info, nil]
    C -- no --> E[cloneContainerHostConfigInternal\nshallow copy of HostConfig]
    E --> F{dockerClient == nil?}
    F -- yes --> G[return clone, false, empty info, nil]
    F -- no --> H[dockerClient.ServerVersion]
    H --> I[dockerClient.Info]
    I --> J[detectEngineCompatibilityInfoInternal\nname: podman/docker, cgroupVersion]
    J --> K[sanitizeRecreateHostConfigInternal]
    K --> L{isPodman AND cgroupV2?}
    L -- no --> M[return clone, false, engineInfo, nil]
    L -- yes --> N{MemorySwappiness == nil?}
    N -- yes --> M
    N -- no --> O[clone.MemorySwappiness = nil]
    O --> P[return clone, true, engineInfo, nil]
    P --> Q[Caller logs stripped field]
    Q --> R[ContainerCreate with sanitized HostConfig]
```
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Finternal%2Fservices%2Fupdater_service.go%3A394-399%0A**Duplicate%20doc%20comment%20on%20%60UpdateSingleContainer%60**%0A%0AThe%20new%20lines%20added%20in%20this%20PR%20create%20a%20second%20doc-comment%20paragraph%20that%20restates%20the%20same%20information%20as%20the%20existing%20first%20two%20lines%2C%20resulting%20in%20a%20redundant%2C%20contradictory-looking%20comment%20block%3A%0A%0A%60%60%60go%0A%2F%2F%20UpdateSingleContainer%20updates%20a%20single%20container%20by%20ID%20to%20the%20latest%20available%20image.%0A%2F%2F%20It%20pulls%20the%20new%20image%2C%20stops%20the%20container%2C%20removes%20it%2C%20and%20recreates%20it%20with%20the%20new%20image.%0A%2F%2F%0A%2F%2F%20UpdateSingleContainer%20pulls%20the%20latest%20image%20for%20one%20container%20and%20recreates%20%20%E2%86%90%20duplicate%0A%2F%2F%20that%20container%20when%20a%20newer%20image%20is%20available.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%86%90%20duplicate%0A%60%60%60%0A%0AConsider%20removing%20the%20newly%20added%20paragraph%20and%20keeping%20only%20the%20original%20description%20%28or%20replacing%20it%20with%20just%20the%20new%20one%29.%0A%0A%60%60%60suggestion%0A%2F%2F%20UpdateSingleContainer%20updates%20a%20single%20container%20by%20ID%20to%20the%20latest%20available%20image.%0A%2F%2F%20It%20pulls%20the%20new%20image%2C%20stops%20the%20container%2C%20removes%20it%2C%20and%20recreates%20it%20with%20the%20new%20image.%0A%2F%2F%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Fpkg%2Flibarcane%2Fengine_compat.go%3A54-61%0A**Shallow%20clone%20doesn't%20fully%20honour%20the%20%22safe%20to%20mutate%22%20guarantee**%0A%0A%60cloneContainerHostConfigInternal%60%20performs%20a%20one-level%20struct%20copy%20%28%60cloned%20%3A%3D%20*hostConfig%60%29.%20This%20means%20every%20slice%20and%20map%20field%20in%20%60HostConfig%60%20%28e.g.%2C%20%60Binds%60%2C%20%60PortBindings%60%2C%20%60Sysctls%60%2C%20%60Devices%60%2C%20%60Annotations%60%2C%20%E2%80%A6%29%20shares%20the%20same%20underlying%20backing%20array%2Fmap%20with%20the%20original.%0A%0AThe%20exported%20function's%20doc%20comment%20states%3A%0A%0A%3E%20The%20returned%20HostConfig%20is%20always%20safe%20to%20mutate%20without%20affecting%20the%20caller's%20original%20value.%0A%0AThis%20promise%20holds%20**only%20for%20the%20mutations%20currently%20performed**%20%28pointer-field%20nil-out%20and%20bool%20reset%20%E2%80%94%20both%20are%20safe%20because%20they%20overwrite%20the%20field%20slot%20without%20touching%20the%20backing%20data%29.%20However%2C%20any%20future%20caller%20that%20does%20a%20content-level%20mutation%20%28e.g.%2C%20%60hostConfig.Sysctls%5B%22key%22%5D%20%3D%20%22val%22%60%2C%20or%20%60hostConfig.Binds%20%3D%20append%28hostConfig.Binds%2C%20%22new%22%29%60%20within%20capacity%29%20would%20silently%20corrupt%20the%20original.%0A%0AConsider%20either%3A%0A-%20Narrowing%20the%20doc%20comment%20to%20describe%20what%20the%20function%20actually%20guarantees%20%28field%20reassignment%20is%20safe%29%2C%20or%0A-%20Deep-copying%20at%20least%20the%20map%2Fslice%20fields%20that%20callers%20are%20known%20to%20touch%20%28like%20%60PortBindings%60%29.%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/updater_service.go
Line: 394-399

Comment:
**Duplicate doc comment on `UpdateSingleContainer`**

The new lines added in this PR create a second doc-comment paragraph that restates the same information as the existing first two lines, resulting in a redundant, contradictory-looking comment block:

```go
// UpdateSingleContainer updates a single container by ID to the latest available image.
// It pulls the new image, stops the container, removes it, and recreates it with the new image.
//
// UpdateSingleContainer pulls the latest image for one container and recreates  ← duplicate
// that container when a newer image is available.                                ← duplicate
```

Consider removing the newly added paragraph and keeping only the original description (or replacing it with just the new one).

```suggestion
// UpdateSingleContainer updates a single container by ID to the latest available image.
// It pulls the new image, stops the container, removes it, and recreates it with the new image.
//
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/libarcane/engine_compat.go
Line: 54-61

Comment:
**Shallow clone doesn't fully honour the "safe to mutate" guarantee**

`cloneContainerHostConfigInternal` performs a one-level struct copy (`cloned := *hostConfig`). This means every slice and map field in `HostConfig` (e.g., `Binds`, `PortBindings`, `Sysctls`, `Devices`, `Annotations`, …) shares the same underlying backing array/map with the original.

The exported function's doc comment states:

> The returned HostConfig is always safe to mutate without affecting the caller's original value.

This promise holds **only for the mutations currently performed** (pointer-field nil-out and bool reset — both are safe because they overwrite the field slot without touching the backing data). However, any future caller that does a content-level mutation (e.g., `hostConfig.Sysctls["key"] = "val"`, or `hostConfig.Binds = append(hostConfig.Binds, "new")` within capacity) would silently corrupt the original.

Consider either:
- Narrowing the doc comment to describe what the function actually guarantees (field reassignment is safe), or
- Deep-copying at least the map/slice fields that callers are known to touch (like `PortBindings`).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 1e973b2</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->