### PR TITLE
fix: containers grouped by projects split between pages

### DIFF
--- a/backend/internal/huma/handlers/containers.go
+++ b/backend/internal/huma/handlers/containers.go
@@ -26,10 +26,11 @@ type ContainerHandler struct {
 
 // Paginated response
 type ContainerPaginatedResponse struct {
-	Success    bool                        `json:"success"`
-	Data       []containertypes.Summary    `json:"data"`
-	Counts     containertypes.StatusCounts `json:"counts"`
-	Pagination base.PaginationResponse     `json:"pagination"`
+	Success    bool                          `json:"success"`
+	Data       []containertypes.Summary      `json:"data"`
+	Groups     []containertypes.SummaryGroup `json:"groups,omitempty"`
+	Counts     containertypes.StatusCounts   `json:"counts"`
+	Pagination base.PaginationResponse       `json:"pagination"`
 }
 
 type ListContainersInput struct {
@@ -39,6 +40,7 @@ type ListContainersInput struct {
 	Order           string `query:"order" default:"asc" doc:"Sort direction"`
 	Start           int    `query:"start" default:"0" doc:"Start index"`
 	Limit           int    `query:"limit" default:"20" doc:"Limit"`
+	GroupBy         string `query:"groupBy" doc:"Optional grouping mode (for example: project)"`
 	IncludeInternal bool   `query:"includeInternal" default:"false" doc:"Include internal containers"`
 	Updates         string `query:"updates" doc:"Filter by update status (has_update, up_to_date, error, unknown)"`
 }
@@ -222,7 +224,7 @@ func (h *ContainerHandler) ListContainers(ctx context.Context, input *ListContai
 		Filters: filters,
 	}
 
-	containers, paginationResp, counts, err := h.containerService.ListContainersPaginated(ctx, params, true, input.IncludeInternal)
+	result, err := h.containerService.ListContainersPaginated(ctx, params, true, input.IncludeInternal, input.GroupBy)
 	if err != nil {
 		return nil, huma.Error500InternalServerError((&common.ContainerListError{Err: err}).Error())
 	}
@@ -230,14 +232,15 @@ func (h *ContainerHandler) ListContainers(ctx context.Context, input *ListContai
 	return &ListContainersOutput{
 		Body: ContainerPaginatedResponse{
 			Success: true,
-			Data:    containers,
-			Counts:  counts,
+			Data:    result.Items,
+			Groups:  result.Groups,
+			Counts:  result.Counts,
 			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
+				TotalPages:      result.Pagination.TotalPages,
+				TotalItems:      result.Pagination.TotalItems,
+				CurrentPage:     result.Pagination.CurrentPage,
+				ItemsPerPage:    result.Pagination.ItemsPerPage,
+				GrandTotalItems: result.Pagination.GrandTotalItems,
 			},
 		},
 	}, nil

--- a/backend/internal/services/container_service.go
+++ b/backend/internal/services/container_service.go
@@ -35,6 +35,18 @@ type ContainerService struct {
 	settingsService *SettingsService
 }
 
+const (
+	containerGroupByProject = "project"
+	containerNoProjectGroup = "No Project"
+)
+
+type ContainerListResult struct {
+	Items      []containertypes.Summary
+	Groups     []containertypes.SummaryGroup
+	Pagination pagination.Response
+	Counts     containertypes.StatusCounts
+}
+
 func NewContainerService(db *database.DB, eventService *EventService, dockerService *DockerClientService, imageService *ImageService, settingsService *SettingsService) *ContainerService {
 	return &ContainerService{
 		db:              db,
@@ -436,15 +448,21 @@ func (s *ContainerService) readAllLogs(logs io.ReadCloser, logsChan chan<- strin
 	return nil
 }
 
-func (s *ContainerService) ListContainersPaginated(ctx context.Context, params pagination.QueryParams, includeAll bool, includeInternal bool) ([]containertypes.Summary, pagination.Response, containertypes.StatusCounts, error) {
+func (s *ContainerService) ListContainersPaginated(
+	ctx context.Context,
+	params pagination.QueryParams,
+	includeAll bool,
+	includeInternal bool,
+	groupBy string,
+) (ContainerListResult, error) {
 	dockerClient, err := s.dockerService.GetClient(ctx)
 	if err != nil {
-		return nil, pagination.Response{}, containertypes.StatusCounts{}, fmt.Errorf("failed to connect to Docker: %w", err)
+		return ContainerListResult{}, fmt.Errorf("failed to connect to Docker: %w", err)
 	}
 
 	containerList, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: includeAll})
 	if err != nil {
-		return nil, pagination.Response{}, containertypes.StatusCounts{}, fmt.Errorf("failed to list Docker containers: %w", err)
+		return ContainerListResult{}, fmt.Errorf("failed to list Docker containers: %w", err)
 	}
 	dockerContainers := containerList.Items
 
@@ -454,11 +472,149 @@ func (s *ContainerService) ListContainersPaginated(ctx context.Context, params p
 	items := s.buildContainerSummaries(dockerContainers, updateInfoMap)
 
 	config := s.buildContainerPaginationConfig()
-	result := pagination.SearchOrderAndPaginate(items, params, config)
 	counts := s.calculateContainerStatusCounts(items)
+
+	if groupBy == containerGroupByProject {
+		ungroupedParams := params
+		ungroupedParams.Start = 0
+		ungroupedParams.Limit = -1
+
+		result := pagination.SearchOrderAndPaginate(items, ungroupedParams, config)
+		groups, paginationResp := paginateContainerProjectGroupsInternal(result, params)
+		return ContainerListResult{
+			Items:      flattenContainerProjectGroupsInternal(groups),
+			Groups:     groups,
+			Pagination: paginationResp,
+			Counts:     counts,
+		}, nil
+	}
+
+	result := pagination.SearchOrderAndPaginate(items, params, config)
 	paginationResp := pagination.BuildResponseFromFilterResult(result, params)
 
-	return result.Items, paginationResp, counts, nil
+	return ContainerListResult{
+		Items:      result.Items,
+		Pagination: paginationResp,
+		Counts:     counts,
+	}, nil
+}
+
+func paginateContainerProjectGroupsInternal(
+	result pagination.FilterResult[containertypes.Summary],
+	params pagination.QueryParams,
+) ([]containertypes.SummaryGroup, pagination.Response) {
+	groups := groupContainersByProjectInternal(result.Items)
+	groupedItems := flattenContainerProjectGroupsInternal(groups)
+	totalCount := len(groupedItems)
+
+	if params.Limit <= 0 {
+		return groups, pagination.Response{
+			TotalPages:      1,
+			TotalItems:      int64(totalCount),
+			CurrentPage:     1,
+			ItemsPerPage:    totalCount,
+			GrandTotalItems: result.TotalAvailable,
+		}
+	}
+
+	pages := partitionContainerProjectPagesInternal(groups, params.Limit)
+	requestedPage := 1
+	if params.Limit > 0 {
+		requestedPage = (params.Start / params.Limit) + 1
+	}
+
+	if requestedPage < 1 {
+		requestedPage = 1
+	}
+
+	totalPages := len(pages)
+	if totalPages == 0 {
+		totalPages = 1
+	}
+	if requestedPage > totalPages {
+		requestedPage = totalPages
+	}
+
+	pageGroups := []containertypes.SummaryGroup{}
+	if len(pages) > 0 {
+		pageGroups = pages[requestedPage-1]
+	}
+
+	return pageGroups, pagination.Response{
+		TotalPages:      int64(totalPages),
+		TotalItems:      int64(totalCount),
+		CurrentPage:     requestedPage,
+		ItemsPerPage:    params.Limit,
+		GrandTotalItems: result.TotalAvailable,
+	}
+}
+
+func groupContainersByProjectInternal(items []containertypes.Summary) []containertypes.SummaryGroup {
+	groups := make([]containertypes.SummaryGroup, 0)
+	groupIndexes := make(map[string]int)
+
+	for _, item := range items {
+		groupName := getContainerProjectNameInternal(item)
+		groupIndex, exists := groupIndexes[groupName]
+		if !exists {
+			groupIndex = len(groups)
+			groupIndexes[groupName] = groupIndex
+			groups = append(groups, containertypes.SummaryGroup{GroupName: groupName})
+		}
+
+		groups[groupIndex].Items = append(groups[groupIndex].Items, item)
+	}
+
+	return groups
+}
+
+func flattenContainerProjectGroupsInternal(groups []containertypes.SummaryGroup) []containertypes.Summary {
+	flattened := make([]containertypes.Summary, 0)
+	for _, group := range groups {
+		flattened = append(flattened, group.Items...)
+	}
+
+	return flattened
+}
+
+func partitionContainerProjectPagesInternal(groups []containertypes.SummaryGroup, limit int) [][]containertypes.SummaryGroup {
+	if len(groups) == 0 {
+		return [][]containertypes.SummaryGroup{{}}
+	}
+
+	pages := make([][]containertypes.SummaryGroup, 0)
+	currentPage := make([]containertypes.SummaryGroup, 0)
+	currentCount := 0
+
+	for _, group := range groups {
+		currentPage = append(currentPage, group)
+		currentCount += len(group.Items)
+
+		if currentCount >= limit {
+			pages = append(pages, currentPage)
+			currentPage = make([]containertypes.SummaryGroup, 0)
+			currentCount = 0
+		}
+	}
+
+	if len(currentPage) > 0 || len(pages) == 0 {
+		pages = append(pages, currentPage)
+	}
+
+	return pages
+}
+
+func getContainerProjectNameInternal(container containertypes.Summary) string {
+	if container.Labels == nil {
+		return containerNoProjectGroup
+	}
+
+	projectName := strings.TrimSpace(container.Labels["com.docker.compose.project"])
+	if projectName == "" {
+		return containerNoProjectGroup
+	}
+
+	return projectName
 }
 
 func filterInternalContainers(containers []container.Summary, includeInternal bool) []container.Summary {

--- a/backend/internal/services/container_service_test.go
+++ b/backend/internal/services/container_service_test.go
@@ -1,0 +1,86 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/getarcaneapp/arcane/backend/internal/utils/pagination"
+	containertypes "github.com/getarcaneapp/arcane/types/container"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPaginateContainerProjectGroupsKeepsProjectWhole(t *testing.T) {
+	items := []containertypes.Summary{
+		newGroupedContainerSummary("other-1", "other-1"),
+		newGroupedContainerSummary("other-2", "other-2"),
+		newGroupedContainerSummary("other-3", "other-3"),
+		newGroupedContainerSummary("other-4", "other-4"),
+		newGroupedContainerSummary("other-5", "other-5"),
+		newGroupedContainerSummary("other-6", "other-6"),
+		newGroupedContainerSummary("other-7", "other-7"),
+		newGroupedContainerSummary("other-8", "other-8"),
+		newGroupedContainerSummary("other-9", "other-9"),
+		newGroupedContainerSummary("other-10", "other-10"),
+		newGroupedContainerSummary("other-11", "other-11"),
+		newGroupedContainerSummary("other-12", "other-12"),
+		newGroupedContainerSummary("other-13", "other-13"),
+		newGroupedContainerSummary("other-14", "other-14"),
+		newGroupedContainerSummary("other-15", "other-15"),
+		newGroupedContainerSummary("other-16", "other-16"),
+		newGroupedContainerSummary("other-17", "other-17"),
+		newGroupedContainerSummary("other-18", "other-18"),
+		newGroupedContainerSummary("immich-server", "immich"),
+		newGroupedContainerSummary("immich-ml", "immich"),
+		newGroupedContainerSummary("immich-redis", "immich"),
+		newGroupedContainerSummary("immich-postgres", "immich"),
+	}
+
+	groupedItems, resp := paginateContainerProjectGroupsInternal(
+		pagination.FilterResult[containertypes.Summary]{Items: items, TotalCount: int64(len(items)), TotalAvailable: int64(len(items))},
+		pagination.QueryParams{PaginationParams: pagination.PaginationParams{Start: 0, Limit: 20}},
+	)
+
+	require.Len(t, groupedItems, 19)
+	require.Equal(t, int64(1), resp.TotalPages)
+	require.Equal(t, 1, resp.CurrentPage)
+	require.Equal(t, 20, resp.ItemsPerPage)
+	require.Equal(t, int64(22), resp.TotalItems)
+
+	projectCounts := make(map[string]int)
+	for _, group := range groupedItems {
+		projectCounts[group.GroupName] += len(group.Items)
+	}
+
+	require.Equal(t, 4, projectCounts["immich"])
+	require.Equal(t, 1, projectCounts["other-1"])
+	require.Equal(t, 1, projectCounts["other-18"])
+}
+
+func TestGroupContainersByProjectUsesNoProjectBucket(t *testing.T) {
+	groups := groupContainersByProjectInternal([]containertypes.Summary{
+		{ID: "1", Labels: map[string]string{"com.docker.compose.project": "alpha"}},
+		{ID: "2", Labels: map[string]string{}},
+		{ID: "3", Labels: nil},
+	})
+
+	require.Len(t, groups, 2)
+	require.Equal(t, "alpha", groups[0].GroupName)
+	require.Len(t, groups[0].Items, 1)
+	require.Equal(t, containerNoProjectGroup, groups[1].GroupName)
+	require.Len(t, groups[1].Items, 2)
+	require.Equal(t, containerNoProjectGroup, getContainerProjectNameInternal(groups[1].Items[0]))
+	require.Equal(t, containerNoProjectGroup, getContainerProjectNameInternal(groups[1].Items[1]))
+}
+
+func newGroupedContainerSummary(name string, project string) containertypes.Summary {
+	labels := map[string]string{}
+	if project != "" {
+		labels["com.docker.compose.project"] = project
+	}
+
+	return containertypes.Summary{
+		ID:     name,
+		Names:  []string{name},
+		Labels: labels,
+		State:  "running",
+	}
+}

--- a/frontend/src/lib/components/arcane-table/arcane-table.svelte
+++ b/frontend/src/lib/components/arcane-table/arcane-table.svelte
@@ -61,6 +61,7 @@
 		customTableView,
 		customSettings = $bindable<Record<string, unknown>>({}),
 		columnVisibility = $bindable<VisibilityState>({}),
+		groupedRows = null,
 		// Grouping props
 		groupBy,
 		groupIcon,
@@ -97,6 +98,7 @@
 		>;
 		customSettings?: Record<string, unknown>;
 		columnVisibility?: VisibilityState;
+		groupedRows?: GroupedData<TData>[] | null;
 		// Grouping props
 		groupBy?: (item: TData) => string;
 		groupIcon?: (groupName: string) => Component;
@@ -509,7 +511,8 @@
 	);
 
 	// Compute grouped rows when groupBy is provided
-	const groupedRows = $derived.by((): GroupedData<TData>[] | null => {
+	const effectiveGroupedRows = $derived.by((): GroupedData<TData>[] | null => {
+		if (groupedRows) return groupedRows;
 		if (!groupBy) return null;
 
 		const groups = new Map<string, TData[]>();
@@ -660,7 +663,7 @@
 				{table}
 				{selectedIds}
 				columnsCount={columnsDef.length}
-				{groupedRows}
+				groupedRows={effectiveGroupedRows}
 				{groupIcon}
 				{groupCollapsedState}
 				{selectionDisabled}
@@ -678,7 +681,7 @@
 					{table}
 					{mobileCard}
 					{mobileFieldVisibility}
-					{groupedRows}
+					groupedRows={effectiveGroupedRows}
 					{groupIcon}
 					{groupCollapsedState}
 					onGroupToggle={handleGroupToggle}
@@ -716,7 +719,7 @@
 				{table}
 				{selectedIds}
 				columnsCount={columnsDef.length}
-				{groupedRows}
+				groupedRows={effectiveGroupedRows}
 				{groupIcon}
 				{groupCollapsedState}
 				{selectionDisabled}
@@ -732,7 +735,7 @@
 				{table}
 				{mobileCard}
 				{mobileFieldVisibility}
-				{groupedRows}
+				groupedRows={effectiveGroupedRows}
 				{groupIcon}
 				{groupCollapsedState}
 				onGroupToggle={handleGroupToggle}

--- a/frontend/src/lib/services/container-service.ts
+++ b/frontend/src/lib/services/container-service.ts
@@ -3,29 +3,38 @@ import { environmentStore } from '$lib/stores/environment.store.svelte';
 import type {
 	ContainerStatusCounts,
 	ContainerSummaryDto,
+	ContainerSummaryGroupDto,
 	ContainerStats,
 	ContainerCreateRequest
 } from '$lib/types/container.type';
 import type { SearchPaginationSortRequest, Paginated } from '$lib/types/pagination.type';
 import { transformPaginationParams } from '$lib/utils/params.util';
 
-export type ContainersPaginatedResponse = Paginated<ContainerSummaryDto, ContainerStatusCounts>;
+export type ContainersPaginatedResponse = Paginated<ContainerSummaryDto, ContainerStatusCounts> & {
+	groups?: ContainerSummaryGroupDto[];
+};
+export type ContainerListRequestOptions = SearchPaginationSortRequest & {
+	groupByProject?: boolean;
+};
 
 export class ContainerService extends BaseAPIService {
 	private async resolveEnvironmentId(environmentId?: string): Promise<string> {
 		return environmentId ?? (await environmentStore.getCurrentEnvironmentId());
 	}
 
-	async getContainers(options?: SearchPaginationSortRequest): Promise<ContainersPaginatedResponse> {
+	async getContainers(options?: ContainerListRequestOptions): Promise<ContainersPaginatedResponse> {
 		const envId = await this.resolveEnvironmentId();
 		return this.getContainersForEnvironment(envId, options);
 	}
 
 	async getContainersForEnvironment(
 		environmentId: string,
-		options?: SearchPaginationSortRequest
+		options?: ContainerListRequestOptions
 	): Promise<ContainersPaginatedResponse> {
 		const params = transformPaginationParams(options);
+		if (options?.groupByProject) {
+			params.groupBy = 'project';
+		}
 		const res = await this.api.get(`/environments/${environmentId}/containers`, { params });
 		return res.data;
 	}

--- a/frontend/src/lib/types/container.type.ts
+++ b/frontend/src/lib/types/container.type.ts
@@ -75,6 +75,11 @@ export interface ContainerSummaryDto extends BaseContainer {
 	updateInfo?: ImageUpdateInfoDto;
 }
 
+export interface ContainerSummaryGroupDto {
+	groupName: string;
+	items: ContainerSummaryDto[];
+}
+
 export interface ContainerPorts {
 	ip?: string;
 	privatePort: number;

--- a/frontend/src/routes/(app)/containers/+page.svelte
+++ b/frontend/src/routes/(app)/containers/+page.svelte
@@ -9,9 +9,12 @@
 	import { ResourcePageLayout, type ActionButton, type StatCardConfig } from '$lib/layouts/index';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import type { ContainerCreateRequest, ContainerStatusCounts } from '$lib/types/container.type';
-	import { createMutation, createQuery } from '@tanstack/svelte-query';
+	import { createMutation } from '@tanstack/svelte-query';
 	import { BoxIcon } from '$lib/icons';
 	import { queryKeys } from '$lib/query/query-keys';
+	import type { SearchPaginationSortRequest } from '$lib/types/pagination.type';
+	import type { ContainerListRequestOptions } from '$lib/services/container-service';
+	import ContainerEnvironmentSync from './components/container-environment-sync.svelte';
 
 	let { data } = $props();
 
@@ -19,7 +22,10 @@
 	let selectedIds = $state<string[]>([]);
 	let isCreateDialogOpen = $state(false);
 	let containers = $state(untrack(() => data.containers));
+	let isRefreshing = $state(false);
 	const envId = $derived(environmentStore.selected?.id || '0');
+	let groupByProject = $state(false);
+	let hasSeenEnvironmentSync = $state(false);
 
 	const countsFallback: ContainerStatusCounts = {
 		runningContainers: 0,
@@ -27,18 +33,30 @@
 		totalContainers: 0
 	};
 
-	const containersQuery = createQuery(() => ({
-		queryKey: queryKeys.containers.list(envId, requestOptions),
-		queryFn: () => containerService.getContainersForEnvironment(envId, requestOptions),
-		initialData: data.containers
-	}));
+	function buildRequestOptions(options: SearchPaginationSortRequest = requestOptions): ContainerListRequestOptions {
+		return {
+			...options,
+			groupByProject
+		};
+	}
+
+	async function refreshContainers(options: ContainerListRequestOptions = buildRequestOptions()) {
+		isRefreshing = true;
+		try {
+			const next = await containerService.getContainersForEnvironment(envId, options);
+			containers = next;
+			return next;
+		} finally {
+			isRefreshing = false;
+		}
+	}
 
 	const checkUpdatesMutation = createMutation(() => ({
 		mutationKey: queryKeys.containers.checkUpdates(envId),
 		mutationFn: () => imageService.runAutoUpdate(),
 		onSuccess: async () => {
 			toast.success(m.containers_check_updates_success());
-			await containersQuery.refetch();
+			await refreshContainers();
 		},
 		onError: () => {
 			toast.error(m.containers_check_updates_failed());
@@ -50,7 +68,7 @@
 		mutationFn: (options: ContainerCreateRequest) => containerService.createContainer(options),
 		onSuccess: async () => {
 			toast.success(m.common_create_success({ resource: m.resource_container() }));
-			await containersQuery.refetch();
+			await refreshContainers();
 			isCreateDialogOpen = false;
 		},
 		onError: () => {
@@ -58,21 +76,31 @@
 		}
 	}));
 
-	$effect(() => {
-		if (containersQuery.data) {
-			containers = containersQuery.data;
+	function handleEnvironmentChange() {
+		if (!hasSeenEnvironmentSync) {
+			hasSeenEnvironmentSync = true;
+			return;
 		}
-	});
+
+		const nextOptions: SearchPaginationSortRequest = {
+			...requestOptions,
+			pagination: {
+				page: 1,
+				limit: requestOptions.pagination?.limit ?? containers.pagination?.itemsPerPage ?? 20
+			}
+		};
+		requestOptions = nextOptions;
+		return refreshContainers(buildRequestOptions(nextOptions));
+	}
 
 	async function handleCheckForUpdates() {
 		await checkUpdatesMutation.mutateAsync();
 	}
 
 	async function refresh() {
-		await containersQuery.refetch();
+		await refreshContainers();
 	}
 
-	const isRefreshing = $derived(containersQuery.isFetching && !containersQuery.isPending);
 	const containerStatusCounts = $derived(containers.counts ?? countsFallback);
 
 	const actionButtons: ActionButton[] = $derived([
@@ -124,15 +152,26 @@
 	]);
 </script>
 
+{#key envId}
+	<ContainerEnvironmentSync onActivate={handleEnvironmentChange} />
+{/key}
+
 <ResourcePageLayout title={m.containers_title()} subtitle={m.containers_subtitle()} {actionButtons} {statCards}>
 	{#snippet mainContent()}
 		<ContainerTable
 			bind:containers
 			bind:selectedIds
 			bind:requestOptions
+			bind:groupByProject
 			onRefreshData={async (options) => {
-				requestOptions = options;
-				await containersQuery.refetch();
+				requestOptions = {
+					search: options.search,
+					pagination: options.pagination,
+					sort: options.sort,
+					filters: options.filters,
+					includeInternal: options.includeInternal
+				};
+				return refreshContainers(options);
 			}}
 		/>
 	{/snippet}

--- a/frontend/src/routes/(app)/containers/components/container-environment-sync.svelte
+++ b/frontend/src/routes/(app)/containers/components/container-environment-sync.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	let {
+		onActivate
+	}: {
+		onActivate: () => void | Promise<unknown>;
+	} = $props();
+
+	onMount(() => {
+		void onActivate();
+	});
+</script>

--- a/frontend/src/routes/(app)/containers/components/container-stats-sync.svelte
+++ b/frontend/src/routes/(app)/containers/components/container-stats-sync.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import type { ContainerStatsManager } from './container-stats-manager.svelte';
+
+	let {
+		statsManager,
+		envId,
+		targetIds
+	}: {
+		statsManager: ContainerStatsManager;
+		envId: string;
+		targetIds: Set<string>;
+	} = $props();
+
+	$effect(() => {
+		statsManager.envId = envId;
+		statsManager.targetIds = targetIds;
+	});
+</script>

--- a/frontend/src/routes/(app)/containers/container-table.actions.ts
+++ b/frontend/src/routes/(app)/containers/container-table.actions.ts
@@ -1,8 +1,7 @@
 import { openConfirmDialog } from '$lib/components/confirm-dialog';
 import { m } from '$lib/paraglide/messages';
-import { containerService } from '$lib/services/container-service';
+import { containerService, type ContainersPaginatedResponse } from '$lib/services/container-service';
 import type { ContainerSummaryDto } from '$lib/types/container.type';
-import type { Paginated, SearchPaginationSortRequest } from '$lib/types/pagination.type';
 import { handleApiResultWithCallbacks } from '$lib/utils/api.util';
 import { tryCatch } from '$lib/utils/try-catch';
 import { toast } from 'svelte-sonner';
@@ -16,9 +15,9 @@ type BulkLoadingState = {
 };
 
 type ActionDeps = {
-	getRequestOptions: () => SearchPaginationSortRequest;
-	setContainers: (next: Paginated<ContainerSummaryDto>) => void;
+	setContainers: (next: ContainersPaginatedResponse) => void;
 	setSelectedIds: (next: string[]) => void;
+	refreshContainers: () => Promise<ContainersPaginatedResponse>;
 	actionStatus: Record<string, ActionStatus>;
 	isBulkLoading: BulkLoadingState;
 };
@@ -66,14 +65,14 @@ const containerActionConfigs: Record<ContainerActionKind, ContainerActionConfig>
 };
 
 export function createContainerActions({
-	getRequestOptions,
 	setContainers,
 	setSelectedIds,
+	refreshContainers,
 	actionStatus,
 	isBulkLoading
 }: ActionDeps) {
-	const refreshContainers = async () => {
-		const result = await containerService.getContainers(getRequestOptions());
+	const reloadContainers = async () => {
+		const result = await refreshContainers();
 		setContainers(result);
 		return result;
 	};
@@ -91,7 +90,7 @@ export function createContainerActions({
 				},
 				async onSuccess() {
 					toast.success(config.success());
-					await refreshContainers();
+					await reloadContainers();
 				}
 			});
 		} catch (error) {
@@ -132,7 +131,7 @@ export function createContainerActions({
 						},
 						async onSuccess() {
 							toast.success(m.containers_remove_success());
-							await refreshContainers();
+							await reloadContainers();
 						}
 					});
 				}
@@ -167,7 +166,7 @@ export function createContainerActions({
 							toast.info(m.image_update_up_to_date_title());
 						}
 
-						await refreshContainers();
+						await reloadContainers();
 					} catch (error) {
 						console.error('Container update failed:', error);
 						toast.error(m.containers_update_failed({ name: containerName }));
@@ -206,7 +205,7 @@ export function createContainerActions({
 						toast.error(config.failure());
 					}
 
-					await refreshContainers();
+					await reloadContainers();
 					setSelectedIds([]);
 				}
 			}
@@ -293,7 +292,7 @@ export function createContainerActions({
 						toast.error(m.containers_remove_failed());
 					}
 
-					await refreshContainers();
+					await reloadContainers();
 					setSelectedIds([]);
 				}
 			}

--- a/frontend/src/routes/(app)/containers/container-table.svelte
+++ b/frontend/src/routes/(app)/containers/container-table.svelte
@@ -4,7 +4,7 @@
 	import { Spinner } from '$lib/components/ui/spinner/index.js';
 	import { goto } from '$app/navigation';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
-	import type { SearchPaginationSortRequest, Paginated } from '$lib/types/pagination.type';
+	import type { SearchPaginationSortRequest } from '$lib/types/pagination.type';
 	import StatusBadge from '$lib/components/badges/status-badge.svelte';
 	import { format } from 'date-fns';
 	import { capitalizeFirstLetter } from '$lib/utils/string.utils';
@@ -13,12 +13,17 @@
 	import { m } from '$lib/paraglide/messages';
 	import { PortBadge } from '$lib/components/badges/index.js';
 	import { UniversalMobileCard } from '$lib/components/arcane-table/index.js';
-	import { containerService } from '$lib/services/container-service';
+	import {
+		containerService,
+		type ContainerListRequestOptions,
+		type ContainersPaginatedResponse
+	} from '$lib/services/container-service';
 	import * as ArcaneTooltip from '$lib/components/arcane-tooltip';
 	import ImageUpdateItem from '$lib/components/image-update-item.svelte';
 	import { PersistedState } from 'runed';
 	import { onMount } from 'svelte';
 	import { ContainerStatsManager } from './components/container-stats-manager.svelte';
+	import ContainerStatsSync from './components/container-stats-sync.svelte';
 	import ContainerStatsCell from './components/container-stats-cell.svelte';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import IconImage from '$lib/components/icon-image.svelte';
@@ -28,8 +33,8 @@
 		getActionStatusMessage,
 		getContainerDisplayName,
 		getContainerIpAddress,
+		getProjectName,
 		getStateBadgeVariant,
-		groupContainerByProject,
 		parseImageRef,
 		type ActionStatus
 	} from './container-table.helpers';
@@ -54,12 +59,14 @@
 		containers = $bindable(),
 		selectedIds = $bindable(),
 		requestOptions = $bindable(),
+		groupByProject = $bindable(false),
 		onRefreshData
 	}: {
-		containers: Paginated<ContainerSummaryDto>;
+		containers: ContainersPaginatedResponse;
 		selectedIds: string[];
 		requestOptions: SearchPaginationSortRequest;
-		onRefreshData?: (options: SearchPaginationSortRequest) => Promise<void>;
+		groupByProject?: boolean;
+		onRefreshData?: (options: ContainerListRequestOptions) => Promise<ContainersPaginatedResponse>;
 	} = $props();
 
 	// Track action status per container ID (e.g., "starting", "stopping", "updating", "")
@@ -74,12 +81,21 @@
 
 	const statsManager = new ContainerStatsManager();
 
-	async function refreshContainers(options: SearchPaginationSortRequest) {
+	function buildGroupedRequest(options: SearchPaginationSortRequest, grouped = groupByProject): ContainerListRequestOptions {
+		return {
+			...options,
+			groupByProject: grouped
+		};
+	}
+
+	async function refreshContainers(options: SearchPaginationSortRequest, grouped = groupByProject) {
+		const request = buildGroupedRequest(options, grouped);
 		if (onRefreshData) {
-			await onRefreshData(options);
-			return containers;
+			const result = await onRefreshData(request);
+			containers = result;
+			return result;
 		}
-		const result = await containerService.getContainers(options);
+		const result = await containerService.getContainers(request);
 		containers = result;
 		return result;
 	}
@@ -112,13 +128,13 @@
 		handleBulkRestart,
 		handleBulkRemove
 	} = createContainerActions({
-		getRequestOptions: () => requestOptions,
 		setContainers: (next) => {
 			containers = next;
 		},
 		setSelectedIds: (next) => {
 			selectedIds = next;
 		},
+		refreshContainers: () => refreshContainers(requestOptions),
 		actionStatus,
 		isBulkLoading
 	});
@@ -135,6 +151,12 @@
 	let collapsedGroupsState = $state<PersistedState<Record<string, boolean>> | null>(null);
 	let collapsedGroups = $derived(collapsedGroupsState?.current ?? {});
 	let columnVisibility = $state<Record<string, boolean>>({});
+	const backendGroupedRows = $derived(
+		containers.groups?.map((group) => ({
+			groupName: group.groupName,
+			items: group.items
+		})) ?? null
+	);
 
 	const shouldConnect = $derived.by(() => {
 		const cpuVisible = columnVisibility.cpuUsage !== false;
@@ -151,11 +173,6 @@
 
 	const currentEnvId = $derived(environmentStore.selected?.id || '0');
 
-	$effect(() => {
-		statsManager.envId = currentEnvId;
-		statsManager.targetIds = shouldConnect;
-	});
-
 	onMount(() => {
 		collapsedGroupsState = new PersistedState<Record<string, boolean>>('container-groups-collapsed', {});
 
@@ -165,17 +182,34 @@
 			setShowInternal(persistedInternal);
 		}
 
+		const persistedGroupByProject = (customSettings.groupByProject as boolean) ?? false;
+		if (persistedGroupByProject !== groupByProject) {
+			groupByProject = persistedGroupByProject;
+		}
+
+		if (persistedGroupByProject) {
+			const nextOptions: SearchPaginationSortRequest = {
+				...requestOptions,
+				pagination: { page: 1, limit: getCurrentLimit() }
+			};
+			requestOptions = nextOptions;
+			void refreshContainers(nextOptions, true);
+		}
+
 		return () => {
 			statsManager.destroy();
 		};
 	});
 
-	let groupByProject = $derived.by(() => {
-		return (customSettings.groupByProject as boolean) ?? false;
-	});
-
 	function setGroupByProject(value: boolean) {
 		customSettings = { ...customSettings, groupByProject: value };
+		groupByProject = value;
+		const nextOptions: SearchPaginationSortRequest = {
+			...requestOptions,
+			pagination: { page: 1, limit: getCurrentLimit() }
+		};
+		requestOptions = nextOptions;
+		void refreshContainers(nextOptions, value);
 	}
 
 	function toggleGroup(groupName: string) {
@@ -279,7 +313,13 @@
 	function getGroupIcon(_groupName: string) {
 		return ProjectsIcon;
 	}
+
+	function getGroupName(item: ContainerSummaryDto): string {
+		return getProjectName(item);
+	}
 </script>
+
+<ContainerStatsSync {statsManager} envId={currentEnvId} targetIds={shouldConnect} />
 
 {#snippet IPAddressCell({ item }: { item: ContainerSummaryDto })}
 	{@const ip = getContainerIpAddress(item)}
@@ -633,7 +673,8 @@
 	rowActions={RowActions}
 	mobileCard={ContainerMobileCardSnippet}
 	customViewOptions={CustomViewOptions}
-	groupBy={groupByProject ? groupContainerByProject : undefined}
+	groupedRows={groupByProject ? backendGroupedRows : null}
+	groupBy={groupByProject && !backendGroupedRows ? getGroupName : undefined}
 	groupIcon={groupByProject ? getGroupIcon : undefined}
 	groupCollapsedState={collapsedGroups}
 	onGroupToggle={toggleGroup}

--- a/tests/spec/container-grouped-pagination.spec.ts
+++ b/tests/spec/container-grouped-pagination.spec.ts
@@ -1,0 +1,171 @@
+import { expect, test } from "@playwright/test";
+
+type MockContainer = {
+  id: string;
+  names: string[];
+  image: string;
+  imageId: string;
+  command: string;
+  created: number;
+  labels: Record<string, string>;
+  state: string;
+  status: string;
+  ports: [];
+  hostConfig: { networkMode: string };
+  networkSettings: { networks: Record<string, unknown> };
+  mounts: [];
+};
+
+function createContainer(id: string, name: string, project: string, created: number): MockContainer {
+  return {
+    id,
+    names: [`/${name}`],
+    image: `${project || "misc"}:latest`,
+    imageId: `image-${id}`,
+    command: "",
+    created,
+    labels: project ? { "com.docker.compose.project": project } : {},
+    state: "running",
+    status: "Up 5 minutes",
+    ports: [],
+    hostConfig: { networkMode: "default" },
+    networkSettings: { networks: {} },
+    mounts: [],
+  };
+}
+
+function buildContainersResponse(containers: MockContainer[], start: number, limit: number) {
+  const safeLimit = limit > 0 ? limit : containers.length;
+  const pageItems = limit === -1 ? containers : containers.slice(start, start + safeLimit);
+  const currentPage = limit > 0 ? Math.floor(start / safeLimit) + 1 : 1;
+  const totalPages = limit > 0 ? Math.max(1, Math.ceil(containers.length / safeLimit)) : 1;
+  const itemsPerPage = limit === -1 ? containers.length : safeLimit;
+
+  return {
+    success: true,
+    data: pageItems,
+    counts: {
+      runningContainers: containers.length,
+      stoppedContainers: 0,
+      totalContainers: containers.length,
+    },
+    pagination: {
+      totalPages,
+      totalItems: containers.length,
+      currentPage,
+      itemsPerPage,
+      grandTotalItems: containers.length,
+    },
+  };
+}
+
+test("grouped containers do not split the same project across pages", async ({ page, context }) => {
+  await page.addInitScript(() => {
+    localStorage.removeItem("arcane-container-table");
+    localStorage.setItem("container-groups-collapsed", JSON.stringify({ immich: false }));
+    localStorage.removeItem("collapsible-cards-expanded");
+  });
+
+  let groupedMockPayload:
+    | {
+        groups: Array<{ groupName: string; items: MockContainer[] }>;
+      }
+    | undefined;
+
+  const otherContainers = Array.from({ length: 18 }, (_, index) => {
+    const project = `other-${index + 1}`;
+    return createContainer(`other-${index + 1}`, `${project}-service`, project, 1_000 - index);
+  });
+
+  const immichContainers = [
+    createContainer("immich-1", "immich-server", "immich", 900),
+    createContainer("immich-2", "immich-machine-learning", "immich", 899),
+    createContainer("immich-3", "immich-redis", "immich", 898),
+    createContainer("immich-4", "immich-postgres", "immich", 897),
+  ];
+
+  const allContainers = [...otherContainers, ...immichContainers];
+
+  await context.route("**/containers**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+
+    const url = new URL(route.request().url());
+    if (!/^\/api\/environments\/[^/]+\/containers$/.test(url.pathname)) {
+      await route.continue();
+      return;
+    }
+
+    const start = Number(url.searchParams.get("start") ?? "0");
+    const limit = Number(url.searchParams.get("limit") ?? "20");
+    const groupBy = url.searchParams.get("groupBy");
+
+    if (groupBy === "project") {
+      groupedMockPayload = {
+        groups: [
+          {
+            groupName: "immich",
+            items: immichContainers,
+          },
+          ...otherContainers.slice(0, 18).map((container, index) => ({
+            groupName: `other-${index + 1}`,
+            items: [container],
+          })),
+        ],
+      };
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: [...immichContainers, ...otherContainers.slice(0, 18)],
+          groups: groupedMockPayload.groups,
+          counts: {
+            runningContainers: allContainers.length,
+            stoppedContainers: 0,
+            totalContainers: allContainers.length,
+          },
+          pagination: {
+            totalPages: 1,
+            totalItems: allContainers.length,
+            currentPage: 1,
+            itemsPerPage: 20,
+            grandTotalItems: allContainers.length,
+          },
+        }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(buildContainersResponse(allContainers, start, limit)),
+    });
+  });
+
+  await page.goto("/containers");
+  await page.waitForLoadState("networkidle");
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+
+  await page.getByRole("button", { name: "View" }).click();
+  await page.getByRole("menuitemcheckbox", { name: "Group by Project" }).click();
+  await page.keyboard.press("Escape");
+
+  await expect.poll(() => groupedMockPayload?.groups.find((group) => group.groupName === "immich")?.items.length ?? 0).toBe(4);
+
+  const immichGroupRow = page.locator("table tbody tr").filter({ has: page.getByText("immich", { exact: true }) });
+
+  await expect(immichGroupRow).toHaveCount(1);
+  await expect(immichGroupRow).toContainText("immich");
+  await expect(immichGroupRow).toContainText("(4)");
+
+  await expect(page.getByRole("link", { name: "immich-server", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "immich-machine-learning", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "immich-redis", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "immich-postgres", exact: true })).toBeVisible();
+});

--- a/types/container/container.go
+++ b/types/container/container.go
@@ -634,6 +634,19 @@ type Summary struct {
 	UpdateInfo *imagetypes.UpdateInfo `json:"updateInfo,omitempty"`
 }
 
+// SummaryGroup represents a group of container summaries.
+type SummaryGroup struct {
+	// GroupName is the group label, such as a compose project name.
+	//
+	// Required: true
+	GroupName string `json:"groupName"`
+
+	// Items contains the container summaries in the group.
+	//
+	// Required: true
+	Items []Summary `json:"items"`
+}
+
 // Details represents detailed container information.
 type Details struct {
 	// ID is the unique identifier of the container.


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/1637

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the bug where containers grouped by Docker Compose project could be split across pagination pages. The fix moves grouping logic to the backend: when `groupBy=project` is requested, all containers are fetched at once, grouped by the `com.docker.compose.project` label, then paginated at the **group** boundary rather than the item boundary so no project is ever split between pages. The response gains a `groups` field alongside the existing flat `data` array, and the frontend is updated to consume it.

On the frontend, `createQuery` is replaced with a manual `refreshContainers` function so that `groupByProject` can be threaded into every API call. A new `ContainerEnvironmentSync` micro-component uses the `{#key envId}` + `onMount` pattern to trigger a re-fetch on environment change without mutating `$state` inside `$effect`.

Key points:
- Backend correctly fetches all containers (limit -1), groups them, then paginates on group boundaries ensuring compose projects stay intact.
- The `partitionContainerProjectPagesInternal` function intentionally allows a page to exceed the nominal limit when a single project has more containers than the limit.
- `paginateContainerProjectGroupsInternal` contains a minor redundant slice allocation and a dead `requestedPage := 1` initialisation (always overwritten).
- The new backend unit tests only cover the "all groups fit on page 1" scenario; a test exercising multi-page pagination (e.g. `start=20`) would strengthen confidence in the split-prevention guarantee.
- `ContainerStatsManager.envId` / `targetIds` are plain class setters, not `$state`, so the `$effect` in the new `ContainerStatsSync` component is a legitimate side-effect sync, not a rule violation.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with minor cleanup; the core grouping logic is sound and well-covered for the primary scenario.
- The backend algorithm is correct and the fix addresses the reported issue. Two minor items hold back a full 5: a redundant allocation + dead initialisation in `paginateContainerProjectGroupsInternal`, and the absence of a multi-page unit test that directly validates the no-split guarantee across page boundaries. No correctness bugs or regressions were found.
- `backend/internal/services/container_service.go` (minor allocation/dead-code cleanup) and `backend/internal/services/container_service_test.go` (add multi-page test case).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/internal/services/container_service.go | Adds grouped-by-project pagination path; logic is correct but contains a redundant slice allocation and a dead `requestedPage := 1` initialisation inside `paginateContainerProjectGroupsInternal`. |
| backend/internal/services/container_service_test.go | New unit tests cover page-1 "all groups fit" and the no-project fallback, but lack a multi-page test case (start > 0) that would exercise the core split-prevention logic across page boundaries; variable `groupedItems` is misleadingly named for a `[]SummaryGroup`. |
| frontend/src/routes/(app)/containers/+page.svelte | Migrates from `createQuery` to manual refresh; `handleEnvironmentChange` correctly includes `groupByProject` via `buildRequestOptions`; `hasSeenEnvironmentSync` guard properly skips the initial-mount fire from `{#key envId}`. |
| frontend/src/routes/(app)/containers/container-table.svelte | Promotes `groupByProject` to a bindable prop, adds `backendGroupedRows` derived from API response, and routes grouped requests through the new backend path; the `containers = result` assignment inside `refreshContainers` when `onRefreshData` is provided is redundant (parent already sets it via the bindable) but harmless. |
| frontend/src/routes/(app)/containers/components/container-environment-sync.svelte | New micro-component that fires `onActivate` on mount; used inside a `{#key envId}` block to detect environment changes without `$effect`. |

</details>

</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Finternal%2Fservices%2Fcontainer_service.go%3A507-524%0A**Unnecessary%20allocation%20and%20dead%20initialisation**%0A%0A%60groupedItems%60%20is%20flattened%20from%20all%20groups%20purely%20to%20call%20%60len%28%29%60%20on%20the%20result%2C%20then%20the%20slice%20is%20discarded.%20Since%20no%20containers%20are%20added%20or%20removed%20during%20grouping%2C%20%60len%28result.Items%29%60%20equals%20%60len%28flattenContainerProjectGroupsInternal%28groups%29%29%60%20%E2%80%94%20so%20the%20allocation%20is%20superfluous.%0A%0ASeparately%2C%20%60requestedPage%20%3A%3D%201%60%20%28line%20521%29%20is%20dead%20code%3A%20the%20only%20path%20that%20reaches%20line%20521%20has%20already%20passed%20the%20%60params.Limit%20%3C%3D%200%60%20early%20return%20at%20line%20510%2C%20so%20%60params.Limit%20%3E%200%60%20is%20always%20true%20and%20the%20initial%20value%20is%20unconditionally%20overwritten.%0A%0A%60%60%60suggestion%0A%09groups%20%3A%3D%20groupContainersByProjectInternal%28result.Items%29%0A%09totalCount%20%3A%3D%20len%28result.Items%29%0A%0A%09if%20params.Limit%20%3C%3D%200%20%7B%0A%09%09return%20groups%2C%20pagination.Response%7B%0A%09%09%09TotalPages%3A%20%20%20%20%20%201%2C%0A%09%09%09TotalItems%3A%20%20%20%20%20%20int64%28totalCount%29%2C%0A%09%09%09CurrentPage%3A%20%20%20%20%201%2C%0A%09%09%09ItemsPerPage%3A%20%20%20%20totalCount%2C%0A%09%09%09GrandTotalItems%3A%20result.TotalAvailable%2C%0A%09%09%7D%0A%09%7D%0A%0A%09pages%20%3A%3D%20partitionContainerProjectPagesInternal%28groups%2C%20params.Limit%29%0A%09requestedPage%20%3A%3D%20%28params.Start%20%2F%20params.Limit%29%20%2B%201%0A%60%60%60%0A%0A**Rule%20Used%3A**%20GoLang%20Best%20Practices%0A%0A---%0Adescription%3A%20'Instructi...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Finternal%2Fservices%2Fcontainer_service_test.go%3A37-55%0A**Misleading%20variable%20name%20and%20missing%20multi-page%20coverage**%0A%0A%60groupedItems%60%20is%20the%20return%20value%20of%20%60paginateContainerProjectGroupsInternal%60%2C%20which%20has%20type%20%60%5B%5Dcontainertypes.SummaryGroup%60%20%E2%80%94%20it%20contains%20*groups*%2C%20not%20individual%20items.%20The%20name%20%60groupedItems%60%20reads%20as%20if%20it%20is%20a%20slice%20of%20container%20summaries%2C%20making%20the%20subsequent%20%60for%20_%2C%20group%20%3A%3D%20range%20groupedItems%60%20loop%20confusing.%20Consider%20renaming%20it%20to%20%60pageGroups%60%20or%20simply%20%60groups%60.%0A%0AAdditionally%2C%20the%20test%20only%20exercises%20the%20case%20where%20all%2019%20groups%20fit%20on%20page%201%20%28limit%2020%2C%2022%20total%20items%29.%20The%20core%20fix%20being%20validated%20here%20%E2%80%94%20that%20a%20compose%20project%20is%20never%20split%20across%20pages%20%E2%80%94%20is%20most%20likely%20to%20regress%20when%20groups%20*do*%20span%20multiple%20pages.%20A%20companion%20test%20case%20that%20requests%20page%202%20%28e.g.%20%60Start%3A%2020%2C%20Limit%3A%2020%60%29%20with%20enough%20containers%20to%20produce%20at%20least%20two%20pages%20would%20significantly%20strengthen%20confidence%20in%20the%20algorithm.%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/container_service.go
Line: 507-524

Comment:
**Unnecessary allocation and dead initialisation**

`groupedItems` is flattened from all groups purely to call `len()` on the result, then the slice is discarded. Since no containers are added or removed during grouping, `len(result.Items)` equals `len(flattenContainerProjectGroupsInternal(groups))` — so the allocation is superfluous.

Separately, `requestedPage := 1` (line 521) is dead code: the only path that reaches line 521 has already passed the `params.Limit <= 0` early return at line 510, so `params.Limit > 0` is always true and the initial value is unconditionally overwritten.

```suggestion
	groups := groupContainersByProjectInternal(result.Items)
	totalCount := len(result.Items)

	if params.Limit <= 0 {
		return groups, pagination.Response{
			TotalPages:      1,
			TotalItems:      int64(totalCount),
			CurrentPage:     1,
			ItemsPerPage:    totalCount,
			GrandTotalItems: result.TotalAvailable,
		}
	}

	pages := partitionContainerProjectPagesInternal(groups, params.Limit)
	requestedPage := (params.Start / params.Limit) + 1
```

**Rule Used:** GoLang Best Practices

---
description: 'Instructi... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/services/container_service_test.go
Line: 37-55

Comment:
**Misleading variable name and missing multi-page coverage**

`groupedItems` is the return value of `paginateContainerProjectGroupsInternal`, which has type `[]containertypes.SummaryGroup` — it contains *groups*, not individual items. The name `groupedItems` reads as if it is a slice of container summaries, making the subsequent `for _, group := range groupedItems` loop confusing. Consider renaming it to `pageGroups` or simply `groups`.

Additionally, the test only exercises the case where all 19 groups fit on page 1 (limit 20, 22 total items). The core fix being validated here — that a compose project is never split across pages — is most likely to regress when groups *do* span multiple pages. A companion test case that requests page 2 (e.g. `Start: 20, Limit: 20`) with enough containers to produce at least two pages would significantly strengthen confidence in the algorithm.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 1791010</sub>

<!-- /greptile_comment -->