### PR TITLE
fix: docker container creation on api 1.44 attach primary network then remaining networks

### DIFF
--- a/backend/cli/upgrade/upgrade.go
+++ b/backend/cli/upgrade/upgrade.go
@@ -383,9 +383,12 @@ func upgradeContainer(ctx context.Context, dockerClient *client.Client, oldConta
 	}
 
 	// Build network config - preserve all network settings including IP addresses
-	var networkConfig *network.NetworkingConfig
+	var (
+		apiVersion    string
+		networkConfig *network.NetworkingConfig
+	)
 	if !nm.IsContainer() {
-		apiVersion := libarcane.DetectDockerAPIVersion(ctx, dockerClient)
+		apiVersion = libarcane.DetectDockerAPIVersion(ctx, dockerClient)
 		if apiVersion != "" && !libarcane.SupportsDockerCreatePerNetworkMACAddress(apiVersion) {
 			slog.Info("daemon API does not support per-network mac-address on create; stripping endpoint mac addresses",
 				"dockerAPIVersion", apiVersion,
@@ -419,12 +422,12 @@ func upgradeContainer(ctx context.Context, dockerClient *client.Client, oldConta
 
 	fmt.Println("PROGRESS:75:Creating new container")
 	slog.Info("Creating new container", "name", originalName)
-	resp, err := dockerClient.ContainerCreate(ctx, client.ContainerCreateOptions{
+	resp, err := libarcane.ContainerCreateWithCompatibilityForAPIVersion(ctx, dockerClient, client.ContainerCreateOptions{
 		Config:           &config,
 		HostConfig:       hostConfig,
 		NetworkingConfig: networkConfig,
 		Name:             originalName,
-	})
+	}, apiVersion)
 	if err != nil {
 		// Try to restart and restore old container on failure
 		_, _ = dockerClient.ContainerStart(ctx, oldContainer.ID, client.ContainerStartOptions{})

--- a/backend/internal/services/container_service.go
+++ b/backend/internal/services/container_service.go
@@ -239,7 +239,7 @@ func (s *ContainerService) CreateContainer(ctx context.Context, config *containe
 		}
 	}
 
-	resp, err := dockerClient.ContainerCreate(ctx, client.ContainerCreateOptions{
+	resp, err := libarcane.ContainerCreateWithCompatibility(ctx, dockerClient, client.ContainerCreateOptions{
 		Config:           config,
 		HostConfig:       hostConfig,
 		NetworkingConfig: networkingConfig,

--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -797,12 +797,12 @@ func (s *UpdaterService) updateContainer(ctx context.Context, cnt container.Summ
 	// Use original name for new container
 	containerName := strings.TrimPrefix(originalName, "/")
 
-	resp, err := dcli.ContainerCreate(ctx, client.ContainerCreateOptions{
+	resp, err := libarcane.ContainerCreateWithCompatibilityForAPIVersion(ctx, dcli, client.ContainerCreateOptions{
 		Config:           cfg,
 		HostConfig:       hostConfig,
 		NetworkingConfig: networkingConfig,
 		Name:             containerName,
-	})
+	}, apiVersion)
 	if err != nil {
 		slog.DebugContext(ctx, "updateContainer: create failed", "containerName", containerName, "err", err)
 		return fmt.Errorf("create: %w", err)

--- a/backend/pkg/libarcane/docker_compat.go
+++ b/backend/pkg/libarcane/docker_compat.go
@@ -2,19 +2,40 @@ package libarcane
 
 import (
 	"context"
+	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
+	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 )
 
 const NetworkScopedMacAddressMinAPIVersion = "1.44"
 
+// MultiEndpointContainerCreateMinAPIVersion is the first Docker API version
+// that reliably accepts multiple entries in NetworkingConfig.EndpointsConfig on
+// ContainerCreate.
+//
+// This matters because Arcane has several in-process container creation paths
+// (auto-update recreate, manual create, self-upgrade recreate, embedded Compose
+// library usage). Those paths all speak to the daemon through the Moby API
+// client, so Arcane must handle daemon API compatibility itself.
+//
+// A host-side `docker compose up` command can still succeed against the same
+// daemon because the installed Compose CLI/plugin may implement its own
+// fallback strategy for older daemon APIs, such as creating the container on
+// the primary network and then attaching the remaining networks with
+// NetworkConnect. Arcane cannot assume the host CLI's fallback behavior exists
+// in its own code paths, so the compatibility shim below applies that fallback
+// explicitly.
+const MultiEndpointContainerCreateMinAPIVersion = "1.44"
+
 // DetectDockerAPIVersion returns the configured client API version when
 // available, and falls back to the daemon-reported version only when the
 // client version is not yet set.
-func DetectDockerAPIVersion(ctx context.Context, dockerClient *client.Client) string {
+func DetectDockerAPIVersion(ctx context.Context, dockerClient client.APIClient) string {
 	if dockerClient == nil {
 		return ""
 	}
@@ -29,6 +50,16 @@ func DetectDockerAPIVersion(ctx context.Context, dockerClient *client.Client) st
 	}
 
 	return strings.TrimSpace(serverVersion.APIVersion)
+}
+
+// SupportsDockerCreateMultiEndpointNetworking reports whether the connected
+// daemon API supports attaching multiple endpoints during ContainerCreate.
+//
+// On older daemon APIs, sending multiple EndpointsConfig entries can fail with
+// daemon-side networking errors even though newer Compose CLIs may appear to
+// "work" by using a different fallback sequence under the hood.
+func SupportsDockerCreateMultiEndpointNetworking(apiVersion string) bool {
+	return IsDockerAPIVersionAtLeast(apiVersion, MultiEndpointContainerCreateMinAPIVersion)
 }
 
 // SupportsDockerCreatePerNetworkMACAddress reports whether the daemon API
@@ -91,6 +122,134 @@ func SanitizeContainerCreateEndpointSettingsForDockerAPI(endpoints map[string]*n
 	return cloned
 }
 
+// PrepareContainerCreateOptionsForDockerAPI rewrites a container create request
+// for older daemon APIs that cannot accept multiple endpoint attachments in the
+// initial ContainerCreate call.
+//
+// For API versions below MultiEndpointContainerCreateMinAPIVersion, Arcane
+// keeps only the primary network in NetworkingConfig.EndpointsConfig and
+// returns the remaining endpoints so the caller can attach them with
+// NetworkConnect after create but before start. This mirrors the compatibility
+// behavior that a newer host-side Compose CLI may apply internally, which
+// explains why a shell `docker compose up` can succeed while Arcane's embedded
+// or manual create paths fail unless we perform the split ourselves.
+func PrepareContainerCreateOptionsForDockerAPI(options client.ContainerCreateOptions, apiVersion string) (client.ContainerCreateOptions, map[string]*network.EndpointSettings) {
+	if SupportsDockerCreateMultiEndpointNetworking(apiVersion) || options.NetworkingConfig == nil || len(options.NetworkingConfig.EndpointsConfig) <= 1 {
+		return options, nil
+	}
+
+	primaryNetwork := resolvePrimaryContainerCreateNetworkInternal(options.HostConfig, options.NetworkingConfig.EndpointsConfig)
+	if primaryNetwork == "" {
+		return options, nil
+	}
+
+	adjusted := options
+	if options.HostConfig != nil {
+		hostConfigCopy := *options.HostConfig
+		adjusted.HostConfig = &hostConfigCopy
+	}
+	if adjusted.HostConfig == nil {
+		adjusted.HostConfig = &container.HostConfig{}
+	}
+	if strings.TrimSpace(string(adjusted.HostConfig.NetworkMode)) == "" {
+		adjusted.HostConfig.NetworkMode = container.NetworkMode(primaryNetwork)
+	}
+
+	primaryEndpoint := copyEndpointSettingsInternal(options.NetworkingConfig.EndpointsConfig[primaryNetwork])
+	adjusted.NetworkingConfig = &network.NetworkingConfig{
+		EndpointsConfig: map[string]*network.EndpointSettings{
+			primaryNetwork: primaryEndpoint,
+		},
+	}
+
+	extraEndpoints := make(map[string]*network.EndpointSettings, len(options.NetworkingConfig.EndpointsConfig)-1)
+	for networkName, endpoint := range options.NetworkingConfig.EndpointsConfig {
+		if networkName == primaryNetwork {
+			continue
+		}
+		extraEndpoints[networkName] = copyEndpointSettingsInternal(endpoint)
+	}
+	if len(extraEndpoints) == 0 {
+		return adjusted, nil
+	}
+
+	return adjusted, extraEndpoints
+}
+
+// ConnectContainerExtraNetworksForDockerAPI attaches endpoints that were
+// intentionally withheld from ContainerCreate for legacy daemon API
+// compatibility.
+//
+// The intended call order is:
+// 1. create the container on the primary network
+// 2. connect each additional user-defined network
+// 3. start the container
+//
+// Doing the attachment before start preserves the expected network topology
+// while avoiding the legacy daemon limitation on multi-endpoint create.
+func ConnectContainerExtraNetworksForDockerAPI(ctx context.Context, dockerClient client.APIClient, containerID string, endpoints map[string]*network.EndpointSettings) error {
+	if dockerClient == nil || strings.TrimSpace(containerID) == "" || len(endpoints) == 0 {
+		return nil
+	}
+
+	networkNames := make([]string, 0, len(endpoints))
+	for networkName := range endpoints {
+		networkNames = append(networkNames, networkName)
+	}
+	slices.Sort(networkNames)
+
+	for _, networkName := range networkNames {
+		_, err := dockerClient.NetworkConnect(ctx, networkName, client.NetworkConnectOptions{
+			Container:      containerID,
+			EndpointConfig: copyEndpointSettingsInternal(endpoints[networkName]),
+		})
+		if err != nil {
+			return fmt.Errorf("connect network %s: %w", networkName, err)
+		}
+	}
+
+	return nil
+}
+
+// ContainerCreateWithCompatibility applies Arcane's Docker API compatibility
+// shims before calling ContainerCreate.
+//
+// This helper exists so every in-process Arcane create/recreate path can share
+// the same daemon-compatibility behavior instead of relying on whichever
+// fallback logic a separate host CLI binary might have. In practice this is the
+// guardrail that keeps Arcane aligned with older daemons such as Docker 24.x
+// advertising API 1.43 when a container needs multiple user-defined networks.
+func ContainerCreateWithCompatibility(ctx context.Context, dockerClient client.APIClient, options client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
+	return ContainerCreateWithCompatibilityForAPIVersion(ctx, dockerClient, options, DetectDockerAPIVersion(ctx, dockerClient))
+}
+
+// ContainerCreateWithCompatibilityForAPIVersion applies Arcane's Docker API
+// compatibility shims before calling ContainerCreate when the caller has
+// already resolved the daemon API version.
+func ContainerCreateWithCompatibilityForAPIVersion(ctx context.Context, dockerClient client.APIClient, options client.ContainerCreateOptions, apiVersion string) (client.ContainerCreateResult, error) {
+	if dockerClient == nil {
+		return client.ContainerCreateResult{}, fmt.Errorf("docker api client is nil")
+	}
+
+	adjustedOptions, extraEndpoints := PrepareContainerCreateOptionsForDockerAPI(options, apiVersion)
+
+	result, err := dockerClient.ContainerCreate(ctx, adjustedOptions)
+	if err != nil {
+		return client.ContainerCreateResult{}, err
+	}
+
+	if len(extraEndpoints) == 0 {
+		return result, nil
+	}
+
+	if err := ConnectContainerExtraNetworksForDockerAPI(ctx, dockerClient, result.ID, extraEndpoints); err != nil {
+		_, _ = dockerClient.ContainerRemove(ctx, result.ID, client.ContainerRemoveOptions{Force: true})
+		return client.ContainerCreateResult{}, err
+	}
+
+	return result, nil
+}
+
 func parseAPIVersionInternal(version string) ([3]int, bool) {
 	parsed := [3]int{}
 
@@ -118,4 +277,44 @@ func parseAPIVersionInternal(version string) ([3]int, bool) {
 	}
 
 	return parsed, true
+}
+
+func resolvePrimaryContainerCreateNetworkInternal(hostConfig *container.HostConfig, endpoints map[string]*network.EndpointSettings) string {
+	if len(endpoints) == 0 {
+		return ""
+	}
+
+	if hostConfig != nil {
+		networkMode := strings.TrimSpace(string(hostConfig.NetworkMode))
+		switch {
+		case networkMode == "":
+		case container.NetworkMode(networkMode).IsHost(),
+			container.NetworkMode(networkMode).IsNone(),
+			container.NetworkMode(networkMode).IsContainer():
+			return ""
+		default:
+			if _, ok := endpoints[networkMode]; ok {
+				return networkMode
+			}
+			// Named network set in NetworkMode is not represented in endpoint
+			// config, so avoid splitting the request and let the daemon handle
+			// the original create options as-is.
+			return ""
+		}
+	}
+
+	networkNames := make([]string, 0, len(endpoints))
+	for networkName := range endpoints {
+		networkNames = append(networkNames, networkName)
+	}
+	slices.Sort(networkNames)
+	return networkNames[0]
+}
+
+func copyEndpointSettingsInternal(endpoint *network.EndpointSettings) *network.EndpointSettings {
+	if endpoint == nil {
+		return nil
+	}
+
+	return endpoint.Copy()
 }

--- a/backend/pkg/libarcane/docker_compat_test.go
+++ b/backend/pkg/libarcane/docker_compat_test.go
@@ -1,13 +1,74 @@
 package libarcane
 
 import (
+	"context"
+	"errors"
 	"net"
 	"net/netip"
 	"testing"
 
+	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeContainerCreateCompatibilityClient struct {
+	client.APIClient
+	containerCreateResult client.ContainerCreateResult
+	containerCreateErr    error
+	networkConnectErrs    map[string]error
+	containerRemoveErr    error
+	containerCreateCalls  []client.ContainerCreateOptions
+	networkConnectCalls   []fakeNetworkConnectCall
+	containerRemoveCalls  []fakeContainerRemoveCall
+	clientVersionCalls    int
+	serverVersionCalls    int
+}
+
+type fakeNetworkConnectCall struct {
+	network string
+	options client.NetworkConnectOptions
+}
+
+type fakeContainerRemoveCall struct {
+	containerID string
+	options     client.ContainerRemoveOptions
+}
+
+func (f *fakeContainerCreateCompatibilityClient) ClientVersion() string {
+	f.clientVersionCalls++
+	return ""
+}
+
+func (f *fakeContainerCreateCompatibilityClient) ServerVersion(context.Context, client.ServerVersionOptions) (client.ServerVersionResult, error) {
+	f.serverVersionCalls++
+	return client.ServerVersionResult{}, nil
+}
+
+func (f *fakeContainerCreateCompatibilityClient) ContainerCreate(_ context.Context, options client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
+	f.containerCreateCalls = append(f.containerCreateCalls, options)
+	if f.containerCreateErr != nil {
+		return client.ContainerCreateResult{}, f.containerCreateErr
+	}
+	return f.containerCreateResult, nil
+}
+
+func (f *fakeContainerCreateCompatibilityClient) NetworkConnect(_ context.Context, networkName string, options client.NetworkConnectOptions) (client.NetworkConnectResult, error) {
+	f.networkConnectCalls = append(f.networkConnectCalls, fakeNetworkConnectCall{network: networkName, options: options})
+	if err := f.networkConnectErrs[networkName]; err != nil {
+		return client.NetworkConnectResult{}, err
+	}
+	return client.NetworkConnectResult{}, nil
+}
+
+func (f *fakeContainerCreateCompatibilityClient) ContainerRemove(_ context.Context, containerID string, options client.ContainerRemoveOptions) (client.ContainerRemoveResult, error) {
+	f.containerRemoveCalls = append(f.containerRemoveCalls, fakeContainerRemoveCall{containerID: containerID, options: options})
+	if f.containerRemoveErr != nil {
+		return client.ContainerRemoveResult{}, f.containerRemoveErr
+	}
+	return client.ContainerRemoveResult{}, nil
+}
 
 func mustHardwareAddr(t *testing.T, addr string) network.HardwareAddr {
 	t.Helper()
@@ -47,6 +108,13 @@ func TestSupportsDockerCreatePerNetworkMACAddress(t *testing.T) {
 	require.False(t, SupportsDockerCreatePerNetworkMACAddress("1.41"))
 }
 
+func TestSupportsDockerCreateMultiEndpointNetworking(t *testing.T) {
+	require.True(t, SupportsDockerCreateMultiEndpointNetworking("1.44"))
+	require.True(t, SupportsDockerCreateMultiEndpointNetworking("1.46"))
+	require.False(t, SupportsDockerCreateMultiEndpointNetworking("1.43"))
+	require.False(t, SupportsDockerCreateMultiEndpointNetworking("1.41"))
+}
+
 func TestSanitizeContainerCreateEndpointSettingsForDockerAPI(t *testing.T) {
 	input := map[string]*network.EndpointSettings{
 		"bridge": {
@@ -84,5 +152,167 @@ func TestSanitizeContainerCreateEndpointSettingsForDockerAPI(t *testing.T) {
 	t.Run("nil or empty input", func(t *testing.T) {
 		require.Nil(t, SanitizeContainerCreateEndpointSettingsForDockerAPI(nil, "1.44"))
 		require.Nil(t, SanitizeContainerCreateEndpointSettingsForDockerAPI(map[string]*network.EndpointSettings{}, "1.44"))
+	})
+}
+
+func TestPrepareContainerCreateOptionsForDockerAPI(t *testing.T) {
+	options := client.ContainerCreateOptions{
+		HostConfig: &container.HostConfig{
+			NetworkMode: container.NetworkMode("synobridge"),
+		},
+		NetworkingConfig: &network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				"synobridge": {
+					Aliases: []string{"app"},
+				},
+				"nginx-proxy-manager_zbridge": {
+					Aliases: []string{"proxy"},
+				},
+			},
+		},
+	}
+
+	t.Run("splits legacy multi-network create into primary plus extras", func(t *testing.T) {
+		adjusted, extras := PrepareContainerCreateOptionsForDockerAPI(options, "1.43")
+		require.NotNil(t, adjusted.NetworkingConfig)
+		require.Len(t, adjusted.NetworkingConfig.EndpointsConfig, 1)
+		require.Contains(t, adjusted.NetworkingConfig.EndpointsConfig, "synobridge")
+		require.Equal(t, []string{"app"}, adjusted.NetworkingConfig.EndpointsConfig["synobridge"].Aliases)
+
+		require.Len(t, extras, 1)
+		require.Contains(t, extras, "nginx-proxy-manager_zbridge")
+		require.Equal(t, []string{"proxy"}, extras["nginx-proxy-manager_zbridge"].Aliases)
+
+		adjusted.NetworkingConfig.EndpointsConfig["synobridge"].Aliases[0] = "changed"
+		extras["nginx-proxy-manager_zbridge"].Aliases[0] = "changed-too"
+
+		require.Equal(t, []string{"app"}, options.NetworkingConfig.EndpointsConfig["synobridge"].Aliases)
+		require.Equal(t, []string{"proxy"}, options.NetworkingConfig.EndpointsConfig["nginx-proxy-manager_zbridge"].Aliases)
+	})
+
+	t.Run("leaves create options unchanged on newer daemon apis", func(t *testing.T) {
+		adjusted, extras := PrepareContainerCreateOptionsForDockerAPI(options, "1.44")
+		require.Len(t, adjusted.NetworkingConfig.EndpointsConfig, 2)
+		require.Nil(t, extras)
+	})
+
+	t.Run("uses deterministic fallback primary network when mode is unset", func(t *testing.T) {
+		adjusted, extras := PrepareContainerCreateOptionsForDockerAPI(client.ContainerCreateOptions{
+			NetworkingConfig: &network.NetworkingConfig{
+				EndpointsConfig: map[string]*network.EndpointSettings{
+					"znet": {Aliases: []string{"z"}},
+					"anet": {Aliases: []string{"a"}},
+				},
+			},
+		}, "1.43")
+
+		require.NotNil(t, adjusted.HostConfig)
+		require.Equal(t, container.NetworkMode("anet"), adjusted.HostConfig.NetworkMode)
+		require.Len(t, adjusted.NetworkingConfig.EndpointsConfig, 1)
+		require.Contains(t, adjusted.NetworkingConfig.EndpointsConfig, "anet")
+		require.Len(t, extras, 1)
+		require.Contains(t, extras, "znet")
+	})
+
+	t.Run("leaves create options unchanged when named network mode is missing from endpoints", func(t *testing.T) {
+		options := client.ContainerCreateOptions{
+			HostConfig: &container.HostConfig{
+				NetworkMode: container.NetworkMode("mynetwork"),
+			},
+			NetworkingConfig: &network.NetworkingConfig{
+				EndpointsConfig: map[string]*network.EndpointSettings{
+					"anet": {Aliases: []string{"a"}},
+					"znet": {Aliases: []string{"z"}},
+				},
+			},
+		}
+
+		adjusted, extras := PrepareContainerCreateOptionsForDockerAPI(options, "1.43")
+
+		require.Equal(t, options.HostConfig.NetworkMode, adjusted.HostConfig.NetworkMode)
+		require.Len(t, adjusted.NetworkingConfig.EndpointsConfig, 2)
+		require.Contains(t, adjusted.NetworkingConfig.EndpointsConfig, "anet")
+		require.Contains(t, adjusted.NetworkingConfig.EndpointsConfig, "znet")
+		require.Nil(t, extras)
+	})
+}
+
+func TestContainerCreateWithCompatibilityForAPIVersion(t *testing.T) {
+	t.Run("uses provided api version without re-detecting it", func(t *testing.T) {
+		fakeClient := &fakeContainerCreateCompatibilityClient{
+			containerCreateResult: client.ContainerCreateResult{ID: "created"},
+		}
+
+		result, err := ContainerCreateWithCompatibilityForAPIVersion(t.Context(), fakeClient, client.ContainerCreateOptions{
+			Config: &container.Config{Image: "nginx:latest"},
+		}, "1.44")
+
+		require.NoError(t, err)
+		require.Equal(t, "created", result.ID)
+		require.Zero(t, fakeClient.clientVersionCalls)
+		require.Zero(t, fakeClient.serverVersionCalls)
+		require.Len(t, fakeClient.containerCreateCalls, 1)
+	})
+
+	t.Run("removes created container when a later network attach fails", func(t *testing.T) {
+		fakeClient := &fakeContainerCreateCompatibilityClient{
+			containerCreateResult: client.ContainerCreateResult{ID: "created-container"},
+			networkConnectErrs: map[string]error{
+				"cnet": errors.New("boom"),
+			},
+		}
+
+		_, err := ContainerCreateWithCompatibilityForAPIVersion(t.Context(), fakeClient, client.ContainerCreateOptions{
+			Config: &container.Config{Image: "nginx:latest"},
+			HostConfig: &container.HostConfig{
+				NetworkMode: container.NetworkMode("anet"),
+			},
+			NetworkingConfig: &network.NetworkingConfig{
+				EndpointsConfig: map[string]*network.EndpointSettings{
+					"anet": {Aliases: []string{"a"}},
+					"bnet": {Aliases: []string{"b"}},
+					"cnet": {Aliases: []string{"c"}},
+					"dnet": {Aliases: []string{"d"}},
+				},
+			},
+		}, "1.43")
+
+		require.ErrorContains(t, err, "connect network cnet")
+		require.Len(t, fakeClient.containerCreateCalls, 1)
+		require.Len(t, fakeClient.networkConnectCalls, 2)
+		require.Equal(t, "bnet", fakeClient.networkConnectCalls[0].network)
+		require.Equal(t, "cnet", fakeClient.networkConnectCalls[1].network)
+		require.Len(t, fakeClient.containerRemoveCalls, 1)
+		require.Equal(t, "created-container", fakeClient.containerRemoveCalls[0].containerID)
+		require.True(t, fakeClient.containerRemoveCalls[0].options.Force)
+	})
+
+	t.Run("propagates network attach error when rollback remove also fails", func(t *testing.T) {
+		connectErr := errors.New("connect-boom")
+		removeErr := errors.New("remove-boom")
+		fakeClient := &fakeContainerCreateCompatibilityClient{
+			containerCreateResult: client.ContainerCreateResult{ID: "created-container"},
+			networkConnectErrs: map[string]error{
+				"bnet": connectErr,
+			},
+			containerRemoveErr: removeErr,
+		}
+
+		_, err := ContainerCreateWithCompatibilityForAPIVersion(t.Context(), fakeClient, client.ContainerCreateOptions{
+			HostConfig: &container.HostConfig{
+				NetworkMode: container.NetworkMode("anet"),
+			},
+			NetworkingConfig: &network.NetworkingConfig{
+				EndpointsConfig: map[string]*network.EndpointSettings{
+					"anet": {},
+					"bnet": {},
+				},
+			},
+		}, "1.43")
+
+		require.ErrorContains(t, err, "connect network bnet")
+		require.ErrorIs(t, err, connectErr)
+		require.NotErrorIs(t, err, removeErr)
+		require.Len(t, fakeClient.containerRemoveCalls, 1)
 	})
 }

--- a/backend/pkg/libarcane/inspect_compat.go
+++ b/backend/pkg/libarcane/inspect_compat.go
@@ -35,6 +35,10 @@ type inspectCompatibilityClient struct {
 	client.APIClient
 }
 
+func (c *inspectCompatibilityClient) ContainerCreate(ctx context.Context, options client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
+	return ContainerCreateWithCompatibility(ctx, c.APIClient, options)
+}
+
 func (c *inspectCompatibilityClient) ContainerInspect(ctx context.Context, containerID string, options client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
 	return ContainerInspectWithCompatibility(ctx, c.APIClient, containerID, options)
 }

--- a/backend/pkg/libarcane/inspect_compat_test.go
+++ b/backend/pkg/libarcane/inspect_compat_test.go
@@ -3,6 +3,7 @@ package libarcane
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
@@ -319,6 +320,76 @@ func TestWrapDockerAPIClientForInspectCompatibility(t *testing.T) {
 	result, err := wrapped.ContainerInspect(context.Background(), "test-container", client.ContainerInspectOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::1"), result.Container.NetworkSettings.Networks["bridge"].IPv6Gateway)
+}
+
+func TestWrapDockerAPIClientForInspectCompatibility_ContainerCreateLegacyNetworks(t *testing.T) {
+	type createRequest struct {
+		NetworkingConfig networktypes.NetworkingConfig `json:"NetworkingConfig"`
+	}
+	type connectRequest struct {
+		Container      string                         `json:"Container"`
+		EndpointConfig *networktypes.EndpointSettings `json:"EndpointConfig"`
+	}
+
+	var createPayload createRequest
+	connectPayloads := map[string]connectRequest{}
+
+	dockerClient := newTestDockerClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/containers/create"):
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &createPayload))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Id":"new-container-id","Warnings":[]}`))
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/networks/") && strings.HasSuffix(r.URL.Path, "/connect"):
+			networkName := r.URL.Path
+			networkName = strings.TrimSuffix(networkName, "/connect")
+			networkName = networkName[strings.LastIndex(networkName, "/networks/")+len("/networks/"):]
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			var payload connectRequest
+			require.NoError(t, json.Unmarshal(body, &payload))
+			connectPayloads[networkName] = payload
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	wrapped := WrapDockerAPIClientForInspectCompatibility(dockerClient)
+	result, err := wrapped.ContainerCreate(context.Background(), client.ContainerCreateOptions{
+		Config: &containertypes.Config{
+			Image: "nginx:alpine",
+		},
+		HostConfig: &containertypes.HostConfig{
+			NetworkMode: containertypes.NetworkMode("synobridge"),
+		},
+		NetworkingConfig: &networktypes.NetworkingConfig{
+			EndpointsConfig: map[string]*networktypes.EndpointSettings{
+				"synobridge": {
+					Aliases: []string{"app"},
+				},
+				"nginx-proxy-manager_zbridge": {
+					Aliases: []string{"proxy"},
+				},
+			},
+		},
+		Name: "test-app",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "new-container-id", result.ID)
+
+	require.Len(t, createPayload.NetworkingConfig.EndpointsConfig, 1)
+	require.Contains(t, createPayload.NetworkingConfig.EndpointsConfig, "synobridge")
+	assert.Equal(t, []string{"app"}, createPayload.NetworkingConfig.EndpointsConfig["synobridge"].Aliases)
+
+	require.Len(t, connectPayloads, 1)
+	require.Contains(t, connectPayloads, "nginx-proxy-manager_zbridge")
+	assert.Equal(t, "new-container-id", connectPayloads["nginx-proxy-manager_zbridge"].Container)
+	require.NotNil(t, connectPayloads["nginx-proxy-manager_zbridge"].EndpointConfig)
+	assert.Equal(t, []string{"proxy"}, connectPayloads["nginx-proxy-manager_zbridge"].EndpointConfig.Aliases)
 }
 
 func newTestDockerClient(t *testing.T, handler http.HandlerFunc) *client.Client {

--- a/types/project/marshal_utils.go
+++ b/types/project/marshal_utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"reflect"
 	"strconv"
 	"strings"
@@ -14,7 +15,7 @@ import (
 
 // unitBytesType is used to detect compose-go fields that need string-or-number
 // normalization before they can be decoded by encoding/json.
-var unitBytesType = reflect.TypeOf(composetypes.UnitBytes(0))
+var unitBytesType = reflect.TypeFor[composetypes.UnitBytes]()
 
 // runtimeServiceJSON is an internal decode shape that lets RuntimeService
 // handle serviceConfig separately from the rest of the payload.
@@ -112,7 +113,7 @@ func unmarshalComposeServiceConfigJSONInternal(data []byte) (*composetypes.Servi
 		return nil, err
 	}
 
-	normalized, err := normalizeJSONValueForTypeInternal(raw, reflect.TypeOf(composetypes.ServiceConfig{}))
+	normalized, err := normalizeJSONValueForTypeInternal(raw, reflect.TypeFor[composetypes.ServiceConfig]())
 	if err != nil {
 		return nil, err
 	}
@@ -188,12 +189,9 @@ func normalizeJSONObjectForTypeInternal(value any, destType reflect.Type) (any, 
 	}
 
 	normalized := make(map[string]any, len(object))
-	for key, item := range object {
-		normalized[key] = item
-	}
+	maps.Copy(normalized, object)
 
-	for i := 0; i < destType.NumField(); i++ {
-		field := destType.Field(i)
+	for field := range destType.Fields() {
 		if field.PkgPath != "" {
 			continue
 		}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/1951

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements a Docker API 1.44 compatibility shim for multi-endpoint container creation, fixing a regression where Arcane's in-process container creation paths would fail on older daemons (API < 1.44) when a container needed to be attached to more than one user-defined network. The fix mirrors the fallback strategy used by newer Docker Compose CLI versions: create the container on the primary network first, then attach the remaining networks via `NetworkConnect` before starting the container.

Key changes:
- **`docker_compat.go`**: Adds `PrepareContainerCreateOptionsForDockerAPI` (splits multi-endpoint options into primary + extras), `ConnectContainerExtraNetworksForDockerAPI` (attaches extras sequentially in alphabetical order), and `ContainerCreateWithCompatibility[ForAPIVersion]` (orchestrates the full flow with rollback on `NetworkConnect` failure).
- **`inspect_compat.go`**: Adds `ContainerCreate` to `inspectCompatibilityClient` so any caller using the wrapped client automatically gets the compatibility behavior without code changes.
- **`upgrade.go` / `updater_service.go` / `container_service.go`**: All three in-process create paths are switched to the new compatibility helpers.
- **`marshal_utils.go`**: Minor Go 1.23+ modernization (`reflect.TypeFor`, `maps.Copy`, range-over-`Fields()`).
- Test coverage is thorough: unit tests cover the split logic, deep-copy isolation, alphabetical ordering, the rollback path (addressed from a previous review thread), and an end-to-end integration test against a real HTTP test server.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge; the compatibility logic is correct and well-tested, with one minor gap in the test suite around the containerRemoveErr path.
- The core networking compatibility shim is logically sound: the primary-network resolution correctly handles all special NetworkMode values (host, none, container mode, empty, and named-but-missing-from-endpoints), the rollback on NetworkConnect failure is implemented and now covered by a test, and all three in-process create paths have been updated consistently. The single deduction is for the untested "ContainerRemove itself fails during rollback" scenario — the field is wired in the test fake but no test exercises it, leaving the error-swallowing behavior of `_, _ = dockerClient.ContainerRemove(...)` unverified by tests.
- No files require special attention beyond the minor test gap noted in `backend/pkg/libarcane/docker_compat_test.go`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/pkg/libarcane/docker_compat.go | Core compatibility shim: adds PrepareContainerCreateOptionsForDockerAPI, ConnectContainerExtraNetworksForDockerAPI, and ContainerCreateWithCompatibility[ForAPIVersion]; logic is sound with correct edge-case handling for container/host/none network modes and the NetworkMode-not-in-endpoints guard. |
| backend/pkg/libarcane/docker_compat_test.go | Good unit-test coverage added for PrepareContainerCreateOptionsForDockerAPI and ContainerCreateWithCompatibilityForAPIVersion including the rollback path; fakeContainerCreateCompatibilityClient.containerRemoveErr is wired into ContainerRemove but never set in any test case, leaving the "ContainerRemove returns an error" path untested. |
| backend/pkg/libarcane/inspect_compat.go | Adds ContainerCreate override to inspectCompatibilityClient that delegates to ContainerCreateWithCompatibility with c.APIClient (not c itself), correctly avoiding infinite recursion; no issues found. |
| backend/pkg/libarcane/inspect_compat_test.go | Integration test exercises the full legacy split path through a real HTTP test server with API version 1.41; correctly validates both the single-endpoint ContainerCreate payload and the subsequent NetworkConnect call. |
| backend/cli/upgrade/upgrade.go | Correctly switches from dockerClient.ContainerCreate to ContainerCreateWithCompatibilityForAPIVersion using the already-detected apiVersion; when nm.IsContainer() is true apiVersion stays "" but networkConfig is nil so PrepareContainerCreateOptionsForDockerAPI exits early — safe. |
| backend/internal/services/container_service.go | Straightforward swap from dockerClient.ContainerCreate to ContainerCreateWithCompatibility; version is detected internally; no issues found. |
| backend/internal/services/updater_service.go | Correctly passes the already-resolved apiVersion to ContainerCreateWithCompatibilityForAPIVersion to avoid a redundant ServerVersion round-trip; no issues found. |
| types/project/marshal_utils.go | Minor modernization: reflect.TypeFor[T](), maps.Copy, and the destType.Fields() range iterator are all valid under Go 1.23+ (project requires Go 1.26); behavior is identical to the removed code. |

</details>

</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fpkg%2Flibarcane%2Fdocker_compat_test.go%3A21%0A**%60containerRemoveErr%60%20field%20is%20never%20exercised**%0A%0A%60containerRemoveErr%60%20is%20declared%20and%20wired%20into%20the%20%60ContainerRemove%60%20stub%20%28lines%2067%E2%80%9368%29%2C%20but%20no%20existing%20test%20sets%20it%20to%20a%20non-nil%20value.%20This%20means%20the%20scenario%20where%20the%20rollback%20%60ContainerRemove%60%20call%20itself%20fails%20is%20untested.%20Given%20that%20%60ContainerCreateWithCompatibilityForAPIVersion%60%20silently%20ignores%20that%20error%20%28%60_%2C%20_%20%3D%20dockerClient.ContainerRemove%28...%29%60%29%2C%20a%20test%20asserting%20that%20the%20original%20%60NetworkConnect%60%20error%20is%20still%20propagated%20even%20when%20removal%20also%20fails%20would%20make%20the%20contract%20explicit%3A%0A%0A%60%60%60go%0At.Run%28%22propagates%20network%20connect%20error%20even%20when%20container%20remove%20also%20fails%22%2C%20func%28t%20*testing.T%29%20%7B%0A%20%20%20%20fakeClient%20%3A%3D%20%26fakeContainerCreateCompatibilityClient%7B%0A%20%20%20%20%20%20%20%20containerCreateResult%3A%20client.ContainerCreateResult%7BID%3A%20%22created-container%22%7D%2C%0A%20%20%20%20%20%20%20%20networkConnectErrs%3A%20%20%20%20map%5Bstring%5Derror%7B%22bnet%22%3A%20errors.New%28%22connect-boom%22%29%7D%2C%0A%20%20%20%20%20%20%20%20containerRemoveErr%3A%20%20%20%20errors.New%28%22remove-boom%22%29%2C%0A%20%20%20%20%7D%0A%0A%20%20%20%20_%2C%20err%20%3A%3D%20ContainerCreateWithCompatibilityForAPIVersion%28t.Context%28%29%2C%20fakeClient%2C%20client.ContainerCreateOptions%7B%0A%20%20%20%20%20%20%20%20HostConfig%3A%20%26container.HostConfig%7BNetworkMode%3A%20%22anet%22%7D%2C%0A%20%20%20%20%20%20%20%20NetworkingConfig%3A%20%26network.NetworkingConfig%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20EndpointsConfig%3A%20map%5Bstring%5D*network.EndpointSettings%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22anet%22%3A%20%7B%7D%2C%20%22bnet%22%3A%20%7B%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%7D%2C%20%221.43%22%29%0A%0A%20%20%20%20require.ErrorContains%28t%2C%20err%2C%20%22connect%20network%20bnet%22%29%0A%20%20%20%20require.NotErrorIs%28t%2C%20err%2C%20errors.New%28%22remove-boom%22%29%29%20%2F%2F%20remove%20error%20swallowed%0A%20%20%20%20require.Len%28t%2C%20fakeClient.containerRemoveCalls%2C%201%29%0A%7D%29%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/libarcane/docker_compat_test.go
Line: 21

Comment:
**`containerRemoveErr` field is never exercised**

`containerRemoveErr` is declared and wired into the `ContainerRemove` stub (lines 67–68), but no existing test sets it to a non-nil value. This means the scenario where the rollback `ContainerRemove` call itself fails is untested. Given that `ContainerCreateWithCompatibilityForAPIVersion` silently ignores that error (`_, _ = dockerClient.ContainerRemove(...)`), a test asserting that the original `NetworkConnect` error is still propagated even when removal also fails would make the contract explicit:

```go
t.Run("propagates network connect error even when container remove also fails", func(t *testing.T) {
    fakeClient := &fakeContainerCreateCompatibilityClient{
        containerCreateResult: client.ContainerCreateResult{ID: "created-container"},
        networkConnectErrs:    map[string]error{"bnet": errors.New("connect-boom")},
        containerRemoveErr:    errors.New("remove-boom"),
    }

    _, err := ContainerCreateWithCompatibilityForAPIVersion(t.Context(), fakeClient, client.ContainerCreateOptions{
        HostConfig: &container.HostConfig{NetworkMode: "anet"},
        NetworkingConfig: &network.NetworkingConfig{
            EndpointsConfig: map[string]*network.EndpointSettings{
                "anet": {}, "bnet": {},
            },
        },
    }, "1.43")

    require.ErrorContains(t, err, "connect network bnet")
    require.NotErrorIs(t, err, errors.New("remove-boom")) // remove error swallowed
    require.Len(t, fakeClient.containerRemoveCalls, 1)
})
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 8f5cc81</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->