### PR TITLE
fix: only allow deleting admins if more than one exists

### DIFF
--- a/backend/internal/huma/handlers/users.go
+++ b/backend/internal/huma/handlers/users.go
@@ -10,7 +10,6 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/common"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/getarcaneapp/arcane/backend/internal/services"
-	"github.com/getarcaneapp/arcane/backend/internal/utils/mapper"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/validation"
 	"github.com/getarcaneapp/arcane/types/base"
 	"github.com/getarcaneapp/arcane/types/user"
@@ -229,7 +228,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, input *CreateUserInput) (*
 		return nil, huma.Error500InternalServerError((&common.UserCreationError{Err: err}).Error())
 	}
 
-	out, err := mapper.MapOne[*models.User, user.User](createdUser)
+	out, err := h.userService.ToUserResponseDto(ctx, *createdUser)
 	if err != nil {
 		return nil, huma.Error500InternalServerError((&common.UserMappingError{Err: err}).Error())
 	}
@@ -257,7 +256,7 @@ func (h *UserHandler) GetUser(ctx context.Context, input *GetUserInput) (*GetUse
 		return nil, huma.Error404NotFound((&common.UserNotFoundError{}).Error())
 	}
 
-	out, err := mapper.MapOne[*models.User, user.User](userModel)
+	out, err := h.userService.ToUserResponseDto(ctx, *userModel)
 	if err != nil {
 		return nil, huma.Error500InternalServerError((&common.UserMappingError{Err: err}).Error())
 	}
@@ -320,10 +319,16 @@ func (h *UserHandler) UpdateUser(ctx context.Context, input *UpdateUserInput) (*
 
 	updatedUser, err := h.userService.UpdateUser(ctx, userModel)
 	if err != nil {
+		if errors.Is(err, services.ErrCannotRemoveLastAdmin) {
+			return nil, huma.Error409Conflict(services.ErrCannotRemoveLastAdmin.Error())
+		}
+		if errors.Is(err, services.ErrUserNotFound) {
+			return nil, huma.Error404NotFound((&common.UserNotFoundError{}).Error())
+		}
 		return nil, huma.Error500InternalServerError((&common.UserUpdateError{Err: err}).Error())
 	}
 
-	out, err := mapper.MapOne[*models.User, user.User](updatedUser)
+	out, err := h.userService.ToUserResponseDto(ctx, *updatedUser)
 	if err != nil {
 		return nil, huma.Error500InternalServerError((&common.UserMappingError{Err: err}).Error())
 	}
@@ -347,6 +352,12 @@ func (h *UserHandler) DeleteUser(ctx context.Context, input *DeleteUserInput) (*
 	}
 
 	if err := h.userService.DeleteUser(ctx, input.UserID); err != nil {
+		if errors.Is(err, services.ErrCannotRemoveLastAdmin) {
+			return nil, huma.Error409Conflict(services.ErrCannotRemoveLastAdmin.Error())
+		}
+		if errors.Is(err, services.ErrUserNotFound) {
+			return nil, huma.Error404NotFound((&common.UserNotFoundError{}).Error())
+		}
 		return nil, huma.Error500InternalServerError((&common.UserDeletionError{Err: err}).Error())
 	}
 

--- a/backend/internal/huma/handlers/users_test.go
+++ b/backend/internal/huma/handlers/users_test.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	humamw "github.com/getarcaneapp/arcane/backend/internal/huma/middleware"
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/internal/services"
+	usertypes "github.com/getarcaneapp/arcane/types/user"
+	glsqlite "github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/getarcaneapp/arcane/backend/internal/database"
+)
+
+func setupUserHandlerTestDB(t *testing.T) *database.DB {
+	t.Helper()
+
+	db, err := gorm.Open(glsqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}))
+
+	return &database.DB{DB: db}
+}
+
+func createHandlerTestUser(t *testing.T, svc *services.UserService, id, username string, roles models.StringSlice) *models.User {
+	t.Helper()
+
+	user := &models.User{
+		BaseModel: models.BaseModel{ID: id},
+		Username:  username,
+		Roles:     roles,
+	}
+
+	created, err := svc.CreateUser(context.Background(), user)
+	require.NoError(t, err)
+
+	return created
+}
+
+func adminContext() context.Context {
+	return context.WithValue(context.Background(), humamw.ContextKeyUserIsAdmin, true)
+}
+
+func TestDeleteUserReturnsConflictForLastAdmin(t *testing.T) {
+	db := setupUserHandlerTestDB(t)
+	userSvc := services.NewUserService(db)
+	handler := &UserHandler{userService: userSvc}
+	admin := createHandlerTestUser(t, userSvc, "admin-1", "arcane", models.StringSlice{"admin"})
+
+	_, err := handler.DeleteUser(adminContext(), &DeleteUserInput{UserID: admin.ID})
+	require.Error(t, err)
+
+	var statusErr huma.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	require.Equal(t, http.StatusConflict, statusErr.GetStatus())
+	require.Contains(t, statusErr.Error(), services.ErrCannotRemoveLastAdmin.Error())
+}
+
+func TestUpdateUserReturnsConflictWhenRemovingLastAdminRole(t *testing.T) {
+	db := setupUserHandlerTestDB(t)
+	userSvc := services.NewUserService(db)
+	handler := &UserHandler{userService: userSvc}
+	admin := createHandlerTestUser(t, userSvc, "admin-1", "arcane", models.StringSlice{"ADMIN"})
+
+	_, err := handler.UpdateUser(adminContext(), &UpdateUserInput{
+		UserID: admin.ID,
+		Body: usertypes.UpdateUser{
+			Roles: []string{"user"},
+		},
+	})
+	require.Error(t, err)
+
+	var statusErr huma.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	require.Equal(t, http.StatusConflict, statusErr.GetStatus())
+	require.Contains(t, statusErr.Error(), services.ErrCannotRemoveLastAdmin.Error())
+}

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -44,6 +44,8 @@ type UserService struct {
 	argon2Params *Argon2Params
 }
 
