### PR TITLE
fix: incorrect ipv6 parsing on api responses

### DIFF
--- a/backend/cli/upgrade/upgrade.go
+++ b/backend/cli/upgrade/upgrade.go
@@ -83,7 +83,7 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 		containerName = strings.TrimPrefix(targetContainer.Name, "/")
 		slog.Info("Found Arcane container", "name", containerName, "id", targetContainer.ID[:12])
 	} else {
-		inspectResult, inspectErr := dockerClient.ContainerInspect(ctx, containerName, client.ContainerInspectOptions{})
+		inspectResult, inspectErr := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, containerName, client.ContainerInspectOptions{})
 		targetContainer = inspectResult.Container
 		err = inspectErr
 		if err != nil {
@@ -134,7 +134,7 @@ func findArcaneContainer(ctx context.Context, dockerClient *client.Client) (cont
 			continue
 		}
 
-		inspectResult, err := dockerClient.ContainerInspect(ctx, c.ID, client.ContainerInspectOptions{})
+		inspectResult, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, c.ID, client.ContainerInspectOptions{})
 		if err != nil {
 			continue
 		}

--- a/backend/internal/services/container_service.go
+++ b/backend/internal/services/container_service.go
@@ -124,7 +124,7 @@ func (s *ContainerService) GetContainerByID(ctx context.Context, id string) (*co
 		return nil, fmt.Errorf("failed to connect to Docker: %w", err)
 	}
 
-	containerInspect, err := dockerClient.ContainerInspect(ctx, id, client.ContainerInspectOptions{})
+	containerInspect, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, id, client.ContainerInspectOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("container not found: %w", err)
 	}
