### PR TITLE
fix: unable to edit env when synced from git

### DIFF
--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"path/filepath"
 	"strings"
 	"time"
@@ -14,6 +15,7 @@ import (
 	bootstraputils "github.com/getarcaneapp/arcane/backend/internal/utils"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/mapper"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/pagination"
+	"github.com/getarcaneapp/arcane/backend/pkg/projects"
 	"github.com/getarcaneapp/arcane/types/gitops"
 	"gorm.io/gorm"
 )
@@ -611,6 +613,10 @@ func (s *GitOpsSyncService) createProjectForSyncInternal(ctx context.Context, sy
 		return nil, s.failSync(ctx, id, result, sync, actor, "Failed to mark project as GitOps-managed", err.Error())
 	}
 
+	if _, err := s.projectService.ApplyGitSyncProjectFiles(ctx, project.ID, composeContent, envContent, actor); err != nil {
+		return nil, s.failSync(ctx, id, result, sync, actor, "Failed to sync project env files", err.Error())
+	}
+
 	slog.InfoContext(ctx, "Created project for GitOps sync", "projectName", sync.ProjectName, "projectId", project.ID)
 
 	// Deploy the project immediately after creation
@@ -647,21 +653,16 @@ func (s *GitOpsSyncService) getOrCreateProjectInternal(ctx context.Context, sync
 func (s *GitOpsSyncService) updateProjectForSyncInternal(ctx context.Context, sync *models.GitOpsSync, id string, project *models.Project, composeContent string, envContent *string, result *gitops.SyncResult, actor models.User) error {
 	// Get current content to see if it changed
 	oldCompose, oldEnv, _ := s.projectService.GetProjectContent(ctx, project.ID)
-	contentChanged := oldCompose != composeContent
-	if envContent != nil {
-		if oldEnv != *envContent {
-			contentChanged = true
-		}
-	} else if oldEnv != "" {
-		contentChanged = true
-	}
 
 	// Update existing project's compose and env files
-	_, err := s.projectService.UpdateProject(ctx, project.ID, nil, &composeContent, envContent, actor)
+	_, err := s.projectService.ApplyGitSyncProjectFiles(ctx, project.ID, composeContent, envContent, actor)
 	if err != nil {
 		return s.failSync(ctx, id, result, sync, actor, "Failed to update project files", err.Error())
 	}
 	slog.InfoContext(ctx, "Updated project files", "projectName", project.Name, "projectId", project.ID)
+
+	newCompose, newEnv, _ := s.projectService.GetProjectContent(ctx, project.ID)
+	contentChanged := oldCompose != newCompose || envContentChangedInternal(oldEnv, newEnv)
 
 	// If content changed and project is running, redeploy
 	if contentChanged {
@@ -675,4 +676,14 @@ func (s *GitOpsSyncService) updateProjectForSyncInternal(ctx context.Context, sy
 	}
 
 	return nil
+}
+
+func envContentChangedInternal(oldEnv, newEnv string) bool {
+	oldEnvMap, oldErr := projects.ParseProjectEnvContent(oldEnv, nil)
+	newEnvMap, newErr := projects.ParseProjectEnvContent(newEnv, nil)
+	if oldErr != nil || newErr != nil {
+		return oldEnv != newEnv
+	}
+
+	return !maps.Equal(oldEnvMap, newEnvMap)
 }

--- a/backend/internal/services/gitops_sync_service_test.go
+++ b/backend/internal/services/gitops_sync_service_test.go
@@ -1,0 +1,23 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvContentChangedInternal(t *testing.T) {
+	t.Run("ignores formatting-only changes", func(t *testing.T) {
+		oldEnv := "B=2\nA=1\n# comment\n"
+		newEnv := "A=1\nB=2\n"
+
+		assert.False(t, envContentChangedInternal(oldEnv, newEnv))
+	})
+
+	t.Run("detects semantic changes", func(t *testing.T) {
+		oldEnv := "A=1\nB=2\n"
+		newEnv := "A=1\nB=3\n"
+
+		assert.True(t, envContentChangedInternal(oldEnv, newEnv))
+	})
+}

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -82,7 +82,7 @@ func (s *ProjectService) getPathMapper(ctx context.Context) (*pathmapper.PathMap
 	}
 
 	// If hostDir not obtained from mapping, attempt auto-discovery from Docker mounts
-	if hostDir == "" {
+	if hostDir == "" && s.dockerService != nil {
 		if dockerCli, derr := s.dockerService.GetClient(ctx); derr == nil {
 			absContainerDir, _ := filepath.Abs(containerDirResolved)
 			if discovery, aerr := docker.GetHostPathForContainerPath(ctx, dockerCli, absContainerDir); aerr == nil && discovery != "" {
@@ -371,17 +371,26 @@ func (s *ProjectService) GetProjectDetails(ctx context.Context, projectID string
 		return project.Details{}, err
 	}
 
-	composeContent, envContent, _ := s.GetProjectContent(ctx, projectID)
+	composeContent, _, _ := s.GetProjectContent(ctx, projectID)
+	envState, err := projects.ReadProjectEnvState(proj.Path)
+	if err != nil {
+		return project.Details{}, fmt.Errorf("failed to read project env state: %w", err)
+	}
 
 	var resp project.Details
 	if err := mapper.MapStruct(proj, &resp); err != nil {
 		return project.Details{}, fmt.Errorf("failed to map project: %w", err)
 	}
 
+	effectiveEnvContent, err := s.resolveStoredEffectiveEnvContentInternal(envState)
+	if err != nil {
+		return project.Details{}, err
+	}
+
 	resp.CreatedAt = proj.CreatedAt.Format(time.RFC3339)
 	resp.UpdatedAt = proj.UpdatedAt.Format(time.RFC3339)
 	resp.ComposeContent = composeContent
-	resp.EnvContent = envContent
+	resp.EnvContent = effectiveEnvContent
 	resp.HasBuildDirective = false
 	resp.DirName = utils.DerefString(proj.DirName)
 	resp.GitOpsManagedBy = proj.GitOpsManagedBy
@@ -1849,6 +1858,48 @@ func (s *ProjectService) UpdateProject(ctx context.Context, projectID string, na
 	return &proj, nil
 }
 
+func (s *ProjectService) ApplyGitSyncProjectFiles(ctx context.Context, projectID string, composeContent string, gitEnvContent *string, user models.User) (*models.Project, error) {
+	proj, projectsDirectory, err := s.getProjectForUpdate(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	envUpdate, err := s.prepareGitSyncEnvUpdateInternal(proj.Path, gitEnvContent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve git env state: %w", err)
+	}
+
+	if err := s.validateComposeContentForUpdate(ctx, proj.Path, proj.Name, composeContent, envUpdate.effectiveContent); err != nil {
+		return nil, fmt.Errorf("invalid compose file: %w", err)
+	}
+
+	if err := fs.WriteComposeFile(projectsDirectory, proj.Path, composeContent); err != nil {
+		return nil, fmt.Errorf("failed to save compose file: %w", err)
+	}
+	if err := s.persistGitSyncEnvFilesInternal(proj.Path, projectsDirectory, envUpdate); err != nil {
+		return nil, fmt.Errorf("failed to sync git env files: %w", err)
+	}
+	if err := s.db.WithContext(ctx).Save(&proj).Error; err != nil {
+		return nil, fmt.Errorf("failed to update project: %w", err)
+	}
+
+	metadata := models.JSON{
+		"action":         "git_sync_update",
+		"projectID":      proj.ID,
+		"projectName":    proj.Name,
+		"composeUpdated": true,
+		"envUpdated":     gitEnvContent != nil,
+	}
+	if gitEnvContent == nil {
+		metadata["envSourceRemoved"] = true
+	}
+	if logErr := s.eventService.LogProjectEvent(ctx, models.EventTypeProjectUpdate, proj.ID, proj.Name, user.ID, user.Username, "0", metadata); logErr != nil {
+		slog.ErrorContext(ctx, "could not log git sync project update action", "error", logErr)
+	}
+
+	return &proj, nil
+}
+
 func (s *ProjectService) getProjectForUpdate(ctx context.Context, projectID string) (models.Project, string, error) {
 	var proj models.Project
 	if err := s.db.WithContext(ctx).First(&proj, "id = ?", projectID).Error; err != nil {
@@ -1892,14 +1943,25 @@ func (s *ProjectService) withProjectRenameRollback(ctx context.Context, proj *mo
 func (s *ProjectService) persistUpdatedProjectFiles(ctx context.Context, proj *models.Project, projectsDirectory string, composeContent, envContent *string) error {
 	switch {
 	case composeContent != nil:
-		if err := s.validateComposeContentForUpdate(ctx, proj.Path, proj.Name, *composeContent, envContent); err != nil {
+		effectiveEnvContent, err := s.resolveEffectiveEnvContentForUpdateInternal(proj.Path, envContent)
+		if err != nil {
 			return fmt.Errorf("invalid compose file: %w", err)
 		}
-		if err := fs.SaveOrUpdateProjectFiles(projectsDirectory, proj.Path, *composeContent, envContent); err != nil {
+		if err := s.validateComposeContentForUpdate(ctx, proj.Path, proj.Name, *composeContent, effectiveEnvContent); err != nil {
+			return fmt.Errorf("invalid compose file: %w", err)
+		}
+		if err := fs.WriteComposeFile(projectsDirectory, proj.Path, *composeContent); err != nil {
+			return fmt.Errorf("failed to save project files: %w", err)
+		}
+		if envContent != nil {
+			if err := s.persistEffectiveEnvContentInternal(proj.Path, projectsDirectory, *envContent); err != nil {
+				return fmt.Errorf("failed to save project files: %w", err)
+			}
+		} else if err := s.ensureEffectiveEnvFileInternal(proj.Path, projectsDirectory); err != nil {
 			return fmt.Errorf("failed to save project files: %w", err)
 		}
 	case envContent != nil:
-		if err := fs.WriteEnvFile(projectsDirectory, proj.Path, *envContent); err != nil {
+		if err := s.persistEffectiveEnvContentInternal(proj.Path, projectsDirectory, *envContent); err != nil {
 			return err
 		}
 	}
@@ -1907,7 +1969,7 @@ func (s *ProjectService) persistUpdatedProjectFiles(ctx context.Context, proj *m
 	return nil
 }
 
-func (s *ProjectService) validateComposeContentForUpdate(ctx context.Context, projectPath, projectName, composeContent string, envContent *string) (err error) {
+func (s *ProjectService) validateComposeContentForUpdate(ctx context.Context, projectPath, projectName, composeContent string, effectiveEnvContent *string) (err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			err = fmt.Errorf("compose file contains invalid syntax: %v", recovered)
@@ -1922,9 +1984,9 @@ func (s *ProjectService) validateComposeContentForUpdate(ctx context.Context, pr
 		fullEnvMap["PWD"] = absWorkdir
 	}
 
-	// Prefer the provided new environment content if available, otherwise read from disk.
-	if envContent != nil {
-		if fileEnv, envErr := projects.ParseProjectEnvContent(*envContent, fullEnvMap); envErr != nil {
+	// Prefer the provided effective environment content if available, otherwise read from disk.
+	if effectiveEnvContent != nil {
+		if fileEnv, envErr := projects.ParseProjectEnvContent(*effectiveEnvContent, fullEnvMap); envErr != nil {
 			return fmt.Errorf("parse provided env content: %w", envErr)
 		} else {
 			maps.Copy(fullEnvMap, fileEnv)
@@ -1948,7 +2010,7 @@ func (s *ProjectService) validateComposeContentForUpdate(ctx context.Context, pr
 		Environment: composetypes.Mapping(fullEnvMap),
 	}
 
-	err = withTransientValidationEnvFile(projectPath, envContent, func() error {
+	err = withTransientValidationEnvFile(projectPath, effectiveEnvContent, func() error {
 		_, loadErr := loader.LoadWithContext(ctx, cfg, func(opts *loader.Options) {
 			if validationProjectName != "" {
 				opts.SetProjectName(validationProjectName, true)
@@ -1960,7 +2022,7 @@ func (s *ProjectService) validateComposeContentForUpdate(ctx context.Context, pr
 	return err
 }
 
-func withTransientValidationEnvFile(projectPath string, envContent *string, run func() error) (err error) {
+func withTransientValidationEnvFile(projectPath string, effectiveEnvContent *string, run func() error) (err error) {
 	envPath := filepath.Join(projectPath, ".env")
 	originalContent, readErr := os.ReadFile(envPath)
 	originalExists := readErr == nil
@@ -1968,11 +2030,11 @@ func withTransientValidationEnvFile(projectPath string, envContent *string, run 
 		return fmt.Errorf("prepare env file for compose validation: %w", readErr)
 	}
 
-	shouldWrite := envContent != nil || !originalExists
+	shouldWrite := effectiveEnvContent != nil || !originalExists
 	if shouldWrite {
 		content := ""
-		if envContent != nil {
-			content = *envContent
+		if effectiveEnvContent != nil {
+			content = *effectiveEnvContent
 		}
 		if writeErr := fs.WriteEnvFile(projectPath, projectPath, content); writeErr != nil {
 			return fmt.Errorf("prepare env file for compose validation: %w", writeErr)
@@ -1983,7 +2045,7 @@ func withTransientValidationEnvFile(projectPath string, envContent *string, run 
 			switch {
 			case originalExists:
 				restoreErr = fs.WriteEnvFile(projectPath, projectPath, string(originalContent))
-			case envContent != nil:
+			case effectiveEnvContent != nil:
 				restoreErr = os.Remove(envPath)
 			default:
 				restoreErr = os.Remove(envPath)
@@ -2002,6 +2064,226 @@ func withTransientValidationEnvFile(projectPath string, envContent *string, run 
 	}
 
 	return run()
+}
+
+func (s *ProjectService) resolveEffectiveEnvContentForUpdateInternal(projectPath string, envContent *string) (*string, error) {
+	if envContent != nil {
+		return envContent, nil
+	}
+
+	state, err := projects.ReadProjectEnvState(projectPath)
+	if err != nil {
+		return nil, fmt.Errorf("read project env state: %w", err)
+	}
+
+	effectiveContent, err := s.resolveStoredEffectiveEnvContentInternal(state)
+	if err != nil {
+		return nil, err
+	}
+	if effectiveContent == "" && !state.HasEffective && !state.HasGitSource && !state.HasOverride {
+		return nil, nil
+	}
+
+	return &effectiveContent, nil
+}
+
+func (s *ProjectService) resolveStoredEffectiveEnvContentInternal(state projects.ProjectEnvState) (string, error) {
+	if state.HasEffective {
+		return state.EffectiveContent, nil
+	}
+	if state.HasGitSource || state.HasOverride {
+		effectiveContent, err := projects.BuildEffectiveEnvContent(state.GitContent, state.OverrideContent)
+		if err != nil {
+			return "", fmt.Errorf("build effective env content: %w", err)
+		}
+		return effectiveContent, nil
+	}
+	return state.DirectContent, nil
+}
+
+func (s *ProjectService) persistEffectiveEnvContentInternal(projectPath, projectsDirectory, envContent string) error {
+	state, err := projects.ReadProjectEnvState(projectPath)
+	if err != nil {
+		return fmt.Errorf("read project env state: %w", err)
+	}
+
+	if !state.HasGitSource {
+		if state.HasOverride {
+			if err := fs.RemoveProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName); err != nil {
+				return err
+			}
+		}
+		return fs.WriteEnvFile(projectsDirectory, projectPath, envContent)
+	}
+
+	overrideContent, err := projects.BuildOverrideEnvContent(state.GitContent, envContent)
+	if err != nil {
+		return fmt.Errorf("build override env content: %w", err)
+	}
+
+	effectiveContent, err := projects.BuildEffectiveEnvContent(state.GitContent, overrideContent)
+	if err != nil {
+		return fmt.Errorf("build effective env content: %w", err)
+	}
+
+	if err := fs.WriteEnvFile(projectsDirectory, projectPath, effectiveContent); err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(overrideContent) == "" {
+		if err := fs.RemoveProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName); err != nil {
+			return err
+		}
+	} else if err := fs.WriteProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName, overrideContent); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *ProjectService) ensureEffectiveEnvFileInternal(projectPath, projectsDirectory string) error {
+	state, err := projects.ReadProjectEnvState(projectPath)
+	if err != nil {
+		return fmt.Errorf("read project env state: %w", err)
+	}
+
+	if !state.HasGitSource {
+		if state.HasOverride {
+			if err := fs.RemoveProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName); err != nil {
+				return err
+			}
+			effectiveContent, err := s.resolveStoredEffectiveEnvContentInternal(state)
+			if err != nil {
+				return err
+			}
+			return fs.WriteEnvFile(projectsDirectory, projectPath, effectiveContent)
+		}
+		return fs.EnsureEnvFile(projectsDirectory, projectPath)
+	}
+
+	effectiveContent, err := projects.BuildEffectiveEnvContent(state.GitContent, state.OverrideContent)
+	if err != nil {
+		return fmt.Errorf("build effective env content: %w", err)
+	}
+
+	return fs.WriteEnvFile(projectsDirectory, projectPath, effectiveContent)
+}
+
+type gitSyncEnvUpdateInternal struct {
+	state            projects.ProjectEnvState
+	gitEnvContent    *string
+	overrideContent  string
+	effectiveContent *string
+}
+
+func (s *ProjectService) prepareGitSyncEnvUpdateInternal(projectPath string, gitEnvContent *string) (gitSyncEnvUpdateInternal, error) {
+	state, err := projects.ReadProjectEnvState(projectPath)
+	if err != nil {
+		return gitSyncEnvUpdateInternal{}, fmt.Errorf("read project env state: %w", err)
+	}
+
+	update := gitSyncEnvUpdateInternal{
+		state:         state,
+		gitEnvContent: gitEnvContent,
+	}
+
+	if gitEnvContent == nil {
+		effectiveContent, err := s.resolveStoredEffectiveEnvContentInternal(state)
+		if err != nil {
+			return gitSyncEnvUpdateInternal{}, err
+		}
+		if effectiveContent == "" && !state.HasEffective && !state.HasGitSource && !state.HasOverride {
+			return update, nil
+		}
+		update.effectiveContent = &effectiveContent
+		return update, nil
+	}
+
+	overrideContent, err := s.resolveOverrideContentForGitSyncInternal(state, *gitEnvContent)
+	if err != nil {
+		return gitSyncEnvUpdateInternal{}, err
+	}
+	update.overrideContent = overrideContent
+
+	effectiveContent, err := projects.BuildEffectiveEnvContent(*gitEnvContent, overrideContent)
+	if err != nil {
+		return gitSyncEnvUpdateInternal{}, fmt.Errorf("build effective env content: %w", err)
+	}
+	update.effectiveContent = &effectiveContent
+
+	return update, nil
+}
+
+func (s *ProjectService) resolveOverrideContentForGitSyncInternal(state projects.ProjectEnvState, gitEnvContent string) (string, error) {
+	switch {
+	case state.HasGitSource:
+		overrideContent, err := projects.BuildOverrideEnvContent(state.GitContent, state.OverrideContent)
+		if err != nil {
+			return "", fmt.Errorf("build override env content: %w", err)
+		}
+		return overrideContent, nil
+	case state.HasOverride:
+		effectiveContent, err := s.resolveStoredEffectiveEnvContentInternal(state)
+		if err != nil {
+			return "", err
+		}
+		overrideContent, err := projects.BuildOverrideEnvContent(gitEnvContent, effectiveContent)
+		if err != nil {
+			return "", fmt.Errorf("build override env content: %w", err)
+		}
+		return overrideContent, nil
+	case strings.TrimSpace(state.DirectContent) != "":
+		overrideContent, err := projects.BuildAdditiveOverrideEnvContent(gitEnvContent, state.DirectContent)
+		if err != nil {
+			return "", fmt.Errorf("build override env content: %w", err)
+		}
+		return overrideContent, nil
+	default:
+		return "", nil
+	}
+}
+
+func (s *ProjectService) persistGitSyncEnvFilesInternal(projectPath, projectsDirectory string, update gitSyncEnvUpdateInternal) error {
+	if update.gitEnvContent == nil {
+		if update.state.HasGitSource {
+			if err := fs.RemoveProjectFile(projectsDirectory, projectPath, projects.GitSourceEnvFileName); err != nil {
+				return err
+			}
+		}
+		if update.state.HasOverride {
+			if err := fs.RemoveProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName); err != nil {
+				return err
+			}
+		}
+		if update.effectiveContent != nil || update.state.HasEffective || update.state.HasGitSource || update.state.HasOverride {
+			effectiveContent := ""
+			if update.effectiveContent != nil {
+				effectiveContent = *update.effectiveContent
+			}
+			return fs.WriteEnvFile(projectsDirectory, projectPath, effectiveContent)
+		}
+		return fs.EnsureEnvFile(projectsDirectory, projectPath)
+	}
+
+	if update.effectiveContent == nil {
+		return fmt.Errorf("missing effective env content for git sync update")
+	}
+
+	if err := fs.WriteEnvFile(projectsDirectory, projectPath, *update.effectiveContent); err != nil {
+		return err
+	}
+	if err := fs.WriteProjectFile(projectsDirectory, projectPath, projects.GitSourceEnvFileName, *update.gitEnvContent); err != nil {
+		return err
+	}
+	if strings.TrimSpace(update.overrideContent) == "" {
+		if err := fs.RemoveProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName); err != nil {
+			return err
+		}
+	} else if err := fs.WriteProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName, update.overrideContent); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *ProjectService) applyProjectRenameIfNeeded(proj *models.Project, name *string, projectsDirectory string) error {

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -716,6 +716,371 @@ func TestProjectService_UpdateProject_ReturnsEnvParseErrorDuringComposeValidatio
 	assert.Contains(t, err.Error(), "parse env")
 }
 
+func TestProjectService_UpdateProject_DerivesProjectOverrideEnvWhenGitSourceExists(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil)
+
+	dirName := "override-edit"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:alpine\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env"), []byte("BASE=git\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env.git"), []byte("BASE=git\n"), 0o600))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-override-edit"},
+		Name:      "override-edit",
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	env := "BASE=git\nTOKEN=secret\n"
+	updated, err := svc.UpdateProject(ctx, project.ID, nil, nil, &env, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	overrideBytes, readErr := os.ReadFile(filepath.Join(projectPath, "project.env"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "TOKEN=secret\n", string(overrideBytes))
+
+	effectiveBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
+	require.NoError(t, readErr)
+	assert.Contains(t, string(effectiveBytes), "BASE=git\n")
+	assert.Contains(t, string(effectiveBytes), "TOKEN=secret\n")
+}
+
+func TestProjectService_UpdateProject_DeletingGitBackedKeyFallsBackToGit(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil)
+
+	dirName := "override-delete"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:alpine\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env"), []byte("BASE=git\nTOKEN=local\nLOCAL_ONLY=1\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env.git"), []byte("BASE=git\nTOKEN=git\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "project.env"), []byte("TOKEN=local\nLOCAL_ONLY=1\n"), 0o600))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-override-delete"},
+		Name:      "override-delete",
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	env := "BASE=git\nLOCAL_ONLY=1\n"
+	updated, err := svc.UpdateProject(ctx, project.ID, nil, nil, &env, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	overrideBytes, readErr := os.ReadFile(filepath.Join(projectPath, "project.env"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "LOCAL_ONLY=1\n", string(overrideBytes))
+
+	effectiveBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
+	require.NoError(t, readErr)
+	assert.Contains(t, string(effectiveBytes), "BASE=git\n")
+	assert.Contains(t, string(effectiveBytes), "TOKEN=git\n")
+	assert.Contains(t, string(effectiveBytes), "LOCAL_ONLY=1\n")
+	assert.NotContains(t, string(overrideBytes), "TOKEN=")
+}
+
+func TestProjectService_ApplyGitSyncProjectFiles_MigratesDirectEnvIntoProjectOverride(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil)
+
+	dirName := "git-sync-migrate"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:alpine\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env"), []byte("TOKEN=stale-local\nLOCAL_ONLY=1\n"), 0o600))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-git-sync-migrate"},
+		Name:      "git-sync-migrate",
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	gitEnv := "TOKEN=git\nREMOTE_ONLY=1\n"
+	updated, err := svc.ApplyGitSyncProjectFiles(ctx, project.ID, "services:\n  app:\n    image: nginx:alpine\n", &gitEnv, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	gitSourceBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env.git"))
+	require.NoError(t, readErr)
+	assert.Equal(t, gitEnv, string(gitSourceBytes))
+
+	overrideBytes, readErr := os.ReadFile(filepath.Join(projectPath, "project.env"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "LOCAL_ONLY=1\n", string(overrideBytes))
+
+	effectiveBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
+	require.NoError(t, readErr)
+	assert.Contains(t, string(effectiveBytes), "TOKEN=git\n")
+	assert.Contains(t, string(effectiveBytes), "LOCAL_ONLY=1\n")
+	assert.Contains(t, string(effectiveBytes), "REMOTE_ONLY=1\n")
+}
+
+func TestProjectService_ApplyGitSyncProjectFiles_NormalizesStaleCopiedGitOverrides(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil)
+
+	dirName := "git-sync-normalize"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:alpine\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env.git"), []byte("BASE=git\nSHARED=1\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "project.env"), []byte("BASE=git\nSHARED=1\nTOKEN=local\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env"), []byte("BASE=git\nSHARED=1\nTOKEN=local\n"), 0o600))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-git-sync-normalize"},
+		Name:      "git-sync-normalize",
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	gitEnv := "BASE=git-updated\nSHARED=1\nREMOTE_ONLY=1\n"
+	updated, err := svc.ApplyGitSyncProjectFiles(ctx, project.ID, "services:\n  app:\n    image: nginx:alpine\n", &gitEnv, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	overrideBytes, readErr := os.ReadFile(filepath.Join(projectPath, "project.env"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "TOKEN=local\n", string(overrideBytes))
+
+	effectiveBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
+	require.NoError(t, readErr)
+	assert.Contains(t, string(effectiveBytes), "BASE=git-updated\n")
+	assert.Contains(t, string(effectiveBytes), "REMOTE_ONLY=1\n")
+	assert.Contains(t, string(effectiveBytes), "TOKEN=local\n")
+}
+
+func TestProjectService_ApplyGitSyncProjectFiles_RemovesLegacyDeletedGitMasks(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil)
+
+	dirName := "git-sync-delete-mask"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:alpine\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env.git"), []byte("TOKEN=git\nSHARED=1\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "project.env"), []byte("TOKEN=\nLOCAL_ONLY=1\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env"), []byte("LOCAL_ONLY=1\nSHARED=1\n"), 0o600))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-git-sync-delete-mask"},
+		Name:      "git-sync-delete-mask",
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	gitEnv := "TOKEN=git-updated\nSHARED=1\nREMOTE_ONLY=1\n"
+	updated, err := svc.ApplyGitSyncProjectFiles(ctx, project.ID, "services:\n  app:\n    image: nginx:alpine\n", &gitEnv, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	overrideBytes, readErr := os.ReadFile(filepath.Join(projectPath, "project.env"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "LOCAL_ONLY=1\n", string(overrideBytes))
+
+	effectiveBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
+	require.NoError(t, readErr)
+	assert.Contains(t, string(effectiveBytes), "TOKEN=git-updated\n")
+	assert.Contains(t, string(effectiveBytes), "LOCAL_ONLY=1\n")
+	assert.Contains(t, string(effectiveBytes), "REMOTE_ONLY=1\n")
+	assert.NotContains(t, string(overrideBytes), "TOKEN=")
+}
+
+func TestProjectService_ApplyGitSyncProjectFiles_RemovesGitEnvSource(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil)
+
+	dirName := "git-sync-remove"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:alpine\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env"), []byte("BASE=git\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env.git"), []byte("BASE=git\n"), 0o600))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-git-sync-remove"},
+		Name:      "git-sync-remove",
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	updated, err := svc.ApplyGitSyncProjectFiles(ctx, project.ID, "services:\n  app:\n    image: nginx:alpine\n", nil, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	_, statErr := os.Stat(filepath.Join(projectPath, ".env.git"))
+	assert.True(t, os.IsNotExist(statErr))
+
+	effectiveBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "BASE=git\n", string(effectiveBytes))
+}
+
+func TestProjectService_PersistGitSyncEnvFiles_UsesPreparedState(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil)
+
+	dirName := "git-sync-prepared-state"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:alpine\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env"), []byte("BASE=git\nTOKEN=local\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env.git"), []byte("BASE=git\nTOKEN=git\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "project.env"), []byte("TOKEN=local\n"), 0o600))
+
+	gitEnv := "BASE=git-updated\nTOKEN=git\nREMOTE=1\n"
+	update, err := svc.prepareGitSyncEnvUpdateInternal(projectPath, &gitEnv)
+	require.NoError(t, err)
+	require.NotNil(t, update.effectiveContent)
+
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "project.env"), []byte("TOKEN=unexpected\n"), 0o600))
+
+	require.NoError(t, svc.persistGitSyncEnvFilesInternal(projectPath, projectsDir, update))
+
+	overrideBytes, readErr := os.ReadFile(filepath.Join(projectPath, "project.env"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "TOKEN=local\n", string(overrideBytes))
+
+	effectiveBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "BASE=git-updated\nREMOTE=1\nTOKEN=local\n", string(effectiveBytes))
+}
+
+func TestProjectService_GetProjectDetails_ReturnsEffectiveEnvContent(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil)
+
+	dirName := "details-override"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:alpine\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env"), []byte("BASE=git\nTOKEN=secret\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env.git"), []byte("BASE=git\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "project.env"), []byte("TOKEN=secret\n"), 0o600))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-details-override"},
+		Name:      "details-override",
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	details, err := svc.GetProjectDetails(ctx, project.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "BASE=git\nTOKEN=secret\n", details.EnvContent)
+}
+
 func TestProjectService_MergeBuildTags(t *testing.T) {
 	tags := mergeBuildTags("example/app:latest", []string{"example/app:sha", "example/app:latest", " "})
 	assert.Equal(t, []string{"example/app:latest", "example/app:sha"}, tags)

--- a/backend/internal/utils/fs/fs_writer.go
+++ b/backend/internal/utils/fs/fs_writer.go
@@ -1,9 +1,11 @@
 package fs
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/getarcaneapp/arcane/backend/internal/common"
 )
@@ -69,9 +71,7 @@ func WriteComposeFile(projectsRoot, dirPath, content string) error {
 	return nil
 }
 
-// WriteEnvFile writes a .env file to the specified directory
-// projectsRoot is the allowed root directory to prevent path traversal attacks
-func WriteEnvFile(projectsRoot, dirPath, content string) error {
+func WriteProjectFile(projectsRoot, dirPath, fileName, content string) error {
 	// Security: Validate dirPath is absolute and clean to prevent path traversal
 	absPath, err := filepath.Abs(dirPath)
 	if err != nil {
@@ -87,19 +87,69 @@ func WriteEnvFile(projectsRoot, dirPath, content string) error {
 	rootAbs = filepath.Clean(rootAbs)
 
 	if !IsSafeSubdirectory(rootAbs, dirPath) {
-		return fmt.Errorf("refusing to write env file: path outside projects root")
+		return fmt.Errorf("refusing to write project file: path outside projects root")
 	}
 
 	if err := os.MkdirAll(dirPath, common.DirPerm); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	envPath := filepath.Join(dirPath, ".env")
-	if err := os.WriteFile(envPath, []byte(content), common.FilePerm); err != nil {
-		return fmt.Errorf("failed to write env file: %w", err)
+	if fileName == "" || filepath.Base(fileName) != fileName || strings.Contains(fileName, string(filepath.Separator)) {
+		return fmt.Errorf("invalid project file name %q", fileName)
+	}
+
+	targetPath := filepath.Join(dirPath, fileName)
+	if err := os.WriteFile(targetPath, []byte(content), common.FilePerm); err != nil {
+		return fmt.Errorf("failed to write project file %s: %w", fileName, err)
 	}
 
 	return nil
+}
+
+func RemoveProjectFile(projectsRoot, dirPath, fileName string) error {
+	absPath, err := filepath.Abs(dirPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve directory path: %w", err)
+	}
+	dirPath = filepath.Clean(absPath)
+
+	rootAbs, err := filepath.Abs(projectsRoot)
+	if err != nil {
+		return fmt.Errorf("failed to resolve projects root: %w", err)
+	}
+	rootAbs = filepath.Clean(rootAbs)
+
+	if !IsSafeSubdirectory(rootAbs, dirPath) {
+		return fmt.Errorf("refusing to remove project file: path outside projects root")
+	}
+
+	if fileName == "" || filepath.Base(fileName) != fileName || strings.Contains(fileName, string(filepath.Separator)) {
+		return fmt.Errorf("invalid project file name %q", fileName)
+	}
+
+	targetPath := filepath.Join(dirPath, fileName)
+	if err := os.Remove(targetPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to remove project file %s: %w", fileName, err)
+	}
+
+	return nil
+}
+
+// WriteEnvFile writes a .env file to the specified directory
+// projectsRoot is the allowed root directory to prevent path traversal attacks
+func WriteEnvFile(projectsRoot, dirPath, content string) error {
+	return WriteProjectFile(projectsRoot, dirPath, ".env", content)
+}
+
+func EnsureEnvFile(projectsRoot, dirPath string) error {
+	envPath := filepath.Join(dirPath, ".env")
+	if _, err := os.Stat(envPath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to stat env file: %w", err)
+	}
+
+	return WriteEnvFile(projectsRoot, dirPath, "")
 }
 
 // WriteProjectFiles writes both compose and env files to a project directory.
@@ -119,11 +169,8 @@ func WriteProjectFiles(projectsRoot, dirPath, composeContent string, envContent 
 			return err
 		}
 	} else {
-		envPath := filepath.Join(dirPath, ".env")
-		if _, err := os.Stat(envPath); os.IsNotExist(err) {
-			if err := WriteEnvFile(projectsRoot, dirPath, ""); err != nil {
-				return err
-			}
+		if err := EnsureEnvFile(projectsRoot, dirPath); err != nil {
+			return err
 		}
 	}
 

--- a/backend/pkg/projects/env.go
+++ b/backend/pkg/projects/env.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,9 +18,11 @@ import (
 )
 
 const (
-	globalEnvFileName  = ".env.global"
-	projectEnvFileName = ".env"
-	globalEnvHeader    = `# Global Environment Variables
+	GlobalEnvFileName    = ".env.global"
+	EffectiveEnvFileName = ".env"
+	GitSourceEnvFileName = ".env.git"
+	OverrideEnvFileName  = "project.env"
+	globalEnvHeader      = `# Global Environment Variables
 # These variables are available to all projects
 # Created: %s
 
@@ -26,6 +30,26 @@ const (
 )
 
 type EnvMap = map[string]string
+
+type ProjectEnvMode string
+
+const (
+	ProjectEnvModeDirect   ProjectEnvMode = "direct"
+	ProjectEnvModeOverride ProjectEnvMode = "override"
+)
+
+type ProjectEnvState struct {
+	Mode             ProjectEnvMode
+	EditableFileName string
+	EditableContent  string
+	EffectiveContent string
+	DirectContent    string
+	HasEffective     bool
+	GitContent       string
+	HasGitSource     bool
+	OverrideContent  string
+	HasOverride      bool
+}
 
 type EnvLoader struct {
 	projectsDir   string
@@ -49,7 +73,7 @@ func (l *EnvLoader) LoadEnvironment(ctx context.Context) (envMap EnvMap, injecti
 	envMap = l.loadProcessEnv()
 	injectionVars = make(EnvMap)
 
-	globalEnvPath := filepath.Join(l.projectsDir, globalEnvFileName)
+	globalEnvPath := filepath.Join(l.projectsDir, GlobalEnvFileName)
 	if err := l.ensureGlobalEnvFile(ctx, globalEnvPath); err != nil {
 		slog.WarnContext(ctx, "Failed to ensure global env file", "path", globalEnvPath, "error", err)
 	}
@@ -58,7 +82,7 @@ func (l *EnvLoader) LoadEnvironment(ctx context.Context) (envMap EnvMap, injecti
 		slog.WarnContext(ctx, "Failed to load global env", "path", globalEnvPath, "error", err)
 	}
 
-	projectEnvPath := filepath.Join(l.workdir, projectEnvFileName)
+	projectEnvPath := filepath.Join(l.workdir, EffectiveEnvFileName)
 	if err := l.loadAndMergeProjectEnv(ctx, projectEnvPath, envMap, injectionVars); err != nil {
 		slog.WarnContext(ctx, "Failed to load project env", "path", projectEnvPath, "error", err)
 	}
@@ -179,6 +203,145 @@ func ParseProjectEnvContent(content string, contextEnv EnvMap) (EnvMap, error) {
 	return parseEnvWithContext(strings.NewReader(content), contextEnv)
 }
 
+// BuildEffectiveEnvContent merges git and override env sources into the effective
+// .env content written to disk. The output is normalized: comments are dropped,
+// keys are sorted, and values are rewritten with Arcane's formatter.
+func BuildEffectiveEnvContent(gitContent, overrideContent string) (string, error) {
+	contextEnv := make(EnvMap)
+
+	gitEnv, err := ParseProjectEnvContent(gitContent, contextEnv)
+	if err != nil {
+		return "", fmt.Errorf("parse git env content: %w", err)
+	}
+	maps.Copy(contextEnv, gitEnv)
+
+	overrideEnv, err := ParseProjectEnvContent(overrideContent, contextEnv)
+	if err != nil {
+		return "", fmt.Errorf("parse override env content: %w", err)
+	}
+
+	merged := make(EnvMap, len(gitEnv)+len(overrideEnv))
+	maps.Copy(merged, gitEnv)
+	maps.Copy(merged, overrideEnv)
+
+	return formatEnvMapInternal(merged), nil
+}
+
+// BuildOverrideEnvContent derives the editable override file from git-backed and
+// effective env content. The generated output is normalized and does not retain
+// comments or original key ordering.
+func BuildOverrideEnvContent(gitContent, effectiveContent string) (string, error) {
+	return buildOverrideEnvContentInternal(gitContent, effectiveContent)
+}
+
+// BuildAdditiveOverrideEnvContent derives override content from a pre-git local
+// .env file. Like other generated env helpers, the result is normalized and does
+// not preserve comments or original key ordering.
+func BuildAdditiveOverrideEnvContent(gitContent, localContent string) (string, error) {
+	contextEnv := make(EnvMap)
+
+	gitEnv, err := ParseProjectEnvContent(gitContent, contextEnv)
+	if err != nil {
+		return "", fmt.Errorf("parse git env content: %w", err)
+	}
+	maps.Copy(contextEnv, gitEnv)
+
+	localEnv, err := ParseProjectEnvContent(localContent, contextEnv)
+	if err != nil {
+		return "", fmt.Errorf("parse local env content: %w", err)
+	}
+
+	override := make(EnvMap)
+	for key, value := range localEnv {
+		if _, exists := gitEnv[key]; !exists {
+			override[key] = value
+		}
+	}
+
+	return formatEnvMapInternal(override), nil
+}
+
+func buildOverrideEnvContentInternal(gitContent, effectiveContent string) (string, error) {
+	contextEnv := make(EnvMap)
+
+	gitEnv, err := ParseProjectEnvContent(gitContent, contextEnv)
+	if err != nil {
+		return "", fmt.Errorf("parse git env content: %w", err)
+	}
+	maps.Copy(contextEnv, gitEnv)
+
+	effectiveEnv, err := ParseProjectEnvContent(effectiveContent, contextEnv)
+	if err != nil {
+		return "", fmt.Errorf("parse effective env content: %w", err)
+	}
+
+	override := make(EnvMap)
+	for key, value := range effectiveEnv {
+		gitValue, exists := gitEnv[key]
+		switch {
+		case !exists:
+			override[key] = value
+		case value == "":
+			// Empty values for Git-backed keys are treated as deleting the local override,
+			// so the Git value is restored on the next effective merge.
+			continue
+		case gitValue != value:
+			override[key] = value
+		}
+	}
+
+	return formatEnvMapInternal(override), nil
+}
+
+func ReadProjectEnvState(projectPath string) (ProjectEnvState, error) {
+	effectiveContent, hasEffective, err := readOptionalProjectFileInternal(projectPath, EffectiveEnvFileName)
+	if err != nil {
+		return ProjectEnvState{}, err
+	}
+
+	gitContent, hasGitSource, err := readOptionalProjectFileInternal(projectPath, GitSourceEnvFileName)
+	if err != nil {
+		return ProjectEnvState{}, err
+	}
+
+	overrideContent, hasOverride, err := readOptionalProjectFileInternal(projectPath, OverrideEnvFileName)
+	if err != nil {
+		return ProjectEnvState{}, err
+	}
+
+	state := ProjectEnvState{
+		DirectContent:    effectiveContent,
+		EffectiveContent: effectiveContent,
+		HasEffective:     hasEffective,
+		GitContent:       gitContent,
+		HasGitSource:     hasGitSource,
+		OverrideContent:  overrideContent,
+		HasOverride:      hasOverride,
+	}
+
+	if hasGitSource || hasOverride {
+		state.Mode = ProjectEnvModeOverride
+		state.EditableFileName = OverrideEnvFileName
+		state.EditableContent = overrideContent
+
+		if !hasEffective {
+			mergedContent, mergeErr := BuildEffectiveEnvContent(gitContent, overrideContent)
+			if mergeErr != nil {
+				return ProjectEnvState{}, mergeErr
+			}
+			state.EffectiveContent = mergedContent
+		}
+
+		return state, nil
+	}
+
+	state.Mode = ProjectEnvModeDirect
+	state.EditableFileName = EffectiveEnvFileName
+	state.EditableContent = effectiveContent
+
+	return state, nil
+}
+
 // parseEnvWithContext parses environment variables from an io.Reader using compose-go's
 // dotenv parser with variable expansion using the provided context lookup map.
 func parseEnvWithContext(r io.Reader, contextEnv EnvMap) (EnvMap, error) {
@@ -198,4 +361,61 @@ func parseEnvWithContext(r io.Reader, contextEnv EnvMap) (EnvMap, error) {
 	}
 
 	return EnvMap(envMap), nil
+}
+
+func readOptionalProjectFileInternal(projectPath, fileName string) (string, bool, error) {
+	content, err := os.ReadFile(filepath.Join(projectPath, fileName))
+	if err == nil {
+		return string(content), true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	return "", false, fmt.Errorf("read %s: %w", fileName, err)
+}
+
+// formatEnvMapInternal serializes env maps into Arcane's canonical generated
+// format. This is intentionally lossy: comments are omitted and keys are sorted
+// alphabetically to keep persisted merge output stable.
+func formatEnvMapInternal(envMap EnvMap) string {
+	if len(envMap) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(envMap))
+	for key := range envMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var builder strings.Builder
+	for _, key := range keys {
+		builder.WriteString(key)
+		builder.WriteByte('=')
+		builder.WriteString(formatEnvValueInternal(envMap[key]))
+		builder.WriteByte('\n')
+	}
+
+	return builder.String()
+}
+
+func formatEnvValueInternal(value string) string {
+	if value == "" {
+		return value
+	}
+
+	needsQuotes := strings.ContainsAny(value, " \t\r\n#\"'") || strings.TrimSpace(value) != value
+	if !needsQuotes {
+		return value
+	}
+
+	escaped := strings.NewReplacer(
+		"\\", "\\\\",
+		`"`, `\"`,
+		"\t", `\t`,
+		"\n", `\n`,
+		"\r", `\r`,
+	).Replace(value)
+
+	return `"` + escaped + `"`
 }

--- a/backend/pkg/projects/env_test.go
+++ b/backend/pkg/projects/env_test.go
@@ -68,3 +68,103 @@ func TestLoadEnvironment(t *testing.T) {
 		assert.Equal(t, "project_shared", injectionVars["SHARED_VAR"])
 	})
 }
+
+func TestBuildEffectiveEnvContent(t *testing.T) {
+	gitContent := "BASE_URL=https://example.com\nSHARED=git\n"
+	overrideContent := "API_TOKEN=secret\nSHARED=override\n"
+
+	effective, err := BuildEffectiveEnvContent(gitContent, overrideContent)
+	require.NoError(t, err)
+	assert.Contains(t, effective, "BASE_URL=https://example.com\n")
+	assert.Contains(t, effective, "API_TOKEN=secret\n")
+	assert.Contains(t, effective, "SHARED=override\n")
+	assert.NotContains(t, effective, "SHARED=git\n")
+}
+
+func TestBuildOverrideEnvContent(t *testing.T) {
+	t.Run("includes only values that differ from git", func(t *testing.T) {
+		gitContent := "BASE_URL=https://example.com\nSHARED=git\n"
+		effectiveContent := "BASE_URL=https://example.com\nSHARED=git\nAPI_TOKEN=secret\n"
+
+		override, err := BuildOverrideEnvContent(gitContent, effectiveContent)
+		require.NoError(t, err)
+		assert.Equal(t, "API_TOKEN=secret\n", override)
+	})
+
+	t.Run("falls back to git for removed git variables", func(t *testing.T) {
+		gitContent := "BASE_URL=https://example.com\nREMOVE_ME=1\n"
+		effectiveContent := "BASE_URL=https://example.com\n"
+
+		override, err := BuildOverrideEnvContent(gitContent, effectiveContent)
+		require.NoError(t, err)
+		assert.Equal(t, "", override)
+	})
+
+	t.Run("drops empty overrides for git-backed keys during normalization", func(t *testing.T) {
+		gitContent := "BASE_URL=https://example.com\nREMOVE_ME=1\n"
+		effectiveContent := "BASE_URL=https://example.com\nREMOVE_ME=\nTOKEN=local\n"
+
+		override, err := BuildOverrideEnvContent(gitContent, effectiveContent)
+		require.NoError(t, err)
+		assert.Equal(t, "TOKEN=local\n", override)
+	})
+
+	t.Run("keeps explicit empty local-only values", func(t *testing.T) {
+		gitContent := "BASE_URL=https://example.com\n"
+		effectiveContent := "BASE_URL=https://example.com\nLOCAL_EMPTY=\n"
+
+		override, err := BuildOverrideEnvContent(gitContent, effectiveContent)
+		require.NoError(t, err)
+		assert.Equal(t, "LOCAL_EMPTY=\n", override)
+	})
+
+	t.Run("override derivation keeps local-only keys during migration", func(t *testing.T) {
+		gitContent := "BASE_URL=https://example.com\nREMOTE_ONLY=1\n"
+		effectiveContent := "BASE_URL=https://example.com\nTOKEN=local\n"
+
+		override, err := BuildOverrideEnvContent(gitContent, effectiveContent)
+		require.NoError(t, err)
+		assert.Equal(t, "TOKEN=local\n", override)
+	})
+
+	t.Run("additive migration keeps only local-only keys when a direct env becomes git-managed", func(t *testing.T) {
+		gitContent := "TOKEN=git\nREMOTE_ONLY=1\n"
+		localContent := "TOKEN=stale-local\nLOCAL_ONLY=1\n"
+
+		override, err := BuildAdditiveOverrideEnvContent(gitContent, localContent)
+		require.NoError(t, err)
+		assert.Equal(t, "LOCAL_ONLY=1\n", override)
+	})
+}
+
+func TestReadProjectEnvState(t *testing.T) {
+	t.Run("direct mode uses .env as editable source", func(t *testing.T) {
+		projectDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(projectDir, EffectiveEnvFileName), []byte("FOO=bar\n"), common.FilePerm))
+
+		state, err := ReadProjectEnvState(projectDir)
+		require.NoError(t, err)
+		assert.Equal(t, ProjectEnvModeDirect, state.Mode)
+		assert.Equal(t, EffectiveEnvFileName, state.EditableFileName)
+		assert.Equal(t, "FOO=bar\n", state.EditableContent)
+		assert.False(t, state.HasGitSource)
+		assert.False(t, state.HasOverride)
+	})
+
+	t.Run("override mode exposes project.env and git source separately", func(t *testing.T) {
+		projectDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(projectDir, EffectiveEnvFileName), []byte("A=1\nB=2\n"), common.FilePerm))
+		require.NoError(t, os.WriteFile(filepath.Join(projectDir, GitSourceEnvFileName), []byte("A=1\n"), common.FilePerm))
+		require.NoError(t, os.WriteFile(filepath.Join(projectDir, OverrideEnvFileName), []byte("B=2\n"), common.FilePerm))
+
+		state, err := ReadProjectEnvState(projectDir)
+		require.NoError(t, err)
+		assert.Equal(t, ProjectEnvModeOverride, state.Mode)
+		assert.Equal(t, OverrideEnvFileName, state.EditableFileName)
+		assert.Equal(t, "B=2\n", state.EditableContent)
+		assert.True(t, state.HasGitSource)
+		assert.Equal(t, "A=1\n", state.GitContent)
+		assert.True(t, state.HasOverride)
+		assert.Equal(t, "A=1\nB=2\n", state.EffectiveContent)
+	})
+}

--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -94,7 +94,7 @@
 		!isGitOpsManaged && !isLoading.saving && project?.status !== 'running' && project?.status !== 'partially running'
 	);
 	let canEditCompose = $derived(!isGitOpsManaged);
-	let canEditEnv = $derived(!isGitOpsManaged);
+	let canEditEnv = true;
 
 	let autoScrollStackLogs = $state(true);
 
@@ -287,6 +287,11 @@
 
 	const allComposeContents = $derived.by(() => {
 		return [$inputs.composeContent.value, ...Object.values(includeFilesState)].filter((value) => value.length > 0);
+	});
+	const codeEditorContext = $derived({
+		envContent: $inputs.envContent.value,
+		composeContents: allComposeContents,
+		globalVariables: globalVariableMap
 	});
 
 	async function refreshProjectDetails() {
@@ -589,11 +594,7 @@
 											fileId={`project:${projectId}:compose`}
 											originalValue={originalComposeContent}
 											enableDiff={true}
-											editorContext={{
-												envContent: $inputs.envContent.value,
-												composeContents: allComposeContents,
-												globalVariables: globalVariableMap
-											}}
+											editorContext={codeEditorContext}
 										/>
 									{:else if selectedFile === 'env'}
 										<CodePanel
@@ -608,11 +609,7 @@
 											fileId={`project:${projectId}:env`}
 											originalValue={originalEnvContent}
 											enableDiff={true}
-											editorContext={{
-												envContent: $inputs.envContent.value,
-												composeContents: allComposeContents,
-												globalVariables: globalVariableMap
-											}}
+											editorContext={codeEditorContext}
 										/>
 									{:else}
 										{@const includeFile = project?.includeFiles?.find((f) => f.relativePath === selectedFile)}
@@ -627,11 +624,7 @@
 												fileId={`project:${projectId}:include:${includeFile.relativePath}`}
 												originalValue={originalIncludeFiles[includeFile.relativePath]}
 												enableDiff={true}
-												editorContext={{
-													envContent: $inputs.envContent.value,
-													composeContents: allComposeContents,
-													globalVariables: globalVariableMap
-												}}
+												editorContext={codeEditorContext}
 											/>
 										{/if}
 									{/if}
@@ -714,11 +707,7 @@
 												fileId={`project:${projectId}:compose`}
 												originalValue={originalComposeContent}
 												enableDiff={true}
-												editorContext={{
-													envContent: $inputs.envContent.value,
-													composeContents: allComposeContents,
-													globalVariables: globalVariableMap
-												}}
+												editorContext={codeEditorContext}
 											/>
 										{:else if selectedFile === 'env'}
 											<CodePanel
@@ -733,11 +722,7 @@
 												fileId={`project:${projectId}:env`}
 												originalValue={originalEnvContent}
 												enableDiff={true}
-												editorContext={{
-													envContent: $inputs.envContent.value,
-													composeContents: allComposeContents,
-													globalVariables: globalVariableMap
-												}}
+												editorContext={codeEditorContext}
 											/>
 										{:else}
 											{@const includeFile = project?.includeFiles?.find((f) => f.relativePath === selectedFile)}
@@ -752,11 +737,7 @@
 													fileId={`project:${projectId}:include:${includeFile.relativePath}`}
 													originalValue={originalIncludeFiles[includeFile.relativePath]}
 													enableDiff={true}
-													editorContext={{
-														envContent: $inputs.envContent.value,
-														composeContents: allComposeContents,
-														globalVariables: globalVariableMap
-													}}
+													editorContext={codeEditorContext}
 												/>
 											{/if}
 										{/if}
@@ -799,11 +780,7 @@
 											fileId={`project:${projectId}:include:${includeFile.relativePath}`}
 											originalValue={originalIncludeFiles[includeFile.relativePath]}
 											enableDiff={true}
-											editorContext={{
-												envContent: $inputs.envContent.value,
-												composeContents: allComposeContents,
-												globalVariables: globalVariableMap
-											}}
+											editorContext={codeEditorContext}
 										/>
 									{/if}
 								{:else}
@@ -820,11 +797,7 @@
 											fileId={`project:${projectId}:compose`}
 											originalValue={originalComposeContent}
 											enableDiff={true}
-											editorContext={{
-												envContent: $inputs.envContent.value,
-												composeContents: allComposeContents,
-												globalVariables: globalVariableMap
-											}}
+											editorContext={codeEditorContext}
 										/>
 										<CodePanel
 											bind:open={envOpen}
@@ -838,11 +811,7 @@
 											fileId={`project:${projectId}:env`}
 											originalValue={originalEnvContent}
 											enableDiff={true}
-											editorContext={{
-												envContent: $inputs.envContent.value,
-												composeContents: allComposeContents,
-												globalVariables: globalVariableMap
-											}}
+											editorContext={codeEditorContext}
 										/>
 									</div>
 
@@ -872,11 +841,7 @@
 													fileId={`project:${projectId}:compose`}
 													originalValue={originalComposeContent}
 													enableDiff={true}
-													editorContext={{
-														envContent: $inputs.envContent.value,
-														composeContents: allComposeContents,
-														globalVariables: globalVariableMap
-													}}
+													editorContext={codeEditorContext}
 												/>
 											</div>
 										{/snippet}
@@ -895,11 +860,7 @@
 													fileId={`project:${projectId}:env`}
 													originalValue={originalEnvContent}
 													enableDiff={true}
-													editorContext={{
-														envContent: $inputs.envContent.value,
-														composeContents: allComposeContents,
-														globalVariables: globalVariableMap
-													}}
+													editorContext={codeEditorContext}
 												/>
 											</div>
 										{/snippet}

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -36,8 +36,9 @@ async function createProjectViaUI(page: Page, projectName: string) {
 	await page.getByRole('textbox', { name: 'My New Project' }).fill(projectName);
 	await page.getByRole('textbox', { name: 'My New Project' }).press('Enter');
 
-	const composeEditor = page.locator('.cm-editor').first();
-	const envEditor = page.locator('.cm-editor').nth(1);
+	const visibleEditors = page.locator('.cm-editor:visible');
+	const composeEditor = visibleEditors.first();
+	const envEditor = visibleEditors.nth(1);
 	await expect(composeEditor).toBeVisible();
 	await expect(envEditor).toBeVisible();
 
@@ -284,7 +285,7 @@ test.describe('New Compose Project Page', () => {
 		await page.getByRole('textbox', { name: 'My New Project' }).fill('syntax-check-project');
 		await page.getByRole('textbox', { name: 'My New Project' }).press('Enter');
 
-		const composeEditor = page.locator('.cm-editor').first();
+		const composeEditor = page.locator('.cm-editor:visible').first();
 		await expect(composeEditor).toBeVisible();
 
 		await setCodeMirrorValue(page, composeEditor, 'services:\n\tredis:\n\t\timage: redis:latest\n');
@@ -307,8 +308,9 @@ test.describe('New Compose Project Page', () => {
 		await page.getByRole('textbox', { name: 'My New Project' }).fill('env-check-project');
 		await page.getByRole('textbox', { name: 'My New Project' }).press('Enter');
 
-		const composeEditor = page.locator('.cm-editor').first();
-		const envEditor = page.locator('.cm-editor').nth(1);
+		const visibleEditors = page.locator('.cm-editor:visible');
+		const composeEditor = visibleEditors.first();
+		const envEditor = visibleEditors.nth(1);
 		await expect(composeEditor).toBeVisible();
 		await expect(envEditor).toBeVisible();
 
@@ -337,12 +339,12 @@ test.describe('New Compose Project Page', () => {
 		await page.getByRole('textbox', { name: 'My New Project' }).fill(projectName);
 		await page.getByRole('textbox', { name: 'My New Project' }).press('Enter');
 
-		const composeEditor = page.locator('.cm-editor').first();
+		const composeEditor = page.locator('.cm-editor:visible').first();
 		await expect(composeEditor).toBeVisible();
 		await setCodeMirrorValue(page, composeEditor, TEST_COMPOSE_YAML);
 		await expect(composeEditor).toContainText(/redis/i);
 
-		const envEditor = page.locator('.cm-editor').nth(1);
+		const envEditor = page.locator('.cm-editor:visible').nth(1);
 		await expect(envEditor).toBeVisible();
 		await setCodeMirrorValue(page, envEditor, envFile);
 		await expect(envEditor).toContainText(/redis/i);
@@ -509,7 +511,7 @@ test.describe('New Compose Project Page', () => {
 		await page.getByRole('textbox', { name: 'My New Project' }).fill(projectName);
 		await page.getByRole('textbox', { name: 'My New Project' }).press('Enter');
 
-		const composeEditor = page.locator('.cm-editor').first();
+		const composeEditor = page.locator('.cm-editor:visible').first();
 		await expect(composeEditor).toBeVisible();
 		await setCodeMirrorValue(page, composeEditor, TEST_COMPOSE_YAML);
 
@@ -619,11 +621,13 @@ test.describe('GitOps Managed Project', () => {
 		await page.waitForLoadState('networkidle');
 
 		await page.waitForTimeout(800);
-		const composeContent = page.locator('.cm-editor').first().locator('.cm-content');
+		const composeContent = page.locator('.cm-editor:visible').first().locator('.cm-content');
 		await expect(composeContent).toHaveAttribute('aria-readonly', 'true');
 	});
 
-	test('should have env editor in read-only mode when GitOps managed', async ({ page }) => {
+	test('should allow editing env editor when GitOps managed in classic and tree view', async ({
+		page
+	}) => {
 		const gitOpsProject = realProjects.find((p) => p.gitOpsManagedBy);
 		test.skip(!gitOpsProject, 'No GitOps-managed projects found');
 
@@ -635,8 +639,33 @@ test.describe('GitOps Managed Project', () => {
 		await page.waitForLoadState('networkidle');
 
 		await page.waitForTimeout(800);
-		const envContent = page.locator('.cm-editor').nth(1).locator('.cm-content');
-		await expect(envContent).toHaveAttribute('aria-readonly', 'true');
+		const envEditor = page.locator('.cm-editor:visible').nth(1);
+		const envContent = envEditor.locator('.cm-content');
+		const marker = `ARCANE_E2E_${Date.now()}`;
+		const originalEnv = await envContent.evaluate((node) => (node as HTMLElement).innerText ?? '');
+		const updatedEnv = `${originalEnv.trimEnd()}\n${marker}=1\n`;
+
+		await expect(envContent).not.toHaveAttribute('aria-readonly', 'true');
+		await setCodeMirrorValue(page, envEditor, updatedEnv);
+		await expect(envEditor).toContainText(marker);
+		await expect(page.getByRole('button', { name: 'Save', exact: true }).first()).toBeVisible();
+
+		const layoutSwitch = page.getByRole('switch', {
+			name: /Classic|Tree View/i
+		});
+		if (await layoutSwitch.count()) {
+			await layoutSwitch.click();
+			await page.waitForLoadState('networkidle');
+
+			const envFileButton = page.getByRole('button', { name: '.env' }).first();
+			await expect(envFileButton).toBeVisible();
+			await envFileButton.click();
+
+			const treeEnvEditor = page.locator('.cm-editor:visible').first();
+			const treeEnvContent = treeEnvEditor.locator('.cm-content');
+			await expect(treeEnvContent).not.toHaveAttribute('aria-readonly', 'true');
+			await expect(treeEnvEditor).toContainText(marker);
+		}
 	});
 
 	test('should allow editing for non-GitOps managed projects', async ({ page }) => {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/1748

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the issue where users could not edit env variables for projects synced from Git. The fix introduces a three-file env model (`.env.git` for the git source, `project.env` for user overrides, `.env` for the merged effective env), ensuring that user-local changes are preserved across git syncs while compose always reads a consistent effective env file.

Key changes:
- **Frontend**: `canEditEnv` is unconditionally set to `true`, unlocking the env editor for GitOps-managed projects.
- **Backend — env model**: New `ProjectEnvState`, `ReadProjectEnvState`, and `Build*EnvContent` helpers in `pkg/projects/env.go` formalise the three-file model and provide deterministic, alphabetically-sorted output.
- **Backend — project service**: `GetProjectDetails` now returns the *effective* env content (git + override merged) so the UI always shows what Docker Compose actually uses. `UpdateProject` routes env writes through `persistEffectiveEnvContentInternal`, which derives and persists the override on save. New exported `ApplyGitSyncProjectFiles` replaces the previous direct `UpdateProject` call in the GitOps sync path.
- **Backend — fs utilities**: `WriteEnvFile` is refactored into a generic `WriteProjectFile` with filename validation; `RemoveProjectFile` and `EnsureEnvFile` are added.
- **Tests**: Comprehensive table-driven integration tests cover override derivation, stale-value normalisation, first-sync migration, git source removal, and `GetProjectDetails` returning effective content.

One logic concern was identified in `resolveOverrideContentForGitSyncInternal` (see inline comment): the `HasGitSource` branch ignores the incoming new git content entirely and passes raw override content where full effective content is expected, which is functionally equivalent today but semantically fragile.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge with caution — core logic is well-tested but one branch in the override resolution has a subtle semantic issue that could introduce a latent bug if the shared helper is refactored.
- The PR is broadly correct and all edge cases are covered by integration tests. However, `resolveOverrideContentForGitSyncInternal`'s `HasGitSource` branch silently ignores the incoming new git content when normalising user overrides, and misuses `BuildOverrideEnvContent` by passing override content as the `effectiveContent` argument. While today's implementation makes the two calls equivalent, a future change to `buildOverrideEnvContentInternal` could silently regress this path. The PR also changes `GetProjectDetails` from silently ignoring env-read errors to returning hard errors, which is a behaviour change worth validating in staging for projects with unusual filesystem conditions.
- `backend/internal/services/project_service.go` — specifically the `resolveOverrideContentForGitSyncInternal` function and its `HasGitSource` branch.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/gitops_sync_service.go | Refactored to use `ApplyGitSyncProjectFiles` for both project creation and update paths. Content-change detection is now post-update and semantic (key/value equality, not string equality). New `envContentChangedInternal` helper correctly ignores ordering and comment changes. |
| backend/internal/services/project_service.go | Core of the fix: adds `ApplyGitSyncProjectFiles` and seven new private helpers for git-backed env management. `GetProjectDetails` now uses `ReadProjectEnvState` to return the effective env. `getPathMapper` nil-guard for `dockerService` fixes a nil panic in tests. Semantic mismatch in `resolveOverrideContentForGitSyncInternal` HasGitSource branch (uses old git content, passes override as effectiveContent) — functionally equivalent today but fragile. |
| backend/pkg/projects/env.go | Adds `ProjectEnvState`, `ReadProjectEnvState`, and the three `Build*EnvContent` helpers. Previously private constants exported. `formatEnvMapInternal` produces stable alphabetically-sorted output. `buildOverrideEnvContentInternal` correctly handles empty-value deletion semantics for git-backed keys. |
| backend/internal/utils/fs/fs_writer.go | Generalised from `WriteEnvFile` to `WriteProjectFile` with filename validation. Added `RemoveProjectFile` (idempotent on not-found) and `EnsureEnvFile`. Path traversal guards are correctly applied on writes and removes. |
| frontend/src/routes/(app)/projects/[projectId]/+page.svelte | `canEditEnv` changed from `$derived(!isGitOpsManaged)` to a plain `true` constant, enabling env editing for GitOps-managed projects. Duplicate `editorContext` inline object literals replaced with a single `$derived` `codeEditorContext`. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (6)</h3></summary>

1. `backend/internal/services/project_service.go`, line 291-299 ([link](https://github.com/getarcaneapp/arcane/blob/971f605050d5bd525067e9546880ca4a2e2025f3/backend/internal/services/project_service.go#L291-L299)) 

   **`.env` written after `project.env`, leaving it stale on crash**

   When `state.HasGitSource` is true the write sequence is:

   1. Write or remove `project.env` (the override)
   2. Write `.env` (the effective file)

   If the process crashes or returns an error after step 1 but before step 2, `project.env` contains the new override while `.env` still holds the old effective content. On the next read, `resolveStoredEffectiveEnvContentInternal` short-circuits as soon as it sees that `.env` exists (`state.HasEffective == true`) and returns the stale content verbatim — it never recomputes from the git+override sources. The user would then see their changes silently discarded until the next full sync or save.

   `persistGitSyncEnvFilesInternal` (further down in this file) correctly writes `.env` first for exactly this reason. The same ordering should be applied here:

   ```go
   // write .env first so it is always consistent with at least one
   // complete set of source files
   if err := fs.WriteEnvFile(projectsDirectory, projectPath, effectiveContent); err != nil {
       return err
   }
   if strings.TrimSpace(overrideContent) == "" {
       if err := fs.RemoveProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName); err != nil {
           return err
       }
   } else if err := fs.WriteProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName, overrideContent); err != nil {
       return err
   }
   return nil
   ```

2. `backend/pkg/projects/env.go`, line 394-409 ([link](https://github.com/getarcaneapp/arcane/blob/971f605050d5bd525067e9546880ca4a2e2025f3/backend/pkg/projects/env.go#L394-L409)) 

   **Tab character not escaped in quoted values**

   `needsQuotes` fires for `\t` (via `strings.ContainsAny(value, " \t\r\n#\"'")`), but the `strings.NewReplacer` only handles `\\`, `"`, `\n`, and `\r`. A value containing a literal tab will be emitted as `"value<TAB>rest"` — a quoted string with a raw tab byte inside.

   While most dotenv parsers preserve literal whitespace inside double-quoted strings, adding `\t` to the replacer makes the output unambiguous and consistent with how `\n` and `\r` are already handled:

3. `backend/internal/services/project_service.go`, line 1895-1950 ([link](https://github.com/getarcaneapp/arcane/blob/05b1714cd8596d60f9463b32e3120a49140aaa7c/backend/internal/services/project_service.go#L1895-L1950)) 

   **Double read of filesystem state causes TOCTOU risk**

   `ApplyGitSyncProjectFiles` calls `resolveEffectiveEnvContentForGitSyncUpdateInternal` (which internally calls `ReadProjectEnvState` → `resolveOverrideContentForGitSyncInternal`) for compose validation, and then calls `persistGitSyncEnvFilesInternal` (which independently calls `ReadProjectEnvState` → `resolveOverrideContentForGitSyncInternal` again) to do the actual write.

   Both read the filesystem state independently. If another operation (e.g., a concurrent sync or a direct env edit) modifies `.env.git` / `project.env` between these two calls, compose validation will use a different override than what gets written to disk. This TOCTOU window is small but real — especially in environments with frequent syncs.

   A cleaner approach would be to compute the `ProjectEnvState` and the resolved override once and pass them through:

   ```go
   // Read state once, share it
   state, err := projects.ReadProjectEnvState(proj.Path)
   overrideContent, err := s.resolveOverrideContentForGitSyncInternal(state, ...)
   effectiveContent, err := projects.BuildEffectiveEnvContent(...)
   // pass effectiveContent to validateComposeContentForUpdate
   // pass overrideContent + effectiveContent to the write helpers
   ```

4. `backend/internal/services/gitops_sync_service.go`, line 37-39 ([link](https://github.com/getarcaneapp/arcane/blob/05b1714cd8596d60f9463b32e3120a49140aaa7c/backend/internal/services/gitops_sync_service.go#L37-L39)) 

   **Normalized env output can trigger spurious redeployment on first sync**

   `contentChanged` is now determined by comparing raw file bytes before and after `ApplyGitSyncProjectFiles`. Because the new code normalizes the effective env (sorted keys, no comments, via `formatEnvMapInternal`), a project whose existing `.env` was not previously normalized (any project created before this PR) will always show `oldEnv != newEnv` on the first sync after upgrade — even if no env variables actually changed — causing an unnecessary redeploy.

   For example, if `.env` was previously `B=2\nA=1\n# comment\n` and git sends the same keys/values, after `ApplyGitSyncProjectFiles` the file becomes `A=1\nB=2\n`. The comparison `oldEnv != newEnv` is true → spurious redeploy.

   The old approach compared against the desired incoming content directly. An alternative is to parse both old and new as env maps and compare semantically:

   ```go
   oldEnvMap, _ := projects.ParseProjectEnvContent(oldEnv, nil)
   newEnvMap, _ := projects.ParseProjectEnvContent(newEnv, nil)
   contentChanged := oldCompose != newCompose || !maps.Equal(oldEnvMap, newEnvMap)
   ```

5. `backend/pkg/projects/env.go`, line 372-394 ([link](https://github.com/getarcaneapp/arcane/blob/05b1714cd8596d60f9463b32e3120a49140aaa7c/backend/pkg/projects/env.go#L372-L394)) 

   **Env normalization silently strips comments and reorders keys**

   `formatEnvMapInternal` sorts all keys alphabetically and strips comments. This means every time a git sync runs or the user edits the env for a git-managed project, the effective `.env` file — and the content shown back to the user via `GetProjectDetails` — loses all comments and is alphabetically reordered.

   Since `GetProjectDetails` now returns `effectiveEnvContent` derived from this function, the content a user sees in the UI editor is the stripped/normalized form. Any comments they added (e.g., grouping vars by purpose) are permanently lost after the first save or sync.

   For auto-generated merge output this normalisation is sensible, but the current behaviour is a silent, lossy transformation. At minimum the function should be documented to make the trade-off explicit, and the team should consider whether the API response for git-managed projects should return the raw `project.env` (editable overrides) content to the editor rather than the fully merged, normalized form.

6. `backend/internal/services/project_service.go`, line 2233-2238 ([link](https://github.com/getarcaneapp/arcane/blob/3a18ab8e66776c066ca93dc2d7f7f7720dc81edd/backend/internal/services/project_service.go#L2233-L2238)) 

   **`HasGitSource` branch ignores the incoming `gitEnvContent` argument**

   In `resolveOverrideContentForGitSyncInternal`, the `HasGitSource` branch normalises the override by calling `BuildOverrideEnvContent(state.GitContent, state.OverrideContent)`. Two things stand out:

   1. The `gitEnvContent` parameter (the **new** git content arriving from the sync) is not used at all in this branch; the call uses the **old** `state.GitContent` stored on disk.
   2. `BuildOverrideEnvContent`'s second parameter is documented as `effectiveContent` (the full merged env), but `state.OverrideContent` — the raw `project.env` file — is passed instead. As long as `buildOverrideEnvContentInternal` is not modified to rely on git keys being present in `effectiveContent`, the result is accidentally equivalent, but the semantic mismatch makes the code harder to reason about and fragile under future refactors.

   A clearer approach would be to derive the override relative to the incoming new git content:

   ```go
   case state.HasGitSource:
       // Re-derive the override against the NEW git content so that any
       // key in the existing override that now matches the updated git
       // value is automatically stripped.
       effectiveContent, err := s.resolveStoredEffectiveEnvContentInternal(state)
       if err != nil {
           return "", err
       }
       overrideContent, err := projects.BuildOverrideEnvContent(gitEnvContent, effectiveContent)
       if err != nil {
           return "", fmt.Errorf("build override env content: %w", err)
       }
       return overrideContent, nil
   ```

   This also has the nice property that, when git updates a key to match what the user had previously overridden, the override is automatically cleaned up.

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A2233-2238%0A**%60HasGitSource%60%20branch%20ignores%20the%20incoming%20%60gitEnvContent%60%20argument**%0A%0AIn%20%60resolveOverrideContentForGitSyncInternal%60%2C%20the%20%60HasGitSource%60%20branch%20normalises%20the%20override%20by%20calling%20%60BuildOverrideEnvContent%28state.GitContent%2C%20state.OverrideContent%29%60.%20Two%20things%20stand%20out%3A%0A%0A1.%20The%20%60gitEnvContent%60%20parameter%20%28the%20**new**%20git%20content%20arriving%20from%20the%20sync%29%20is%20not%20used%20at%20all%20in%20this%20branch%3B%20the%20call%20uses%20the%20**old**%20%60state.GitContent%60%20stored%20on%20disk.%0A2.%20%60BuildOverrideEnvContent%60's%20second%20parameter%20is%20documented%20as%20%60effectiveContent%60%20%28the%20full%20merged%20env%29%2C%20but%20%60state.OverrideContent%60%20%E2%80%94%20the%20raw%20%60project.env%60%20file%20%E2%80%94%20is%20passed%20instead.%20As%20long%20as%20%60buildOverrideEnvContentInternal%60%20is%20not%20modified%20to%20rely%20on%20git%20keys%20being%20present%20in%20%60effectiveContent%60%2C%20the%20result%20is%20accidentally%20equivalent%2C%20but%20the%20semantic%20mismatch%20makes%20the%20code%20harder%20to%20reason%20about%20and%20fragile%20under%20future%20refactors.%0A%0AA%20clearer%20approach%20would%20be%20to%20derive%20the%20override%20relative%20to%20the%20incoming%20new%20git%20content%3A%0A%0A%60%60%60go%0Acase%20state.HasGitSource%3A%0A%20%20%20%20%2F%2F%20Re-derive%20the%20override%20against%20the%20NEW%20git%20content%20so%20that%20any%0A%20%20%20%20%2F%2F%20key%20in%20the%20existing%20override%20that%20now%20matches%20the%20updated%20git%0A%20%20%20%20%2F%2F%20value%20is%20automatically%20stripped.%0A%20%20%20%20effectiveContent%2C%20err%20%3A%3D%20s.resolveStoredEffectiveEnvContentInternal%28state%29%0A%20%20%20%20if%20err%20!%3D%20nil%20%7B%0A%20%20%20%20%20%20%20%20return%20%22%22%2C%20err%0A%20%20%20%20%7D%0A%20%20%20%20overrideContent%2C%20err%20%3A%3D%20projects.BuildOverrideEnvContent%28gitEnvContent%2C%20effectiveContent%29%0A%20%20%20%20if%20err%20!%3D%20nil%20%7B%0A%20%20%20%20%20%20%20%20return%20%22%22%2C%20fmt.Errorf%28%22build%20override%20env%20content%3A%20%25w%22%2C%20err%29%0A%20%20%20%20%7D%0A%20%20%20%20return%20overrideContent%2C%20nil%0A%60%60%60%0A%0AThis%20also%20has%20the%20nice%20property%20that%2C%20when%20git%20updates%20a%20key%20to%20match%20what%20the%20user%20had%20previously%20overridden%2C%20the%20override%20is%20automatically%20cleaned%20up.%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/project_service.go
Line: 2233-2238

Comment:
**`HasGitSource` branch ignores the incoming `gitEnvContent` argument**

In `resolveOverrideContentForGitSyncInternal`, the `HasGitSource` branch normalises the override by calling `BuildOverrideEnvContent(state.GitContent, state.OverrideContent)`. Two things stand out:

1. The `gitEnvContent` parameter (the **new** git content arriving from the sync) is not used at all in this branch; the call uses the **old** `state.GitContent` stored on disk.
2. `BuildOverrideEnvContent`'s second parameter is documented as `effectiveContent` (the full merged env), but `state.OverrideContent` — the raw `project.env` file — is passed instead. As long as `buildOverrideEnvContentInternal` is not modified to rely on git keys being present in `effectiveContent`, the result is accidentally equivalent, but the semantic mismatch makes the code harder to reason about and fragile under future refactors.

A clearer approach would be to derive the override relative to the incoming new git content:

```go
case state.HasGitSource:
    // Re-derive the override against the NEW git content so that any
    // key in the existing override that now matches the updated git
    // value is automatically stripped.
    effectiveContent, err := s.resolveStoredEffectiveEnvContentInternal(state)
    if err != nil {
        return "", err
    }
    overrideContent, err := projects.BuildOverrideEnvContent(gitEnvContent, effectiveContent)
    if err != nil {
        return "", fmt.Errorf("build override env content: %w", err)
    }
    return overrideContent, nil
```

This also has the nice property that, when git updates a key to match what the user had previously overridden, the override is automatically cleaned up.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 3a18ab8</sub>

<!-- /greptile_comment -->