+var ErrCannotRemoveLastAdmin = errors.New("cannot remove the last admin user")
+
 func NewUserService(db *database.DB) *UserService {
 	return &UserService{
 		db:           db,
@@ -188,6 +190,27 @@ func (s *UserService) GetUserByEmail(ctx context.Context, email string) (*models
 
 func (s *UserService) UpdateUser(ctx context.Context, user *models.User) (*models.User, error) {
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing models.User
+		if err := tx.
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ?", user.ID).
+			First(&existing).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrUserNotFound
+			}
+			return fmt.Errorf("failed to load user: %w", err)
+		}
+
+		if userHasRoleInternal(existing.Roles, "admin") && !userHasRoleInternal(user.Roles, "admin") {
+			remainingAdmins, err := s.remainingAdminCountExcludingUserInternal(tx, user.ID)
+			if err != nil {
+				return err
+			}
+			if remainingAdmins == 0 {
+				return ErrCannotRemoveLastAdmin
+			}
+		}
+
 		if err := tx.Save(user).Error; err != nil {
 			return fmt.Errorf("failed to update user: %w", err)
 		}
@@ -292,6 +315,27 @@ func (s *UserService) CreateDefaultAdmin(ctx context.Context) error {
 
 func (s *UserService) DeleteUser(ctx context.Context, id string) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing models.User
+		if err := tx.
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ?", id).
+			First(&existing).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrUserNotFound
+			}
+			return fmt.Errorf("failed to load user: %w", err)
+		}
+
+		if userHasRoleInternal(existing.Roles, "admin") {
+			remainingAdmins, err := s.remainingAdminCountExcludingUserInternal(tx, id)
+			if err != nil {
+				return err
+			}
+			if remainingAdmins == 0 {
+				return ErrCannotRemoveLastAdmin
+			}
+		}
+
 		if err := tx.Delete(&models.User{}, "id = ?", id).Error; err != nil {
 			return fmt.Errorf("failed to delete user: %w", err)
 		}
@@ -340,25 +384,54 @@ func (s *UserService) ListUsersPaginated(ctx context.Context, params pagination.
 		return nil, pagination.Response{}, fmt.Errorf("failed to paginate users: %w", err)
 	}
 
-	result := make([]user.User, len(users))
-	for i, u := range users {
-		result[i] = toUserResponseDto(u)
+	result, err := s.toUserResponseDtosInternal(ctx, users)
+	if err != nil {
+		return nil, pagination.Response{}, err
 	}
 
 	return result, paginationResp, nil
 }
 
-func toUserResponseDto(u models.User) user.User {
+func (s *UserService) ToUserResponseDto(ctx context.Context, u models.User) (user.User, error) {
+	if !userHasRoleInternal(u.Roles, "admin") {
+		return toUserResponseDtoInternal(u, 0), nil
+	}
+
+	adminCount, err := s.adminUserCountInternal(ctx)
+	if err != nil {
+		return user.User{}, err
+	}
+
+	return toUserResponseDtoInternal(u, adminCount), nil
+}
+
+func (s *UserService) toUserResponseDtosInternal(ctx context.Context, users []models.User) ([]user.User, error) {
+	adminCount, err := s.adminUserCountInternal(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]user.User, len(users))
+	for i, u := range users {
+		result[i] = toUserResponseDtoInternal(u, adminCount)
+	}
+
+	return result, nil
+}
+
+func toUserResponseDtoInternal(u models.User, adminCount int) user.User {
 	return user.User{
-		ID:            u.ID,
-		Username:      u.Username,
-		DisplayName:   u.DisplayName,
-		Email:         u.Email,
-		Roles:         u.Roles,
-		OidcSubjectId: u.OidcSubjectId,
-		Locale:        u.Locale,
-		CreatedAt:     u.CreatedAt.Format("2006-01-02T15:04:05.999999Z"),
-		UpdatedAt:     u.UpdatedAt.Format("2006-01-02T15:04:05.999999Z"),
+		ID:                     u.ID,
+		Username:               u.Username,
+		DisplayName:            u.DisplayName,
+		Email:                  u.Email,
+		Roles:                  u.Roles,
+		CanDelete:              !userHasRoleInternal(u.Roles, "admin") || adminCount > 1,
+		OidcSubjectId:          u.OidcSubjectId,
+		Locale:                 u.Locale,
+		RequiresPasswordChange: u.RequiresPasswordChange,
+		CreatedAt:              u.CreatedAt.Format("2006-01-02T15:04:05.999999Z"),
+		UpdatedAt:              u.UpdatedAt.Format("2006-01-02T15:04:05.999999Z"),
 	}
 }
 
@@ -375,4 +448,50 @@ func (s *UserService) getUserInternal(ctx context.Context, userID string, tx *go
 		First(&user).
 		Error
 	return &user, err
+}
+
+func (s *UserService) remainingAdminCountExcludingUserInternal(tx *gorm.DB, excludedUserID string) (int, error) {
+	var count int64
+	if err := s.adminUsersScopeInternal(tx.Model(&models.User{}).Where("id <> ?", excludedUserID)).Count(&count).Error; err != nil {
+		return 0, fmt.Errorf("failed to count remaining admin users: %w", err)
+	}
+
+	return int(count), nil
+}
+
+func userHasRoleInternal(roles models.StringSlice, role string) bool {
+	for _, currentRole := range roles {
+		if strings.EqualFold(currentRole, role) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (s *UserService) adminUserCountInternal(ctx context.Context) (int, error) {
+	var count int64
+	if err := s.adminUsersScopeInternal(s.db.WithContext(ctx).Model(&models.User{})).Count(&count).Error; err != nil {
+		return 0, fmt.Errorf("failed to count admin users: %w", err)
+	}
+
+	return int(count), nil
+}
+
+func (s *UserService) adminUsersScopeInternal(query *gorm.DB) *gorm.DB {
+	switch s.db.Name() {
+	case "sqlite":
+		return query.Where(
+			"EXISTS (SELECT 1 FROM json_each(users.roles) WHERE lower(json_each.value) = ?)",
+			"admin",
+		)
+	case "postgres":
+		return query.Where(
+			"EXISTS (SELECT 1 FROM jsonb_array_elements_text(users.roles::jsonb) AS role WHERE lower(role) = ?)",
+			"admin",
+		)
+	default:
+		slog.Warn("Using LIKE-based admin role query fallback for unsupported database dialect", "dialect", s.db.Name())
+		return query.Where("LOWER(roles) LIKE ?", `%\"admin\"%`)
+	}
 }

--- a/backend/internal/services/user_service_test.go
+++ b/backend/internal/services/user_service_test.go
@@ -1,0 +1,130 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/internal/utils/pagination"
+	"github.com/stretchr/testify/require"
+)
+
+func createTestUser(t *testing.T, svc *UserService, id, username string, roles models.StringSlice) *models.User {
+	t.Helper()
+
+	user := &models.User{
+		BaseModel: models.BaseModel{ID: id},
+		Username:  username,
+		Roles:     roles,
+	}
+
+	created, err := svc.CreateUser(context.Background(), user)
+	require.NoError(t, err)
+
+	return created
+}
+
+func TestDeleteUserRejectsDeletingOnlyAdmin(t *testing.T) {
+	db := setupAuthServiceTestDB(t)
+	svc := NewUserService(db)
+	ctx := context.Background()
+
+	admin := createTestUser(t, svc, "admin-1", "arcane", models.StringSlice{"Admin"})
+
+	err := svc.DeleteUser(ctx, admin.ID)
+	require.ErrorIs(t, err, ErrCannotRemoveLastAdmin)
+
+	stillThere, err := svc.GetUserByID(ctx, admin.ID)
+	require.NoError(t, err)
+	require.Equal(t, admin.ID, stillThere.ID)
+}
+
+func TestDeleteUserAllowsDeletingNonAdmin(t *testing.T) {
+	db := setupAuthServiceTestDB(t)
+	svc := NewUserService(db)
+	ctx := context.Background()
+
+	createTestUser(t, svc, "admin-1", "arcane", models.StringSlice{"admin"})
+	nonAdmin := createTestUser(t, svc, "user-1", "user", models.StringSlice{"user"})
+
+	err := svc.DeleteUser(ctx, nonAdmin.ID)
+	require.NoError(t, err)
+
+	_, err = svc.GetUserByID(ctx, nonAdmin.ID)
+	require.ErrorIs(t, err, ErrUserNotFound)
+}
+
+func TestDeleteUserAllowsDeletingAdminWhenAnotherAdminExists(t *testing.T) {
+	db := setupAuthServiceTestDB(t)
+	svc := NewUserService(db)
+	ctx := context.Background()
+
+	adminToDelete := createTestUser(t, svc, "admin-1", "arcane", models.StringSlice{"Admin"})
+	createTestUser(t, svc, "admin-2", "backup", models.StringSlice{"admin"})
+
+	err := svc.DeleteUser(ctx, adminToDelete.ID)
+	require.NoError(t, err)
+
+	_, err = svc.GetUserByID(ctx, adminToDelete.ID)
+	require.ErrorIs(t, err, ErrUserNotFound)
+}
+
+func TestUpdateUserRejectsRemovingAdminFromOnlyAdmin(t *testing.T) {
+	db := setupAuthServiceTestDB(t)
+	svc := NewUserService(db)
+	ctx := context.Background()
+
+	admin := createTestUser(t, svc, "admin-1", "arcane", models.StringSlice{"ADMIN"})
+	admin.Roles = models.StringSlice{"user"}
+
+	_, err := svc.UpdateUser(ctx, admin)
+	require.ErrorIs(t, err, ErrCannotRemoveLastAdmin)
+
+	persisted, err := svc.GetUserByID(ctx, admin.ID)
+	require.NoError(t, err)
+	require.Equal(t, models.StringSlice{"ADMIN"}, persisted.Roles)
+}
+
+func TestUpdateUserAllowsRemovingAdminWhenAnotherAdminExists(t *testing.T) {
+	db := setupAuthServiceTestDB(t)
+	svc := NewUserService(db)
+	ctx := context.Background()
+
+	admin := createTestUser(t, svc, "admin-1", "arcane", models.StringSlice{"admin"})
+	createTestUser(t, svc, "admin-2", "backup", models.StringSlice{"ADMIN"})
+
+	admin.Roles = models.StringSlice{"user"}
+
+	updated, err := svc.UpdateUser(ctx, admin)
+	require.NoError(t, err)
+	require.Equal(t, models.StringSlice{"user"}, updated.Roles)
+
+	persisted, err := svc.GetUserByID(ctx, admin.ID)
+	require.NoError(t, err)
+	require.Equal(t, models.StringSlice{"user"}, persisted.Roles)
+}
+
+func TestListUsersPaginatedSetsCanDeleteFromGlobalAdminCount(t *testing.T) {
+	db := setupAuthServiceTestDB(t)
+	svc := NewUserService(db)
+	ctx := context.Background()
+
+	lastAdmin := createTestUser(t, svc, "admin-1", "arcane", models.StringSlice{"admin"})
+	nonAdmin := createTestUser(t, svc, "user-1", "user", models.StringSlice{"user"})
+
+	users, _, err := svc.ListUsersPaginated(ctx, pagination.QueryParams{
+		PaginationParams: pagination.PaginationParams{Start: 0, Limit: 20},
+		SortParams:       pagination.SortParams{Sort: "Username", Order: pagination.SortOrder("asc")},
+		Filters:          map[string]string{},
+	})
+	require.NoError(t, err)
+	require.Len(t, users, 2)
+
+	canDeleteByID := make(map[string]bool, len(users))
+	for _, user := range users {
+		canDeleteByID[user.ID] = user.CanDelete
+	}
+
+	require.False(t, canDeleteByID[lastAdmin.ID])
+	require.True(t, canDeleteByID[nonAdmin.ID])
+}

--- a/frontend/src/lib/types/user.type.ts
+++ b/frontend/src/lib/types/user.type.ts
@@ -7,6 +7,7 @@ export type User = {
 	displayName?: string;
 	email?: string;
 	roles: string[];
+	canDelete?: boolean;
 	createdAt: string;
 	lastLogin?: string;
 	updatedAt?: string;

--- a/frontend/src/routes/(app)/settings/users/user-table.svelte
+++ b/frontend/src/routes/(app)/settings/users/user-table.svelte
@@ -33,8 +33,18 @@
 		removing: false
 	});
 
+	function canDeleteUser(user: User) {
+		return user.canDelete !== false;
+	}
+
+	const selectedUsers = $derived.by(() =>
+		(selectedIds ?? []).map((id) => users.data.find((user) => user.id === id)).filter((user): user is User => Boolean(user))
+	);
+
+	const hasProtectedSelection = $derived.by(() => selectedUsers.some((user) => !canDeleteUser(user)));
+
 	async function handleDeleteSelected() {
-		if (selectedIds.length === 0) return;
+		if (selectedIds.length === 0 || hasProtectedSelection) return;
 
 		openConfirmDialog({
 			title: m.users_delete_selected_title({ count: selectedIds.length }),
@@ -82,8 +92,10 @@
 		});
 	}
 
-	async function handleDeleteUser(userId: string, username: string) {
-		const safeName = username?.trim() || m.common_unknown();
+	async function handleDeleteUser(user: User) {
+		if (!canDeleteUser(user)) return;
+
+		const safeName = user.username?.trim() || m.common_unknown();
 		openConfirmDialog({
 			title: m.users_delete_user_title({ username: safeName }),
 			message: m.users_delete_user_message({ username: safeName }),
@@ -93,7 +105,7 @@
 				action: async () => {
 					isLoading.removing = true;
 					handleApiResultWithCallbacks({
-						result: await tryCatch(userService.delete(userId)),
+						result: await tryCatch(userService.delete(user.id)),
 						message: m.users_delete_user_failed({ username: safeName }),
 						setLoadingState: (value) => (isLoading.removing = value),
 						onSuccess: async () => {
@@ -136,7 +148,7 @@
 			action: 'remove',
 			onClick: handleDeleteSelected,
 			loading: isLoading.removing,
-			disabled: isLoading.removing,
+			disabled: isLoading.removing || hasProtectedSelection,
 			icon: TrashIcon
 		}
 	]);
@@ -209,7 +221,11 @@
 					<DropdownMenu.Separator />
 				{/if}
 
-				<DropdownMenu.Item variant="destructive" onclick={() => handleDeleteUser(item.id, item.username)}>
+				<DropdownMenu.Item
+					variant="destructive"
+					disabled={!canDeleteUser(item) || isLoading.removing}
+					onclick={() => handleDeleteUser(item)}
+				>
 					<TrashIcon class="size-4" />
 					{m.common_delete()}
 				</DropdownMenu.Item>

--- a/types/user/user.go
+++ b/types/user/user.go
@@ -27,6 +27,7 @@ type User struct {
 	DisplayName            *string  `json:"displayName,omitempty" doc:"Display name of the user" example:"John Doe"`
 	Email                  *string  `json:"email,omitempty" doc:"Email address of the user" example:"john@example.com"`
 	Roles                  []string `json:"roles" doc:"Roles assigned to the user" example:"[\"user\", \"admin\"]"`
+	CanDelete              bool     `json:"canDelete" doc:"Whether the user can currently be deleted"`
 	OidcSubjectId          *string  `json:"oidcSubjectId,omitempty" doc:"OIDC subject identifier for SSO users"`
 	Locale                 *string  `json:"locale,omitempty" doc:"Locale preference of the user" example:"en-US"`
 	CreatedAt              string   `json:"createdAt,omitempty" doc:"Date and time when the user was created"`


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2004

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents deletion of the last admin user by adding transactional guards in `DeleteUser` and `UpdateUser`, exposing a `canDelete` hint on all user responses, and disabling the delete UI controls when the hint is false.

**Key changes:**
- `DeleteUser` and `UpdateUser` now open a `SELECT ... FOR UPDATE` on the target row inside the transaction and return `ErrCannotRemoveLastAdmin` (HTTP 409) when the operation would leave zero admins
- `ToUserResponseDto` / `toUserResponseDtoInternal` replace `mapper.MapOne` for single-record responses and add the `CanDelete` field, computed from an admin-count query scoped to SQLite and Postgres dialects
- Frontend adds `canDeleteUser`, `hasProtectedSelection`, and matching guards on the bulk-delete action and the per-row dropdown
- Handler and service tests cover the last-admin conflict and the happy-path variants

**Issue found:**
- `toUserResponseDtoInternal` does not map `RequiresPasswordChange` — previously `mapper.MapOne` (backed by `jinzhu/copier`) copied all matching fields by name, so `requiresPasswordChange` was returned correctly from `CreateUser`, `GetUser`, and `UpdateUser`. After this PR those three endpoints will always return `"requiresPasswordChange": false`, breaking forced-password-change flows.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge after fixing the RequiresPasswordChange regression in toUserResponseDtoInternal.
- The core admin-protection logic is correct and well-tested. The main concern is a regression introduced by replacing mapper.MapOne with the hand-written toUserResponseDtoInternal: the RequiresPasswordChange field is no longer mapped, causing CreateUser, GetUser, and UpdateUser to always return false for that flag. Until fixed this breaks forced-password-change flows.
- backend/internal/services/user_service.go — toUserResponseDtoInternal is missing the RequiresPasswordChange field mapping.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/user_service.go | Adds admin-guard logic to DeleteUser and UpdateUser transactions, plus new helper functions for admin counting and role detection. Contains a regression: RequiresPasswordChange is omitted from toUserResponseDtoInternal, breaking single-record API responses. |
| backend/internal/huma/handlers/users.go | Replaces mapper.MapOne with ToUserResponseDto for single-record responses, and adds ErrCannotRemoveLastAdmin / ErrUserNotFound error handling in UpdateUser and DeleteUser. The mapper.MapOne replacement is the source of the RequiresPasswordChange regression. |
| backend/internal/huma/handlers/users_test.go | New handler-level tests for the last-admin conflict scenarios on both DeleteUser and UpdateUser. Tests are well-structured and cover the primary cases. |
| backend/internal/services/user_service_test.go | New service-level tests covering all major paths: reject deletion of last admin, allow deletion of non-admin, allow deletion when another admin exists, reject admin role removal from last admin, and CanDelete flag in list responses. Good coverage. |
| frontend/src/routes/(app)/settings/users/user-table.svelte | Adds canDeleteUser helper, hasProtectedSelection derived state, disables bulk-delete when a protected user is selected, and guards handleDeleteUser early-return. Changes are clean and consistent. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant H as UserHandler
    participant S as UserService
    participant DB as Database

    C->>H: DELETE /users/:id
    H->>S: DeleteUser(ctx, id)
    S->>DB: BEGIN TRANSACTION
    S->>DB: SELECT ... FOR UPDATE WHERE id = ?
    DB-->>S: existing user
    alt user is admin
        S->>DB: COUNT admins WHERE id <> ?
        DB-->>S: remainingAdmins
        alt remainingAdmins == 0
            S-->>H: ErrCannotRemoveLastAdmin
            H-->>C: 409 Conflict
        else remainingAdmins > 0
            S->>DB: DELETE WHERE id = ?
            S->>DB: COMMIT
            S-->>H: nil
            H-->>C: 200 OK
        end
    else user is not admin
        S->>DB: DELETE WHERE id = ?
        S->>DB: COMMIT
        S-->>H: nil
        H-->>C: 200 OK
    end

    C->>H: PUT /users/:id (remove admin role)
    H->>S: GetUserByID(ctx, id)
    DB-->>S: userModel
    H->>S: UpdateUser(ctx, userModel)
    S->>DB: BEGIN TRANSACTION
    S->>DB: SELECT ... FOR UPDATE WHERE id = ?
    DB-->>S: existing user
    alt existing is admin AND new roles exclude admin
        S->>DB: COUNT admins WHERE id <> ?
        DB-->>S: remainingAdmins
        alt remainingAdmins == 0
            S-->>H: ErrCannotRemoveLastAdmin
            H-->>C: 409 Conflict
        else remainingAdmins > 0
            S->>DB: SAVE user
            S->>DB: COMMIT
            S-->>H: updatedUser
            H->>S: ToUserResponseDto(ctx, updatedUser)
            S->>DB: COUNT admins (for CanDelete hint)
            DB-->>S: adminCount
            H-->>C: 200 OK (canDelete computed)
        end
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/internal/services/user_service.go`, line 422-435 ([link](https://github.com/getarcaneapp/arcane/blob/76f0f09d0be1e51c4bf7aa3482564ba2214a45b4/backend/internal/services/user_service.go#L422-L435)) 

   **`RequiresPasswordChange` dropped from single-record responses**

   `toUserResponseDtoInternal` does not map `RequiresPasswordChange`. Before this PR, the `CreateUser`, `GetUser`, and `UpdateUser` handlers all used `mapper.MapOne[*models.User, user.User]`, which relies on `jinzhu/copier` and copies all matching fields by name — including `RequiresPasswordChange bool`. By switching those three handlers to `h.userService.ToUserResponseDto` → `toUserResponseDtoInternal`, the `requiresPasswordChange` field will now always serialize as `false` for single-record responses, even when the underlying user model has `RequiresPasswordChange: true`.

   If the application forces password changes after creation or admin resets, the front-end can no longer detect this condition from `GET /users/:id`, `POST /users`, or `PUT /users/:id` responses.

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fuser_service.go%3A422-435%0A**%60RequiresPasswordChange%60%20dropped%20from%20single-record%20responses**%0A%0A%60toUserResponseDtoInternal%60%20does%20not%20map%20%60RequiresPasswordChange%60.%20Before%20this%20PR%2C%20the%20%60CreateUser%60%2C%20%60GetUser%60%2C%20and%20%60UpdateUser%60%20handlers%20all%20used%20%60mapper.MapOne%5B*models.User%2C%20user.User%5D%60%2C%20which%20relies%20on%20%60jinzhu%2Fcopier%60%20and%20copies%20all%20matching%20fields%20by%20name%20%E2%80%94%20including%20%60RequiresPasswordChange%20bool%60.%20By%20switching%20those%20three%20handlers%20to%20%60h.userService.ToUserResponseDto%60%20%E2%86%92%20%60toUserResponseDtoInternal%60%2C%20the%20%60requiresPasswordChange%60%20field%20will%20now%20always%20serialize%20as%20%60false%60%20for%20single-record%20responses%2C%20even%20when%20the%20underlying%20user%20model%20has%20%60RequiresPasswordChange%3A%20true%60.%0A%0AIf%20the%20application%20forces%20password%20changes%20after%20creation%20or%20admin%20resets%2C%20the%20front-end%20can%20no%20longer%20detect%20this%20condition%20from%20%60GET%20%2Fusers%2F%3Aid%60%2C%20%60POST%20%2Fusers%60%2C%20or%20%60PUT%20%2Fusers%2F%3Aid%60%20responses.%0A%0A%60%60%60suggestion%0Afunc%20toUserResponseDtoInternal%28u%20models.User%2C%20adminCount%20int%29%20user.User%20%7B%0A%09return%20user.User%7B%0A%09%09ID%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20u.ID%2C%0A%09%09Username%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20u.Username%2C%0A%09%09DisplayName%3A%20%20%20%20%20%20%20%20%20%20%20%20u.DisplayName%2C%0A%09%09Email%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20u.Email%2C%0A%09%09Roles%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20u.Roles%2C%0A%09%09CanDelete%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20!userHasRoleInternal%28u.Roles%2C%20%22admin%22%29%20%7C%7C%20adminCount%20%3E%201%2C%0A%09%09OidcSubjectId%3A%20%20%20%20%20%20%20%20%20%20u.OidcSubjectId%2C%0A%09%09Locale%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20u.Locale%2C%0A%09%09RequiresPasswordChange%3A%20u.RequiresPasswordChange%2C%0A%09%09CreatedAt%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20u.CreatedAt.Format%28%222006-01-02T15%3A04%3A05.999999Z%22%29%2C%0A%09%09UpdatedAt%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20u.UpdatedAt.Format%28%222006-01-02T15%3A04%3A05.999999Z%22%29%2C%0A%09%7D%0A%7D%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/user_service.go
Line: 422-435

Comment:
**`RequiresPasswordChange` dropped from single-record responses**

`toUserResponseDtoInternal` does not map `RequiresPasswordChange`. Before this PR, the `CreateUser`, `GetUser`, and `UpdateUser` handlers all used `mapper.MapOne[*models.User, user.User]`, which relies on `jinzhu/copier` and copies all matching fields by name — including `RequiresPasswordChange bool`. By switching those three handlers to `h.userService.ToUserResponseDto` → `toUserResponseDtoInternal`, the `requiresPasswordChange` field will now always serialize as `false` for single-record responses, even when the underlying user model has `RequiresPasswordChange: true`.

If the application forces password changes after creation or admin resets, the front-end can no longer detect this condition from `GET /users/:id`, `POST /users`, or `PUT /users/:id` responses.

```suggestion
func toUserResponseDtoInternal(u models.User, adminCount int) user.User {
	return user.User{
		ID:                     u.ID,
		Username:               u.Username,
		DisplayName:            u.DisplayName,
		Email:                  u.Email,
		Roles:                  u.Roles,
		CanDelete:              !userHasRoleInternal(u.Roles, "admin") || adminCount > 1,
		OidcSubjectId:          u.OidcSubjectId,
		Locale:                 u.Locale,
		RequiresPasswordChange: u.RequiresPasswordChange,
		CreatedAt:              u.CreatedAt.Format("2006-01-02T15:04:05.999999Z"),
		UpdatedAt:              u.UpdatedAt.Format("2006-01-02T15:04:05.999999Z"),
	}
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 76f0f09</sub>

<!-- /greptile_comment -->