@@ -143,7 +143,7 @@ func (s *ContainerService) DeleteContainer(ctx context.Context, containerID stri
 	// Get container mounts before deletion if we need to remove volumes
 	var volumesToRemove []string
 	if removeVolumes {
-		containerJSON, inspectErr := dockerClient.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+		containerJSON, inspectErr := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, containerID, client.ContainerInspectOptions{})
 		if inspectErr == nil {
 			for _, mount := range containerJSON.Container.Mounts {
 				// Only collect named volumes (not bind mounts or tmpfs)
@@ -253,7 +253,7 @@ func (s *ContainerService) CreateContainer(ctx context.Context, config *containe
 		return nil, fmt.Errorf("failed to start container: %w", err)
 	}
 
-	containerJSON, err := dockerClient.ContainerInspect(ctx, resp.ID, client.ContainerInspectOptions{})
+	containerJSON, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, resp.ID, client.ContainerInspectOptions{})
 	if err != nil {
 		s.eventService.LogErrorEvent(ctx, models.EventTypeContainerError, "container", resp.ID, containerName, user.ID, user.Username, "0", err, models.JSON{"action": "create", "image": config.Image, "step": "inspect"})
 		return nil, fmt.Errorf("failed to inspect created container: %w", err)

--- a/backend/internal/services/network_service.go
+++ b/backend/internal/services/network_service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	dockerutil "github.com/getarcaneapp/arcane/backend/internal/utils/docker"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/pagination"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
 	networktypes "github.com/getarcaneapp/arcane/types/network"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
@@ -35,7 +36,7 @@ func (s *NetworkService) GetNetworkByID(ctx context.Context, id string) (*networ
 		return nil, fmt.Errorf("failed to connect to Docker: %w", err)
 	}
 
-	networkInspect, err := dockerClient.NetworkInspect(ctx, id, client.NetworkInspectOptions{})
+	networkInspect, err := libarcane.NetworkInspectWithCompatibility(ctx, dockerClient, id, client.NetworkInspectOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("network not found: %w", err)
 	}
@@ -86,7 +87,7 @@ func (s *NetworkService) RemoveNetwork(ctx context.Context, id string, user mode
 		return fmt.Errorf("failed to connect to Docker: %w", err)
 	}
 
-	networkInfo, err := dockerClient.NetworkInspect(ctx, id, client.NetworkInspectOptions{})
+	networkInfo, err := libarcane.NetworkInspectWithCompatibility(ctx, dockerClient, id, client.NetworkInspectOptions{})
 	var networkName string
 	if err == nil {
 		networkName = networkInfo.Network.Name

--- a/backend/internal/services/system_upgrade_service.go
+++ b/backend/internal/services/system_upgrade_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	dockerutils "github.com/getarcaneapp/arcane/backend/internal/utils/docker"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/timeouts"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
 	containertypes "github.com/moby/moby/api/types/container"
 	mounttypes "github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/client"
@@ -227,7 +228,7 @@ func (s *SystemUpgradeService) findArcaneContainer(ctx context.Context, containe
 	}
 
 	// Try to inspect the container directly
-	container, err := dockerClient.ContainerInspect(ctx, containerId, client.ContainerInspectOptions{})
+	container, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, containerId, client.ContainerInspectOptions{})
 	if err == nil {
 		return container.Container, nil
 	}
@@ -246,7 +247,7 @@ func (s *SystemUpgradeService) findArcaneContainer(ctx context.Context, containe
 
 	for _, c := range containers.Items {
 		if strings.HasPrefix(c.ID, containerId) {
-			inspect, inspectErr := dockerClient.ContainerInspect(ctx, c.ID, client.ContainerInspectOptions{})
+			inspect, inspectErr := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, c.ID, client.ContainerInspectOptions{})
 			if inspectErr != nil {
 				return containertypes.InspectResponse{}, inspectErr
 			}
@@ -262,7 +263,7 @@ func (s *SystemUpgradeService) findArcaneContainer(ctx context.Context, containe
 
 	for _, c := range allContainers.Items {
 		if strings.HasPrefix(c.ID, containerId) || c.ID == containerId {
-			inspect, inspectErr := dockerClient.ContainerInspect(ctx, c.ID, client.ContainerInspectOptions{})
+			inspect, inspectErr := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, c.ID, client.ContainerInspectOptions{})
 			if inspectErr != nil {
 				return containertypes.InspectResponse{}, inspectErr
 			}

--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -428,7 +428,7 @@ func (s *UpdaterService) UpdateSingleContainer(ctx context.Context, containerID 
 	slog.InfoContext(ctx, "UpdateSingleContainer: found container", "containerID", containerID, "name", containerName, "image", targetContainer.Image)
 
 	// Inspect container to get full config (needed for label-based controls)
-	inspectBeforeResult, err := dcli.ContainerInspect(ctx, targetContainer.ID, client.ContainerInspectOptions{})
+	inspectBeforeResult, err := libarcane.ContainerInspectWithCompatibility(ctx, dcli, targetContainer.ID, client.ContainerInspectOptions{})
 	if err != nil {
 		out.Items = append(out.Items, updater.ResourceResult{
 			ResourceID:   targetContainer.ID,
@@ -923,7 +923,7 @@ func (s *UpdaterService) collectUsedImagesFromContainersInternal(ctx context.Con
 			continue
 		}
 
-		inspectResult, err := dcli.ContainerInspect(ctx, c.ID, client.ContainerInspectOptions{})
+		inspectResult, err := libarcane.ContainerInspectWithCompatibility(ctx, dcli, c.ID, client.ContainerInspectOptions{})
 		if err != nil {
 			slog.DebugContext(ctx, "collectUsedImagesFromContainersInternal: container inspect failed", "containerId", c.ID, "err", err)
 			continue
@@ -1255,7 +1255,7 @@ func (s *UpdaterService) restartContainersUsingOldIDs(ctx context.Context, oldID
 	if len(markedForRestart) > 0 {
 		for i := range containersWithDeps {
 			cwd := containersWithDeps[i]
-			inspectResult, ierr := dcli.ContainerInspect(ctx, cwd.Container.ID, client.ContainerInspectOptions{})
+			inspectResult, ierr := libarcane.ContainerInspectWithCompatibility(ctx, dcli, cwd.Container.ID, client.ContainerInspectOptions{})
 			if ierr != nil {
 				continue
 			}
@@ -1317,7 +1317,7 @@ func (s *UpdaterService) restartContainersUsingOldIDs(ctx context.Context, oldID
 		name := cd.Name
 		labels := map[string]string{}
 		if p.inspect == nil {
-			inspectResult, ierr := dcli.ContainerInspect(ctx, p.cnt.ID, client.ContainerInspectOptions{})
+			inspectResult, ierr := libarcane.ContainerInspectWithCompatibility(ctx, dcli, p.cnt.ID, client.ContainerInspectOptions{})
 			if ierr != nil {
 				res := updater.ResourceResult{
 					ResourceID:   p.cnt.ID,
@@ -1614,7 +1614,7 @@ func (s *UpdaterService) anyImageIDsStillInUse(ctx context.Context, ids []string
 	}
 	list := listResult.Items
 	for _, c := range list {
-		inspectResult, ierr := dcli.ContainerInspect(ctx, c.ID, client.ContainerInspectOptions{})
+		inspectResult, ierr := libarcane.ContainerInspectWithCompatibility(ctx, dcli, c.ID, client.ContainerInspectOptions{})
 		if ierr != nil {
 			continue
 		}
@@ -1670,7 +1670,7 @@ func (s *UpdaterService) buildRunningImageIDSetInternal(ctx context.Context) (ma
 			continue
 		}
 
-		inspectResult, ierr := dcli.ContainerInspect(ctx, c.ID, client.ContainerInspectOptions{})
+		inspectResult, ierr := libarcane.ContainerInspectWithCompatibility(ctx, dcli, c.ID, client.ContainerInspectOptions{})
 		inspect := inspectResult.Container
 		if ierr == nil && inspect.Image != "" {
 			inUseSet[inspect.Image] = struct{}{}

--- a/backend/internal/services/version_service.go
+++ b/backend/internal/services/version_service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/utils/arcaneupdater"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/cache"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/docker"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
 	"github.com/getarcaneapp/arcane/types/version"
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
@@ -293,7 +294,7 @@ func (s *VersionService) detectCurrentImageInfo(ctx context.Context) (tag string
 	}
 	slog.Debug("detectCurrentImageInfo: detected container", "containerId", containerId)
 
-	inspectResult, err := dockerClient.ContainerInspect(ctx, containerId, client.ContainerInspectOptions{})
+	inspectResult, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, containerId, client.ContainerInspectOptions{})
 	if err != nil {
 		slog.Debug("detectCurrentImageInfo: failed to inspect container", "containerId", containerId, "error", err)
 		return "", "", ""

--- a/backend/internal/services/volume_service.go
+++ b/backend/internal/services/volume_service.go
@@ -404,7 +404,7 @@ func (s *VolumeService) getHelperImageInternal(ctx context.Context, dockerClient
 func (s *VolumeService) resolveArcaneHelperImageInternal(ctx context.Context, dockerClient *client.Client) (string, string, bool) {
 	hostname, _ := os.Hostname()
 	if hostname != "" {
-		if inspect, err := dockerClient.ContainerInspect(ctx, hostname, client.ContainerInspectOptions{}); err == nil && inspect.Container.Config != nil && strings.TrimSpace(inspect.Container.Config.Image) != "" {
+		if inspect, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, hostname, client.ContainerInspectOptions{}); err == nil && inspect.Container.Config != nil && strings.TrimSpace(inspect.Container.Config.Image) != "" {
 			return inspect.Container.Config.Image, "hostname", true
 		}
 	}
@@ -440,7 +440,7 @@ func (s *VolumeService) resolveBackupStorageMountInternal(ctx context.Context, d
 	if dockerClient != nil {
 		containerID := s.getArcaneContainerIDInternal(ctx, dockerClient)
 		if containerID != "" {
-			inspect, err := dockerClient.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+			inspect, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, containerID, client.ContainerInspectOptions{})
 			if err != nil {
 				slog.WarnContext(ctx, "volume service: failed to inspect arcane container for backup mount resolution, falling back to named volume", "container_id", containerID, "error", err.Error())
 			} else if resolved, ok := resolveBackupStorageMountFromMountsInternal(inspect.Container.Mounts, target, readOnly); ok {
@@ -510,7 +510,7 @@ func (s *VolumeService) BackupMountWarning(ctx context.Context) string {
 		return ""
 	}
 
-	inspect, err := dockerClient.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+	inspect, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, containerID, client.ContainerInspectOptions{})
 	if err != nil {
 		return ""
 	}
@@ -521,7 +521,7 @@ func (s *VolumeService) BackupMountWarning(ctx context.Context) string {
 func (s *VolumeService) getArcaneContainerIDInternal(ctx context.Context, dockerClient *client.Client) string {
 	hostname, _ := os.Hostname()
 	if hostname != "" {
-		if inspect, err := dockerClient.ContainerInspect(ctx, hostname, client.ContainerInspectOptions{}); err == nil {
+		if inspect, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, hostname, client.ContainerInspectOptions{}); err == nil {
 			return inspect.Container.ID
 		}
 	}
@@ -737,7 +737,7 @@ func (s *VolumeService) getReusableReadOnlyContainerInternal(ctx context.Context
 		return "", false
 	}
 
-	inspect, err := dockerClient.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+	inspect, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, containerID, client.ContainerInspectOptions{})
 	if err != nil || inspect.Container.State == nil || !inspect.Container.State.Running {
 		s.helperMu.Lock()
 		delete(s.helperByVolume, volumeName)

--- a/backend/internal/utils/arcaneupdater/sorter.go
+++ b/backend/internal/utils/arcaneupdater/sorter.go
@@ -185,26 +185,32 @@ func UpdateImplicitRestart(containers []ContainerWithDeps, markedForRestart map[
 		}
 
 		// Check if any dependency is marked for restart
-		allDeps := make([]string, 0, len(c.Links)+len(c.DependsOn)+len(c.NetworkDeps))
-		allDeps = append(allDeps, c.Links...)
-		allDeps = append(allDeps, c.DependsOn...)
-		allDeps = append(allDeps, c.NetworkDeps...)
-
-		for _, dep := range allDeps {
-			if markedForRestart[dep] {
-				// This container's dependency is restarting, so it needs to restart too
-				markedForRestart[c.Name] = true
-				if containers[i].Container.Labels == nil {
-					containers[i].Container.Labels = map[string]string{}
-				}
-				containers[i].Container.Labels["_arcane_implicit_restart"] = "true"
-				implicitRestarts = append(implicitRestarts, c.Name)
-				break
-			}
+		if !hasMarkedDependencyInternal(markedForRestart, c.Links) &&
+			!hasMarkedDependencyInternal(markedForRestart, c.DependsOn) &&
+			!hasMarkedDependencyInternal(markedForRestart, c.NetworkDeps) {
+			continue
 		}
+
+		// This container's dependency is restarting, so it needs to restart too
+		markedForRestart[c.Name] = true
+		if containers[i].Container.Labels == nil {
+			containers[i].Container.Labels = map[string]string{}
+		}
+		containers[i].Container.Labels["_arcane_implicit_restart"] = "true"
+		implicitRestarts = append(implicitRestarts, c.Name)
 	}
 
 	return implicitRestarts
+}
+
+func hasMarkedDependencyInternal(markedForRestart map[string]bool, deps []string) bool {
+	for _, dep := range deps {
+		if markedForRestart[dep] {
+			return true
+		}
+	}
+
+	return false
 }
 
 // ExtractContainerName extracts a clean container name from the summary

--- a/backend/internal/utils/docker/mount_utils.go
+++ b/backend/internal/utils/docker/mount_utils.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/getarcaneapp/arcane/backend/internal/utils/pathmapper"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
 	containertypes "github.com/moby/moby/api/types/container"
 	mounttypes "github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/client"
@@ -26,7 +27,7 @@ func GetHostPathForContainerPath(ctx context.Context, dockerCli *client.Client, 
 	}
 
 	// 2. Inspect self
-	inspect, err := dockerCli.ContainerInspect(ctx, hostname, client.ContainerInspectOptions{})
+	inspect, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerCli, hostname, client.ContainerInspectOptions{})
 	if err != nil {
 		// Not running in a container or can't reach docker daemon
 		return "", err

--- a/backend/pkg/libarcane/inspect_compat.go
+++ b/backend/pkg/libarcane/inspect_compat.go
@@ -1,0 +1,460 @@
+package libarcane
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+
+	containertypes "github.com/moby/moby/api/types/container"
+	networktypes "github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
+)
+
+// WrapDockerAPIClientForInspectCompatibility wraps a Docker API client so
+// inspect calls can recover from daemon responses that encode address fields
+// with CIDR suffixes that newer typed Moby structs reject.
+func WrapDockerAPIClientForInspectCompatibility(apiClient client.APIClient) client.APIClient {
+	if apiClient == nil {
+		return nil
+	}
+	if _, ok := apiClient.(*inspectCompatibilityClient); ok {
+		return apiClient
+	}
+	return &inspectCompatibilityClient{APIClient: apiClient}
+}
+
+type inspectCompatibilityClient struct {
+	client.APIClient
+}
+
+func (c *inspectCompatibilityClient) ContainerInspect(ctx context.Context, containerID string, options client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+	return ContainerInspectWithCompatibility(ctx, c.APIClient, containerID, options)
+}
+
+func (c *inspectCompatibilityClient) NetworkInspect(ctx context.Context, networkID string, options client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+	return NetworkInspectWithCompatibility(ctx, c.APIClient, networkID, options)
+}
+
+// ContainerInspectWithCompatibility retries inspect decoding against raw daemon
+// JSON when the primary typed decode fails on a ParseAddr-style CIDR issue.
+func ContainerInspectWithCompatibility(ctx context.Context, apiClient client.APIClient, containerID string, options client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+	if apiClient == nil {
+		return client.ContainerInspectResult{}, fmt.Errorf("docker api client is nil")
+	}
+
+	result, err := apiClient.ContainerInspect(ctx, containerID, options)
+	if err == nil || !isInspectAddressParseErrorInternal(err) {
+		return result, err
+	}
+
+	query := url.Values{}
+	if options.Size {
+		query.Set("size", "1")
+	}
+
+	raw, fetchErr := fetchDockerAPIJSONInternal(ctx, apiClient, "/containers/"+strings.TrimSpace(containerID)+"/json", query)
+	if fetchErr != nil {
+		return client.ContainerInspectResult{}, err
+	}
+
+	normalized, changed, normalizeContainerInspectRawJSONInternalErr := normalizeContainerInspectRawJSONInternal(raw)
+	if normalizeContainerInspectRawJSONInternalErr != nil || !changed {
+		return client.ContainerInspectResult{}, err
+	}
+
+	var repaired containertypes.InspectResponse
+	if unmarshalErr := json.Unmarshal(normalized, &repaired); unmarshalErr != nil {
+		return client.ContainerInspectResult{}, err
+	}
+
+	return client.ContainerInspectResult{
+		Container: repaired,
+		Raw:       normalized,
+	}, nil
+}
+
+// NetworkInspectWithCompatibility retries inspect decoding against raw daemon
+// JSON when the primary typed decode fails on a ParseAddr-style CIDR issue.
+func NetworkInspectWithCompatibility(ctx context.Context, apiClient client.APIClient, networkID string, options client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+	if apiClient == nil {
+		return client.NetworkInspectResult{}, fmt.Errorf("docker api client is nil")
+	}
+
+	result, err := apiClient.NetworkInspect(ctx, networkID, options)
+	if err == nil || !isInspectAddressParseErrorInternal(err) {
+		return result, err
+	}
+
+	query := url.Values{}
+	if options.Verbose {
+		query.Set("verbose", "true")
+	}
+	if scope := strings.TrimSpace(options.Scope); scope != "" {
+		query.Set("scope", scope)
+	}
+
+	raw, fetchErr := fetchDockerAPIJSONInternal(ctx, apiClient, "/networks/"+strings.TrimSpace(networkID), query)
+	if fetchErr != nil {
+		return client.NetworkInspectResult{}, err
+	}
+
+	normalized, changed, normalizeNetworkInspectRawJSONInternalErr := normalizeNetworkInspectRawJSONInternal(raw)
+	if normalizeNetworkInspectRawJSONInternalErr != nil || !changed {
+		return client.NetworkInspectResult{}, err
+	}
+
+	var repaired networktypes.Inspect
+	if unmarshalErr := json.Unmarshal(normalized, &repaired); unmarshalErr != nil {
+		return client.NetworkInspectResult{}, err
+	}
+
+	return client.NetworkInspectResult{
+		Network: repaired,
+		Raw:     normalized,
+	}, nil
+}
+
+func fetchDockerAPIJSONInternal(ctx context.Context, apiClient client.APIClient, resourcePath string, query url.Values) ([]byte, error) {
+	dialer := apiClient.Dialer()
+	if dialer == nil {
+		return nil, fmt.Errorf("docker api client does not expose a dialer")
+	}
+
+	reqURL := &url.URL{
+		Scheme:   "http",
+		Host:     client.DummyHost,
+		Path:     buildDockerAPIPathInternal(apiClient.ClientVersion(), resourcePath),
+		RawQuery: query.Encode(),
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// The official Moby client uses a TLS-aware dialer here when the daemon is
+	// configured with client certificates, so this fallback continues to work
+	// for remote tcp+TLS and local socket transports without reimplementing the
+	// client's private request machinery.
+	conn, err := dialer(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	if err := req.Write(conn); err != nil {
+		return nil, err
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("docker api GET %s failed with %s: %s", resourcePath, resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	return body, nil
+}
+
+func buildDockerAPIPathInternal(version, resourcePath string) string {
+	if trimmedVersion := strings.TrimSpace(strings.TrimPrefix(version, "v")); trimmedVersion != "" {
+		return path.Join("/v"+trimmedVersion, resourcePath)
+	}
+	return path.Join("/", resourcePath)
+}
+
+func normalizeContainerInspectRawJSONInternal(raw []byte) ([]byte, bool, error) {
+	payload := map[string]any{}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, false, err
+	}
+
+	changed := false
+
+	networkSettings, ok := asMapInternal(payload["NetworkSettings"])
+	if ok {
+		changed = normalizeAddressStringFieldInternal(networkSettings, "Gateway") || changed
+		changed = normalizeAddressStringFieldInternal(networkSettings, "IPv6Gateway") || changed
+		changed = normalizeAddressWithPrefixFieldInternal(networkSettings, "IPAddress", "IPPrefixLen") || changed
+		changed = normalizeAddressWithPrefixFieldInternal(networkSettings, "GlobalIPv6Address", "GlobalIPv6PrefixLen") || changed
+
+		if networks, ok := asMapInternal(networkSettings["Networks"]); ok {
+			for _, endpointAny := range networks {
+				endpoint, ok := asMapInternal(endpointAny)
+				if !ok {
+					continue
+				}
+
+				changed = normalizeAddressStringFieldInternal(endpoint, "Gateway") || changed
+				changed = normalizeAddressStringFieldInternal(endpoint, "IPv6Gateway") || changed
+				changed = normalizeAddressWithPrefixFieldInternal(endpoint, "IPAddress", "IPPrefixLen") || changed
+				changed = normalizeAddressWithPrefixFieldInternal(endpoint, "GlobalIPv6Address", "GlobalIPv6PrefixLen") || changed
+
+				if ipam, ok := asMapInternal(endpoint["IPAMConfig"]); ok {
+					changed = normalizeAddressStringFieldInternal(ipam, "IPv4Address") || changed
+					changed = normalizeAddressStringFieldInternal(ipam, "IPv6Address") || changed
+					changed = normalizeAddressStringSliceFieldInternal(ipam, "LinkLocalIPs") || changed
+				}
+			}
+		}
+	}
+
+	if !changed {
+		return raw, false, nil
+	}
+
+	normalized, err := json.Marshal(payload)
+	if err != nil {
+		return nil, false, err
+	}
+	return normalized, true, nil
+}
+
+func normalizeNetworkInspectRawJSONInternal(raw []byte) ([]byte, bool, error) {
+	payload := map[string]any{}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, false, err
+	}
+
+	changed := false
+	if ipam, ok := asMapInternal(payload["IPAM"]); ok {
+		if configs, ok := asSliceInternal(ipam["Config"]); ok {
+			for _, configAny := range configs {
+				config, ok := asMapInternal(configAny)
+				if !ok {
+					continue
+				}
+
+				changed = normalizeAddressStringFieldInternal(config, "Gateway") || changed
+				changed = normalizeAuxiliaryAddressesInternal(config, "AuxiliaryAddresses") || changed
+				changed = normalizeAuxiliaryAddressesInternal(config, "AuxAddress") || changed
+			}
+		}
+	}
+	if containers, ok := asMapInternal(payload["Containers"]); ok {
+		for _, endpointAny := range containers {
+			endpoint, ok := asMapInternal(endpointAny)
+			if !ok {
+				continue
+			}
+
+			changed = normalizePrefixStringFieldInternal(endpoint, "IPv4Address") || changed
+			changed = normalizePrefixStringFieldInternal(endpoint, "IPv6Address") || changed
+		}
+	}
+
+	if !changed {
+		return raw, false, nil
+	}
+
+	normalized, err := json.Marshal(payload)
+	if err != nil {
+		return nil, false, err
+	}
+	return normalized, true, nil
+}
+
+func normalizeAddressStringFieldInternal(obj map[string]any, key string) bool {
+	raw, ok := obj[key].(string)
+	if !ok {
+		return false
+	}
+
+	normalized, changed := normalizeAddressStringInternal(raw)
+	if !changed {
+		return false
+	}
+
+	obj[key] = normalized
+	return true
+}
+
+func normalizeAddressWithPrefixFieldInternal(obj map[string]any, addrKey, prefixLenKey string) bool {
+	raw, ok := obj[addrKey].(string)
+	if !ok {
+		return false
+	}
+
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return false
+	}
+	if _, err := netip.ParseAddr(trimmed); err == nil {
+		if raw == trimmed {
+			return false
+		}
+		obj[addrKey] = trimmed
+		return true
+	}
+
+	prefix, err := netip.ParsePrefix(trimmed)
+	if err != nil {
+		return false
+	}
+
+	changed := false
+	addrValue := prefix.Addr().String()
+	if raw != addrValue {
+		obj[addrKey] = addrValue
+		changed = true
+	}
+
+	if prefixLenMissingInternal(obj[prefixLenKey]) {
+		obj[prefixLenKey] = prefix.Bits()
+		changed = true
+	}
+
+	return changed
+}
+
+func normalizeAddressStringSliceFieldInternal(obj map[string]any, key string) bool {
+	values, ok := asSliceInternal(obj[key])
+	if !ok {
+		return false
+	}
+
+	changed := false
+	for i, value := range values {
+		raw, ok := value.(string)
+		if !ok {
+			continue
+		}
+		normalized, fieldChanged := normalizeAddressStringInternal(raw)
+		if !fieldChanged {
+			continue
+		}
+		values[i] = normalized
+		changed = true
+	}
+
+	if changed {
+		obj[key] = values
+	}
+	return changed
+}
+
+func normalizeAuxiliaryAddressesInternal(obj map[string]any, key string) bool {
+	auxMap, ok := asMapInternal(obj[key])
+	if !ok {
+		return false
+	}
+
+	changed := false
+	for auxKey, auxValue := range auxMap {
+		raw, ok := auxValue.(string)
+		if !ok {
+			continue
+		}
+		normalized, fieldChanged := normalizeAddressStringInternal(raw)
+		if !fieldChanged {
+			continue
+		}
+		auxMap[auxKey] = normalized
+		changed = true
+	}
+
+	if changed {
+		obj[key] = auxMap
+	}
+	return changed
+}
+
+func normalizePrefixStringFieldInternal(obj map[string]any, key string) bool {
+	raw, ok := obj[key].(string)
+	if !ok {
+		return false
+	}
+
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return false
+	}
+
+	prefix, err := netip.ParsePrefix(trimmed)
+	if err != nil {
+		return false
+	}
+
+	normalized := prefix.String()
+	if normalized == raw {
+		return false
+	}
+
+	obj[key] = normalized
+	return true
+}
+
+func normalizeAddressStringInternal(raw string) (string, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return raw, false
+	}
+	if _, err := netip.ParseAddr(trimmed); err == nil {
+		return trimmed, trimmed != raw
+	}
+
+	prefix, err := netip.ParsePrefix(trimmed)
+	if err != nil {
+		return raw, false
+	}
+
+	normalized := prefix.Addr().String()
+	return normalized, normalized != raw
+}
+
+func prefixLenMissingInternal(value any) bool {
+	switch v := value.(type) {
+	case nil:
+		return true
+	case float64:
+		return v == 0
+	case int:
+		return v == 0
+	case int32:
+		return v == 0
+	case int64:
+		return v == 0
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return true
+		}
+		parsed, err := strconv.Atoi(trimmed)
+		return err != nil || parsed == 0
+	default:
+		return false
+	}
+}
+
+func asMapInternal(value any) (map[string]any, bool) {
+	out, ok := value.(map[string]any)
+	return out, ok
+}
+
+func asSliceInternal(value any) ([]any, bool) {
+	out, ok := value.([]any)
+	return out, ok
+}
+
+func isInspectAddressParseErrorInternal(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := err.Error()
+	return strings.Contains(msg, "ParseAddr(") || strings.Contains(msg, "ParsePrefix(")
+}

--- a/backend/pkg/libarcane/inspect_compat_test.go
+++ b/backend/pkg/libarcane/inspect_compat_test.go
@@ -1,0 +1,340 @@
+package libarcane
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"testing"
+
+	containertypes "github.com/moby/moby/api/types/container"
+	networktypes "github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeContainerInspectRawJSONInternal(t *testing.T) {
+	raw := []byte(`{
+		"Id":"abc123",
+		"Name":"/app",
+		"Config":{"Image":"test:latest"},
+		"HostConfig":{"NetworkMode":"bridge"},
+		"NetworkSettings":{
+			"Networks":{
+				"bridge":{
+					"IPAMConfig":{
+						"IPv4Address":"172.18.0.50/16",
+						"IPv6Address":"fdd0:0:0:c::10/64",
+						"LinkLocalIPs":["169.254.10.10/16","fe80::10/64"]
+					},
+					"Gateway":"172.18.0.1/16",
+					"IPAddress":"172.18.0.20/16",
+					"IPPrefixLen":0,
+					"IPv6Gateway":"fdd0:0:0:c::1/64",
+					"GlobalIPv6Address":"fdd0:0:0:c::10/64",
+					"GlobalIPv6PrefixLen":0
+				}
+			}
+		}
+	}`)
+
+	normalized, changed, err := normalizeContainerInspectRawJSONInternal(raw)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	var inspect containertypes.InspectResponse
+	require.NoError(t, json.Unmarshal(normalized, &inspect))
+
+	endpoint := inspect.NetworkSettings.Networks["bridge"]
+	require.NotNil(t, endpoint)
+	require.NotNil(t, endpoint.IPAMConfig)
+	assert.Equal(t, netip.MustParseAddr("172.18.0.1"), endpoint.Gateway)
+	assert.Equal(t, netip.MustParseAddr("172.18.0.20"), endpoint.IPAddress)
+	assert.Equal(t, 16, endpoint.IPPrefixLen)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::1"), endpoint.IPv6Gateway)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::10"), endpoint.GlobalIPv6Address)
+	assert.Equal(t, 64, endpoint.GlobalIPv6PrefixLen)
+	assert.Equal(t, netip.MustParseAddr("172.18.0.50"), endpoint.IPAMConfig.IPv4Address)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::10"), endpoint.IPAMConfig.IPv6Address)
+	assert.Equal(t, []netip.Addr{
+		netip.MustParseAddr("169.254.10.10"),
+		netip.MustParseAddr("fe80::10"),
+	}, endpoint.IPAMConfig.LinkLocalIPs)
+}
+
+func TestNormalizeContainerInspectRawJSONInternal_NormalizesTopLevelNetworkSettings(t *testing.T) {
+	raw := []byte(`{
+		"Id":"abc123",
+		"Name":"/app",
+		"Config":{"Image":"test:latest"},
+		"HostConfig":{"NetworkMode":"bridge"},
+		"NetworkSettings":{
+			"Gateway":"172.18.0.1/16",
+			"IPAddress":"172.18.0.20/16",
+			"IPPrefixLen":0,
+			"IPv6Gateway":"fdd0:0:0:c::1/64",
+			"GlobalIPv6Address":"fdd0:0:0:c::10/64",
+			"GlobalIPv6PrefixLen":0,
+			"Networks":{}
+		}
+	}`)
+
+	normalized, changed, err := normalizeContainerInspectRawJSONInternal(raw)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	payload := map[string]any{}
+	require.NoError(t, json.Unmarshal(normalized, &payload))
+
+	networkSettings, ok := asMapInternal(payload["NetworkSettings"])
+	require.True(t, ok)
+	assert.Equal(t, "172.18.0.1", networkSettings["Gateway"])
+	assert.Equal(t, "172.18.0.20", networkSettings["IPAddress"])
+	assert.Equal(t, float64(16), networkSettings["IPPrefixLen"])
+	assert.Equal(t, "fdd0:0:0:c::1", networkSettings["IPv6Gateway"])
+	assert.Equal(t, "fdd0:0:0:c::10", networkSettings["GlobalIPv6Address"])
+	assert.Equal(t, float64(64), networkSettings["GlobalIPv6PrefixLen"])
+}
+
+func TestNormalizeNetworkInspectRawJSONInternal(t *testing.T) {
+	raw := []byte(`{
+		"Name":"test-net",
+		"Id":"net123",
+		"Created":"2026-03-11T00:00:00Z",
+		"Scope":"local",
+		"Driver":"bridge",
+		"EnableIPv6":true,
+		"IPAM":{
+			"Driver":"default",
+			"Config":[
+				{
+					"Subnet":"fdd0:0:0:c::/64",
+					"Gateway":"fdd0:0:0:c::1/64",
+					"AuxiliaryAddresses":{
+						"router":"fdd0:0:0:c::2/64"
+					}
+				}
+			]
+		},
+		"Containers":{}
+	}`)
+
+	normalized, changed, err := normalizeNetworkInspectRawJSONInternal(raw)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	var inspect networktypes.Inspect
+	require.NoError(t, json.Unmarshal(normalized, &inspect))
+	require.Len(t, inspect.IPAM.Config, 1)
+	assert.Equal(t, netip.MustParsePrefix("fdd0:0:0:c::/64"), inspect.IPAM.Config[0].Subnet)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::1"), inspect.IPAM.Config[0].Gateway)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::2"), inspect.IPAM.Config[0].AuxAddress["router"])
+}
+
+func TestNormalizeNetworkInspectRawJSONInternal_NormalizesContainerEndpoints(t *testing.T) {
+	raw := []byte(`{
+		"Name":"test-net",
+		"Id":"net123",
+		"Created":"2026-03-11T00:00:00Z",
+		"Scope":"local",
+		"Driver":"bridge",
+		"IPAM":{"Driver":"default","Config":[]},
+		"Containers":{
+			"abc123":{
+				"Name":"app",
+				"EndpointID":"ep1",
+				"IPv4Address":" 172.18.0.20/16 ",
+				"IPv6Address":" fdd0:0:0:c::10/64 "
+			}
+		}
+	}`)
+
+	normalized, changed, err := normalizeNetworkInspectRawJSONInternal(raw)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	var inspect networktypes.Inspect
+	require.NoError(t, json.Unmarshal(normalized, &inspect))
+	endpoint := inspect.Containers["abc123"]
+	assert.Equal(t, netip.MustParsePrefix("172.18.0.20/16"), endpoint.IPv4Address)
+	assert.Equal(t, netip.MustParsePrefix("fdd0:0:0:c::10/64"), endpoint.IPv6Address)
+}
+
+func TestNormalizeAddressStringInternal_TrimsWhitespaceAroundValidAddress(t *testing.T) {
+	normalized, changed := normalizeAddressStringInternal(" 172.18.0.1 ")
+	assert.True(t, changed)
+	assert.Equal(t, "172.18.0.1", normalized)
+}
+
+func TestNormalizeAddressWithPrefixFieldInternal_TrimsWhitespaceAroundValidAddress(t *testing.T) {
+	obj := map[string]any{
+		"IPAddress":   " 172.18.0.20 ",
+		"IPPrefixLen": 24,
+	}
+
+	changed := normalizeAddressWithPrefixFieldInternal(obj, "IPAddress", "IPPrefixLen")
+	assert.True(t, changed)
+	assert.Equal(t, "172.18.0.20", obj["IPAddress"])
+	assert.Equal(t, 24, obj["IPPrefixLen"])
+}
+
+func TestIsInspectAddressParseErrorInternal_MatchesPrefixErrors(t *testing.T) {
+	_, err := netip.ParsePrefix(" 172.18.0.20/16 ")
+	assert.True(t, isInspectAddressParseErrorInternal(err))
+}
+
+func TestContainerInspectWithCompatibility(t *testing.T) {
+	containerJSON := `{
+		"Id":"abc123",
+		"Name":"/app",
+		"Config":{"Image":"test:latest"},
+		"HostConfig":{"NetworkMode":"bridge"},
+		"NetworkSettings":{
+			"Networks":{
+				"bridge":{
+					"IPAMConfig":{"IPv6Address":"fdd0:0:0:c::10/64"},
+					"IPv6Gateway":"fdd0:0:0:c::1/64",
+					"GlobalIPv6Address":"fdd0:0:0:c::10/64",
+					"GlobalIPv6PrefixLen":0
+				}
+			}
+		}
+	}`
+
+	dockerClient := newTestDockerClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1.41/containers/test-container/json", r.URL.Path)
+		_, _ = w.Write([]byte(containerJSON))
+	})
+
+	result, err := ContainerInspectWithCompatibility(context.Background(), dockerClient, "test-container", client.ContainerInspectOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", result.Container.ID)
+	endpoint := result.Container.NetworkSettings.Networks["bridge"]
+	require.NotNil(t, endpoint)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::1"), endpoint.IPv6Gateway)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::10"), endpoint.GlobalIPv6Address)
+	assert.Equal(t, 64, endpoint.GlobalIPv6PrefixLen)
+}
+
+func TestNetworkInspectWithCompatibility(t *testing.T) {
+	networkJSON := `{
+		"Name":"test-net",
+		"Id":"net123",
+		"Created":"2026-03-11T00:00:00Z",
+		"Scope":"local",
+		"Driver":"bridge",
+		"IPAM":{
+			"Driver":"default",
+			"Config":[
+				{
+					"Subnet":"fdd0:0:0:c::/64",
+					"Gateway":"fdd0:0:0:c::1/64"
+				}
+			]
+		},
+		"Containers":{}
+	}`
+
+	dockerClient := newTestDockerClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1.41/networks/test-net", r.URL.Path)
+		_, _ = w.Write([]byte(networkJSON))
+	})
+
+	result, err := NetworkInspectWithCompatibility(context.Background(), dockerClient, "test-net", client.NetworkInspectOptions{})
+	require.NoError(t, err)
+	require.Len(t, result.Network.IPAM.Config, 1)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::1"), result.Network.IPAM.Config[0].Gateway)
+}
+
+func TestContainerInspectWithCompatibility_TLSRemote(t *testing.T) {
+	containerJSON := `{
+		"Id":"abc123",
+		"Name":"/app",
+		"Config":{"Image":"test:latest"},
+		"HostConfig":{"NetworkMode":"bridge"},
+		"NetworkSettings":{
+			"Networks":{
+				"bridge":{
+					"IPv6Gateway":"fdd0:0:0:c::1/64"
+				}
+			}
+		}
+	}`
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1.41/containers/test-container/json", r.URL.Path)
+		_, _ = w.Write([]byte(containerJSON))
+	}))
+	defer server.Close()
+
+	dockerClient, err := client.New(
+		client.WithHTTPClient(server.Client()),
+		client.WithHost("tcp://"+strings.TrimPrefix(server.URL, "https://")),
+		client.WithScheme("https"),
+		client.WithAPIVersion("1.41"),
+	)
+	require.NoError(t, err)
+	defer func() {
+		_ = dockerClient.Close()
+	}()
+
+	result, err := ContainerInspectWithCompatibility(context.Background(), dockerClient, "test-container", client.ContainerInspectOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::1"), result.Container.NetworkSettings.Networks["bridge"].IPv6Gateway)
+}
+
+func TestInspectCompatibilityLeavesInvalidValuesFailing(t *testing.T) {
+	dockerClient := newTestDockerClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"Name":"test-net",
+			"Id":"net123",
+			"Created":"2026-03-11T00:00:00Z",
+			"Scope":"local",
+			"Driver":"bridge",
+			"IPAM":{"Driver":"default","Config":[{"Subnet":"fdd0:0:0:c::/64","Gateway":"definitely-not-an-ip"}]},
+			"Containers":{}
+		}`))
+	})
+
+	_, err := NetworkInspectWithCompatibility(context.Background(), dockerClient, "test-net", client.NetworkInspectOptions{})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), `ParseAddr("definitely-not-an-ip")`))
+}
+
+func TestWrapDockerAPIClientForInspectCompatibility(t *testing.T) {
+	dockerClient := newTestDockerClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"Id":"abc123",
+			"Name":"/app",
+			"Config":{"Image":"test:latest"},
+			"HostConfig":{"NetworkMode":"bridge"},
+			"NetworkSettings":{"Networks":{"bridge":{"IPv6Gateway":"fdd0:0:0:c::1/64"}}}
+		}`))
+	})
+
+	wrapped := WrapDockerAPIClientForInspectCompatibility(dockerClient)
+	result, err := wrapped.ContainerInspect(context.Background(), "test-container", client.ContainerInspectOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::1"), result.Container.NetworkSettings.Networks["bridge"].IPv6Gateway)
+}
+
+func newTestDockerClient(t *testing.T, handler http.HandlerFunc) *client.Client {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	dockerClient, err := client.New(
+		client.WithHost("tcp://"+strings.TrimPrefix(server.URL, "http://")),
+		client.WithAPIVersion("1.41"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = dockerClient.Close()
+	})
+
+	return dockerClient
+}

--- a/backend/pkg/projects/compose.go
+++ b/backend/pkg/projects/compose.go
@@ -9,6 +9,8 @@ import (
 	"github.com/docker/cli/cli/flags"
 	"github.com/docker/compose/v5/pkg/api"
 	composev2 "github.com/docker/compose/v5/pkg/compose"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
+	"github.com/moby/moby/client"
 )
 
 type Client struct {
@@ -25,14 +27,36 @@ func NewClient(ctx context.Context) (*Client, error) {
 	if err := cli.Initialize(opts); err != nil {
 		return nil, err
 	}
-	svc, err := composev2.NewComposeService(cli,
+
+	composeCLI := wrapDockerCLIWithInspectCompatibilityInternal(cli)
+	svc, err := composev2.NewComposeService(composeCLI,
 		composev2.WithPrompt(composev2.AlwaysOkPrompt()),
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Client{svc: svc, dockerCli: cli}, nil
+	return &Client{svc: svc, dockerCli: composeCLI}, nil
+}
+
+type inspectCompatibleDockerCli struct {
+	command.Cli
+	apiClient client.APIClient
+}
+
+func (c *inspectCompatibleDockerCli) Client() client.APIClient {
+	return c.apiClient
+}
+
+func wrapDockerCLIWithInspectCompatibilityInternal(cli command.Cli) command.Cli {
+	if cli == nil {
+		return nil
+	}
+
+	return &inspectCompatibleDockerCli{
+		Cli:       cli,
+		apiClient: libarcane.WrapDockerAPIClientForInspectCompatibility(cli.Client()),
+	}
 }
 
 func (c *Client) Close() error {

--- a/backend/pkg/projects/compose_test.go
+++ b/backend/pkg/projects/compose_test.go
@@ -1,0 +1,30 @@
+package projects
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/flags"
+	mobyclient "github.com/moby/moby/client"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapDockerCLIWithInspectCompatibility(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "tcp://example.com:2375")
+
+	apiClient, err := mobyclient.New(mobyclient.WithHost("tcp://example.com:2375"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = apiClient.Close()
+	})
+
+	baseCLI, err := command.NewDockerCli(command.WithAPIClient(apiClient))
+	require.NoError(t, err)
+	require.NoError(t, baseCLI.Initialize(flags.NewClientOptions()))
+
+	wrapped := wrapDockerCLIWithInspectCompatibilityInternal(baseCLI)
+	require.NotNil(t, wrapped)
+	require.NotSame(t, baseCLI, wrapped)
+	require.NotEqual(t, reflect.TypeOf(apiClient), reflect.TypeOf(wrapped.Client()))
+}

--- a/backend/pkg/scheduler/auto_heal_job.go
+++ b/backend/pkg/scheduler/auto_heal_job.go
@@ -105,7 +105,7 @@ func (j *AutoHealJob) Run(ctx context.Context) {
 		}
 
 		// Inspect to get health status
-		inspect, err := dockerClient.ContainerInspect(ctx, c.ID, client.ContainerInspectOptions{})
+		inspect, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, c.ID, client.ContainerInspectOptions{})
 		if err != nil {
 			slog.WarnContext(ctx, "auto-heal failed to inspect container", "container", containerName, "error", err)
 			continue


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:  https://github.com/getarcaneapp/arcane/issues/2007

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a parsing failure (issue #2007) where newer Moby structs (`netip.Addr`/`netip.Prefix`) reject Docker daemon responses that encode address fields with CIDR suffixes (e.g. `"Gateway":"172.18.0.1/16"`). The fix introduces a new compatibility layer in `backend/pkg/libarcane/inspect_compat.go` that intercepts `ParseAddr`/`ParsePrefix` errors, re-fetches the raw inspect JSON via a low-level HTTP dial, strips the offending CIDR suffixes, and re-unmarshals the cleaned payload. All `ContainerInspect` and `NetworkInspect` call-sites across services, the scheduler, CLI, and the Compose client are updated to go through this shim.

- The approach (try → detect → re-fetch → normalize → retry unmarshal) is sound and matches the style of the rest of the codebase.
- `normalizeContainerInspectRawJSONInternal` correctly covers top-level `NetworkSettings` address fields, per-endpoint `EndpointSettings` fields, and `IPAMConfig` fields.
- `normalizeNetworkInspectRawJSONInternal` correctly covers IPAM `Config` gateway/auxiliary addresses and `Containers` endpoint prefix fields.
- `isInspectAddressParseErrorInternal` correctly checks for both `"ParseAddr("` and `"ParsePrefix("` error strings.
- Test coverage is solid: unit tests for each normalizer, integration-style tests via `httptest` for the full compatibility path, and idempotency tests for the wrapper.
- Two gaps remain in `inspect_compat.go`: (1) the raw-fetch fallback uses `apiClient.Dialer()` which returns a plain TCP dial, silently bypassing TLS for remote Docker hosts; (2) `normalizeAddressWithPrefixFieldInternal` returns `false` without writing the trimmed value back when a whitespace-padded but otherwise valid address is encountered, causing `changed` to stay `false` and the original error to propagate.
- The `sorter.go` refactor (`hasMarkedDependencyInternal`) is a clean extraction with equivalent logic and correct naming convention.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge for the common Unix-socket case; two logic gaps in the normalization shim can cause the fix to silently not apply under specific edge-case inputs.
- The bulk of the changes (14 call-site migrations) are mechanical and low-risk. The core logic in inspect_compat.go has good test coverage and a well-structured design. However, two verifiable bugs reduce confidence: normalizeAddressWithPrefixFieldInternal misses whitespace-padded valid addresses (returns false without updating the map, so changed stays false and the original ParseAddr error is returned), and fetchDockerAPIJSONInternal uses a raw TCP dial that will fail silently for TLS-configured remote Docker hosts, making the entire fix a no-op in that configuration.
- backend/pkg/libarcane/inspect_compat.go — specifically normalizeAddressWithPrefixFieldInternal (line 282) and fetchDockerAPIJSONInternal (line 125).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/pkg/libarcane/inspect_compat.go | New file: core compatibility shim that intercepts Docker inspect errors containing "ParseAddr(" or "ParsePrefix(", re-fetches raw JSON via a manual HTTP dial, strips CIDR suffixes from address fields, and re-unmarshals. Two logic gaps found: (1) `normalizeAddressWithPrefixFieldInternal` silently misses whitespace-padded valid addresses (returns false without writing the trimmed value back), and (2) the raw-fetch fallback uses `apiClient.Dialer()` which produces a plain TCP connection, causing the fallback to silently fail for TLS-configured remote Docker hosts. |
| backend/pkg/libarcane/inspect_compat_test.go | New test file: good coverage of the normalization helpers and the full compatibility round-trip via httptest. Tests cover top-level NetworkSettings fields, per-endpoint fields, container endpoint prefix fields, whitespace-trimming in normalizeAddressStringInternal, ParsePrefix error detection, and the wrapping client. All previously-identified missing tests are present. |
| backend/pkg/projects/compose.go | Wraps the docker CLI with an inspect-compatibility client before passing it to Compose; also stores the wrapped CLI in the Client struct so all downstream usages automatically benefit. Clean and non-breaking. |
| backend/internal/utils/arcaneupdater/sorter.go | UpdateImplicitRestart refactored to extract hasMarkedDependencyInternal helper (correctly named with "Internal" suffix per convention). Logic is functionally equivalent to the original nested loop with break. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant XWithCompat as ContainerInspect/NetworkInspect<br/>WithCompatibility
    participant APIClient as Docker APIClient
    participant Fetch as fetchDockerAPIJSONInternal
    participant Normalizer as normalizeRawJSONInternal

    Caller->>XWithCompat: inspect(ctx, id, opts)
    XWithCompat->>APIClient: ContainerInspect / NetworkInspect
    alt success
        APIClient-->>XWithCompat: result, nil
        XWithCompat-->>Caller: result, nil
    else ParseAddr / ParsePrefix error
        APIClient-->>XWithCompat: {}, parseErr
        XWithCompat->>Fetch: GET /v{ver}/containers/{id}/json (raw dial)
        alt fetch fails (e.g. TLS host)
            Fetch-->>XWithCompat: nil, fetchErr
            XWithCompat-->>Caller: {}, parseErr (original)
        else fetch succeeds
            Fetch-->>XWithCompat: []byte rawJSON
            XWithCompat->>Normalizer: normalizeRawJSON(rawJSON)
            alt changed == false (e.g. whitespace-only addr field)
                Normalizer-->>XWithCompat: raw, false, nil
                XWithCompat-->>Caller: {}, parseErr (original)
            else normalized
                Normalizer-->>XWithCompat: normalized, true, nil
                XWithCompat->>XWithCompat: json.Unmarshal(normalized, &repaired)
                XWithCompat-->>Caller: {repaired, normalized}, nil
            end
        end
    end
```
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Fpkg%2Flibarcane%2Finspect_compat.go%3A125-166%0A**Fallback%20fetch%20will%20silently%20fail%20for%20TLS-configured%20remote%20Docker%20hosts**%0A%0A%60apiClient.Dialer%28%29%60%20in%20the%20Moby%20client%20returns%20the%20transport's%20%60DialContext%60%2C%20which%20establishes%20a%20**plain%20TCP%20connection**%20without%20a%20TLS%20handshake.%20For%20Docker%20daemons%20configured%20with%20TLS%20%28e.g.%20a%20remote%20host%20on%20port%202376%29%2C%20the%20Docker%20daemon%20expects%20an%20incoming%20TLS%20handshake%20%E2%80%94%20sending%20a%20raw%20HTTP%20request%20over%20plain%20TCP%20will%20cause%20the%20connection%20to%20fail%20immediately.%0A%0AWhen%20that%20happens%2C%20%60fetchErr%20!%3D%20nil%60%2C%20and%20the%20function%20falls%20back%20to%20returning%20the%20original%20%60ParseAddr%60%20error%20unchanged%3A%0A%0A%60%60%60go%0Araw%2C%20fetchErr%20%3A%3D%20fetchDockerAPIJSONInternal%28...%29%0Aif%20fetchErr%20!%3D%20nil%20%7B%0A%20%20%20%20return%20client.ContainerInspectResult%7B%7D%2C%20err%20%20%2F%2F%20original%20ParseAddr%20error%0A%7D%0A%60%60%60%0A%0AThis%20means%20the%20entire%20IPv6%20compatibility%20fix%20is%20silently%20bypassed%20for%20any%20user%20running%20Arcane%20against%20a%20remote%20TLS%20Docker%20daemon%20that%20has%20this%20CIDR-suffix%20encoding%20issue.%20The%20call%20will%20just%20keep%20failing%20with%20the%20same%20parse%20error%20it%20would%20have%20without%20this%20fix.%0A%0AFor%20the%20common%20local%20Unix-socket%20case%20this%20is%20fine%2C%20but%20it's%20worth%20documenting%20the%20limitation%20or%2C%20ideally%2C%20plumbing%20the%20TLS%20credentials%20through%20by%20using%20the%20Docker%20client's%20standard%20HTTP%20machinery%20%28e.g.%20replacing%20the%20%60Accept%60%20header%20on%20the%20existing%20transport%29%20rather%20than%20dialling%20a%20raw%20connection.%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Fpkg%2Flibarcane%2Finspect_compat.go%3A282-313%0A**Whitespace-padded%20valid%20address%20in%20%60IPAddress%60%2F%60GlobalIPv6Address%60%20not%20fixed**%0A%0A%60normalizeAddressWithPrefixFieldInternal%60%20returns%20%60false%60%20immediately%20when%20%60trimmed%60%20%28the%20stripped%20value%29%20parses%20successfully%20as%20a%20plain%20%60netip.Addr%60.%20It%20does%20**not**%20write%20the%20trimmed%20value%20back%20to%20%60obj%5BaddrKey%5D%60%3A%0A%0A%60%60%60go%0Aif%20_%2C%20err%20%3A%3D%20netip.ParseAddr%28trimmed%29%3B%20err%20%3D%3D%20nil%20%7B%0A%20%20%20%20return%20false%20%20%20%2F%2F%20obj%5BaddrKey%5D%20still%20holds%20raw%20%28%22%20172.18.0.20%20%22%29%0A%7D%0A%60%60%60%0A%0AIf%20a%20daemon%20sends%20%60IPAddress%3A%20%22%20172.18.0.20%20%22%60%20%28valid%20address%2C%20but%20whitespace-padded%29%2C%20%60netip.Addr.UnmarshalText%60%20will%20fail%20with%20a%20%60ParseAddr%28...%29%60%20error.%20%60isInspectAddressParseErrorInternal%60%20fires%2C%20the%20fallback%20path%20is%20taken%2C%20and%20%60normalizeContainerInspectRawJSONInternal%60%20is%20called.%20But%20because%20%60normalizeAddressWithPrefixFieldInternal%60%20returns%20%60false%60%20for%20this%20case%2C%20%60changed%60%20stays%20%60false%60%20and%20the%20function%20returns%20the%20original%20error%20unchanged%3A%0A%0A%60%60%60go%0Anormalized%2C%20changed%2C%20_%20%3A%3D%20normalizeContainerInspectRawJSONInternal%28raw%29%0Aif%20!changed%20%7B%0A%20%20%20%20return%20client.ContainerInspectResult%7B%7D%2C%20err%20%20%20%2F%2F%20fix%20had%20no%20effect%0A%7D%0A%60%60%60%0A%0AThe%20fix%20should%20update%20%60obj%5BaddrKey%5D%60%20to%20%60trimmed%60%20whenever%20%60raw%20!%3D%20trimmed%60%2C%20matching%20the%20behaviour%20of%20%60normalizeAddressStringInternal%60%20%28which%20correctly%20returns%20%60trimmed%2C%20trimmed%20!%3D%20raw%60%29%3A%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/libarcane/inspect_compat.go
Line: 125-166

Comment:
**Fallback fetch will silently fail for TLS-configured remote Docker hosts**

`apiClient.Dialer()` in the Moby client returns the transport's `DialContext`, which establishes a **plain TCP connection** without a TLS handshake. For Docker daemons configured with TLS (e.g. a remote host on port 2376), the Docker daemon expects an incoming TLS handshake — sending a raw HTTP request over plain TCP will cause the connection to fail immediately.

When that happens, `fetchErr != nil`, and the function falls back to returning the original `ParseAddr` error unchanged:

```go
raw, fetchErr := fetchDockerAPIJSONInternal(...)
if fetchErr != nil {
    return client.ContainerInspectResult{}, err  // original ParseAddr error
}
```

This means the entire IPv6 compatibility fix is silently bypassed for any user running Arcane against a remote TLS Docker daemon that has this CIDR-suffix encoding issue. The call will just keep failing with the same parse error it would have without this fix.

For the common local Unix-socket case this is fine, but it's worth documenting the limitation or, ideally, plumbing the TLS credentials through by using the Docker client's standard HTTP machinery (e.g. replacing the `Accept` header on the existing transport) rather than dialling a raw connection.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/libarcane/inspect_compat.go
Line: 282-313

Comment:
**Whitespace-padded valid address in `IPAddress`/`GlobalIPv6Address` not fixed**

`normalizeAddressWithPrefixFieldInternal` returns `false` immediately when `trimmed` (the stripped value) parses successfully as a plain `netip.Addr`. It does **not** write the trimmed value back to `obj[addrKey]`:

```go
if _, err := netip.ParseAddr(trimmed); err == nil {
    return false   // obj[addrKey] still holds raw (" 172.18.0.20 ")
}
```

If a daemon sends `IPAddress: " 172.18.0.20 "` (valid address, but whitespace-padded), `netip.Addr.UnmarshalText` will fail with a `ParseAddr(...)` error. `isInspectAddressParseErrorInternal` fires, the fallback path is taken, and `normalizeContainerInspectRawJSONInternal` is called. But because `normalizeAddressWithPrefixFieldInternal` returns `false` for this case, `changed` stays `false` and the function returns the original error unchanged:

```go
normalized, changed, _ := normalizeContainerInspectRawJSONInternal(raw)
if !changed {
    return client.ContainerInspectResult{}, err   // fix had no effect
}
```

The fix should update `obj[addrKey]` to `trimmed` whenever `raw != trimmed`, matching the behaviour of `normalizeAddressStringInternal` (which correctly returns `trimmed, trimmed != raw`):

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 68e6ea8</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->