### PR TITLE
fix: add missing arcane labels for auto updater

### DIFF
--- a/.github/workflows/build-next-images.yml
+++ b/.github/workflows/build-next-images.yml
@@ -143,6 +143,7 @@ jobs:
             org.opencontainers.image.ref.name=arcane-agent
             org.opencontainers.image.title=Arcane Agent
             org.opencontainers.image.description=Arcane Agent
+            com.getarcaneapp.arcane=true
             com.getarcaneapp.arcane.agent=true
 
       - name: Build and push agent image

--- a/.github/workflows/build-pr-images.yml
+++ b/.github/workflows/build-pr-images.yml
@@ -62,6 +62,7 @@ jobs:
                       org.opencontainers.image.ref.name=arcane
                       org.opencontainers.image.title=Arcane
                       org.opencontainers.image.description=Modern Docker Management, Made for Everyone
+                      com.getarcaneapp.arcane=true
 
             - name: Agent image metadata
               id: agent-meta
@@ -81,6 +82,8 @@ jobs:
                       org.opencontainers.image.ref.name=arcane-agent
                       org.opencontainers.image.title=Arcane Agent
                       org.opencontainers.image.description=Arcane Agent
+                      com.getarcaneapp.arcane=true
+                      com.getarcaneapp.arcane.agent=true
 
             - name: Build and push manager image
               uses: depot/build-push-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
             org.opencontainers.image.ref.name=arcane
             org.opencontainers.image.title=Arcane
             org.opencontainers.image.description=Modern Docker Management, Made for Everyone
+            com.getarcaneapp.arcane=true
 
       - name: Build and push manager image
         id: manager-build
@@ -123,6 +124,8 @@ jobs:
             org.opencontainers.image.ref.name=arcane-agent
             org.opencontainers.image.title=Arcane Agent
             org.opencontainers.image.description=Arcane Agent
+            com.getarcaneapp.arcane=true
+            com.getarcaneapp.arcane.agent=true
 
       - name: Build and push agent image
         id: agent-build

--- a/backend/cli/upgrade/upgrade.go
+++ b/backend/cli/upgrade/upgrade.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/getarcaneapp/arcane/backend/internal/utils/arcaneupdater"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/docker"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
+	libupdater "github.com/getarcaneapp/arcane/backend/pkg/libarcane/updater"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
@@ -53,7 +53,7 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 	// This prevents interruption when stopping the target container
 	ctx := context.Background()
 
-	logFile, err := arcaneupdater.SetupMessageOnlyLogFile("/app/data", "arcane-upgrade", slog.LevelInfo)
+	logFile, err := libupdater.SetupMessageOnlyLogFile("/app/data", "arcane-upgrade", slog.LevelInfo)
 	if err != nil {
 		slog.Warn("Failed to setup file logging", "error", err)
 	} else if logFile != nil {
@@ -151,7 +151,7 @@ func findArcaneContainer(ctx context.Context, dockerClient *client.Client) (cont
 		}
 
 		// New label: com.getarcaneapp.arcane=true
-		if arcaneupdater.IsArcaneContainer(labels) {
+		if libupdater.IsArcaneContainer(labels) {
 			slog.Info("Found Arcane container by label", "id", c.ID[:12], "image", c.Image, "names", c.Names)
 			return inspect, nil
 		}

--- a/backend/internal/services/system_service.go
+++ b/backend/internal/services/system_service.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
-	"github.com/getarcaneapp/arcane/backend/internal/utils/arcaneupdater"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/converter"
+	libupdater "github.com/getarcaneapp/arcane/backend/pkg/libarcane/updater"
 	containertypes "github.com/getarcaneapp/arcane/types/container"
 	"github.com/getarcaneapp/arcane/types/system"
 	"github.com/goccy/go-yaml"
@@ -257,7 +257,7 @@ func (s *SystemService) StopAllContainers(ctx context.Context) (*containertypes.
 	return s.performBatchContainerAction(ctx, containers, "stop",
 		func(c container.Summary) bool {
 			// Skip Arcane container
-			return !arcaneupdater.IsArcaneContainer(c.Labels)
+			return !libupdater.IsArcaneContainer(c.Labels)
 		},
 		func(ctx context.Context, id string) error {
 			return s.containerService.StopContainer(ctx, id, systemUser)

--- a/backend/internal/services/system_upgrade_service.go
+++ b/backend/internal/services/system_upgrade_service.go
@@ -14,6 +14,7 @@ import (
 	dockerutils "github.com/getarcaneapp/arcane/backend/internal/utils/docker"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/timeouts"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
+	libupdater "github.com/getarcaneapp/arcane/backend/pkg/libarcane/updater"
 	containertypes "github.com/moby/moby/api/types/container"
 	mounttypes "github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/client"
@@ -95,10 +96,8 @@ func (s *SystemUpgradeService) TriggerUpgradeViaCLI(ctx context.Context, user mo
 
 	// Determine binary path based on container type (agent vs main)
 	binaryPath := "/app/arcane"
-	if currentContainer.Config != nil && currentContainer.Config.Labels != nil {
-		if _, isAgent := currentContainer.Config.Labels["com.getarcaneapp.arcane.agent"]; isAgent {
-			binaryPath = "/app/arcane-agent"
-		}
+	if currentContainer.Config != nil {
+		binaryPath = determineUpgradeBinaryPathInternal(currentContainer.Config.Labels)
 	}
 
 	// Log upgrade event
@@ -209,6 +208,14 @@ func (s *SystemUpgradeService) TriggerUpgradeViaCLI(ctx context.Context, user mo
 	slog.Info("Upgrade container started", "upgraderId", resp.ID[:12], "upgraderName", containerName)
 
 	return nil
+}
+
+func determineUpgradeBinaryPathInternal(labels map[string]string) string {
+	if libupdater.IsArcaneAgentContainer(labels) {
+		return "/app/arcane-agent"
+	}
+
+	return "/app/arcane"
 }
 
 // getCurrentContainerID detects if we're running in Docker and returns container ID

--- a/backend/internal/services/system_upgrade_service_test.go
+++ b/backend/internal/services/system_upgrade_service_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"testing"
 
+	libupdater "github.com/getarcaneapp/arcane/backend/pkg/libarcane/updater"
 	"github.com/stretchr/testify/require"
 )
 
@@ -149,4 +150,37 @@ func TestSystemUpgradeService_AtomicOperations(t *testing.T) {
 	old := s.upgrading.Swap(true)
 	require.False(t, old)
 	require.True(t, s.upgrading.Load())
+}
+
+func TestDetermineUpgradeBinaryPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{
+			name: "agent container uses agent binary",
+			labels: map[string]string{
+				libupdater.LabelArcaneAgent: "true",
+			},
+			want: "/app/arcane-agent",
+		},
+		{
+			name: "main container uses main binary",
+			labels: map[string]string{
+				libupdater.LabelArcane: "true",
+			},
+			want: "/app/arcane",
+		},
+		{
+			name: "no labels defaults to main binary",
+			want: "/app/arcane",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, determineUpgradeBinaryPathInternal(tt.labels))
+		})
+	}
 }

--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
-	"github.com/getarcaneapp/arcane/backend/internal/utils/arcaneupdater"
 	arcRegistry "github.com/getarcaneapp/arcane/backend/internal/utils/registry"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
+	libupdater "github.com/getarcaneapp/arcane/backend/pkg/libarcane/updater"
 	projectspkg "github.com/getarcaneapp/arcane/backend/pkg/projects"
 	"github.com/getarcaneapp/arcane/types/updater"
 )
@@ -38,11 +38,15 @@ type UpdaterService struct {
 	eventService        *EventService
 	imageService        *ImageService
 	notificationService *NotificationService
-	upgradeService      *SystemUpgradeService
+	upgradeService      selfUpgradeService
 
 	statusMu           sync.RWMutex
 	updatingContainers map[string]bool
 	updatingProjects   map[string]bool
+}
+
+type selfUpgradeService interface {
+	TriggerUpgradeViaCLI(ctx context.Context, user models.User) error
 }
 
 // NewUpdaterService constructs an UpdaterService with the dependencies needed
@@ -57,7 +61,7 @@ func NewUpdaterService(
 	events *EventService,
 	imageSvc *ImageService,
 	notifications *NotificationService,
-	upgrade *SystemUpgradeService,
+	upgrade selfUpgradeService,
 ) *UpdaterService {
 	return &UpdaterService{
 		db:                  db,
@@ -158,7 +162,7 @@ func (s *UpdaterService) ApplyPending(ctx context.Context, dryRun bool) (*update
 	if err != nil {
 		return nil, fmt.Errorf("docker connect: %w", err)
 	}
-	digestChecker := arcaneupdater.NewDigestChecker(dcli, s.registryService)
+	digestChecker := libupdater.NewDigestChecker(dcli, s.registryService)
 
 	// track all old image IDs we saw for pulled updates so we can prune them after restart
 	oldIDSet := map[string]struct{}{}
@@ -438,7 +442,7 @@ func (s *UpdaterService) UpdateSingleContainer(ctx context.Context, containerID 
 		labels = inspectBefore.Config.Labels
 	}
 
-	isArcaneContainer := arcaneupdater.IsArcaneContainer(labels)
+	isArcaneContainer := libupdater.IsArcaneContainer(labels)
 	slog.InfoContext(ctx, "UpdateSingleContainer: inspected container",
 		"containerID", containerID,
 		"imageID", inspectBefore.Image,
@@ -450,7 +454,7 @@ func (s *UpdaterService) UpdateSingleContainer(ctx context.Context, containerID 
 	endProjectStatus := s.beginProjectUpdateInternal(composeProjectNameFromLabelsInternal(labels))
 	defer endProjectStatus()
 
-	if arcaneupdater.IsUpdateDisabled(labels) {
+	if libupdater.IsUpdateDisabled(labels) {
 		slog.InfoContext(ctx, "UpdateSingleContainer: updates disabled by label", "containerID", containerID)
 		out.Items = append(out.Items, updater.ResourceResult{
 			ResourceID:   targetContainer.ID,
@@ -526,7 +530,7 @@ func (s *UpdaterService) UpdateSingleContainer(ctx context.Context, containerID 
 	// Compare with pulled image to avoid unnecessary restart.
 	// digestResolver is intentionally nil: CompareWithPulled only inspects local
 	// images and does not need remote registry access.
-	checker := arcaneupdater.NewDigestChecker(dcli, nil)
+	checker := libupdater.NewDigestChecker(dcli, nil)
 	changed, cmpErr := checker.CompareWithPulled(ctx, inspectBefore.Image, normalizedRef)
 	slog.InfoContext(ctx, "UpdateSingleContainer: digest comparison",
 		"containerID", containerID,
@@ -560,16 +564,14 @@ func (s *UpdaterService) UpdateSingleContainer(ctx context.Context, containerID 
 		containerLabels = inspect.Config.Labels
 	}
 
-	if arcaneupdater.IsArcaneContainer(containerLabels) && s.upgradeService != nil {
-		slog.InfoContext(ctx, "UpdateSingleContainer: detected Arcane self-update, using CLI upgrade method", "containerID", containerID)
-
-		if err := s.upgradeService.TriggerUpgradeViaCLI(ctx, systemUser); err != nil {
+	if libupdater.IsArcaneContainer(containerLabels) {
+		if err := s.triggerSelfUpdateViaCLIInternal(ctx, "UpdateSingleContainer", containerID, containerName, containerLabels); err != nil {
 			out.Items = append(out.Items, updater.ResourceResult{
 				ResourceID:   targetContainer.ID,
 				ResourceType: "container",
 				ResourceName: containerName,
 				Status:       "failed",
-				Error:        fmt.Sprintf("CLI upgrade failed: %v", err),
+				Error:        err.Error(),
 			})
 			out.Failed++
 			out.Duration = time.Since(start).String()
@@ -707,7 +709,7 @@ func (s *UpdaterService) updateContainer(ctx context.Context, cnt container.Summ
 
 	name := s.getContainerName(cnt)
 	labels := inspect.Config.Labels
-	isArcane := arcaneupdater.IsArcaneContainer(labels)
+	isArcane := libupdater.IsArcaneContainer(labels)
 
 	// Arcane containers should always use CLI upgrade, not inline update
 	// This method should not be called for Arcane containers
@@ -721,7 +723,7 @@ func (s *UpdaterService) updateContainer(ctx context.Context, cnt container.Summ
 	originalName := inspect.Name
 
 	// Get custom stop signal if configured
-	stopSignal := arcaneupdater.GetStopSignal(labels)
+	stopSignal := libupdater.GetStopSignal(labels)
 	stopOpts := client.ContainerStopOptions{}
 	if stopSignal != "" {
 		stopOpts.Signal = stopSignal
@@ -904,7 +906,7 @@ func (s *UpdaterService) collectUsedImagesFromContainersInternal(ctx context.Con
 	list := listResult.Items
 	slog.DebugContext(ctx, "collectUsedImagesFromContainersInternal: container list fetched", "count", len(list))
 	for _, c := range list {
-		if arcaneupdater.IsUpdateDisabled(c.Labels) {
+		if libupdater.IsUpdateDisabled(c.Labels) {
 			slog.DebugContext(ctx, "collectUsedImagesFromContainersInternal: container opted out by labels", "containerId", c.ID)
 			continue
 		}
@@ -921,7 +923,7 @@ func (s *UpdaterService) collectUsedImagesFromContainersInternal(ctx context.Con
 			continue
 		}
 		inspect := inspectResult.Container
-		if inspect.Config != nil && arcaneupdater.IsUpdateDisabled(inspect.Config.Labels) {
+		if inspect.Config != nil && libupdater.IsUpdateDisabled(inspect.Config.Labels) {
 			slog.DebugContext(ctx, "collectUsedImagesFromContainersInternal: container inspect labels opted out", "containerId", c.ID)
 			continue
 		}
@@ -1033,7 +1035,7 @@ func (s *UpdaterService) collectUsedImagesFromComposeContainersInternal(composeC
 		if _, isActive := activeProjectNames[projectName]; !isActive {
 			continue
 		}
-		if arcaneupdater.IsUpdateDisabled(c.Labels) {
+		if libupdater.IsUpdateDisabled(c.Labels) {
 			continue
 		}
 
@@ -1133,7 +1135,7 @@ func (s *UpdaterService) resolveLocalImageIDsForRef(ctx context.Context, ref str
 	}
 
 	// digestResolver is intentionally nil: GetImageIDsForRef only inspects local images.
-	checker := arcaneupdater.NewDigestChecker(dcli, nil)
+	checker := libupdater.NewDigestChecker(dcli, nil)
 	ids, err := checker.GetImageIDsForRef(ctx, ref)
 	if err != nil {
 		return nil, err
@@ -1182,7 +1184,7 @@ func (s *UpdaterService) restartContainersUsingOldIDs(ctx context.Context, oldID
 
 	plansByName := map[string]*restartPlan{}
 	markedForRestart := map[string]bool{}
-	containersWithDeps := make([]arcaneupdater.ContainerWithDeps, 0, len(list))
+	containersWithDeps := make([]libupdater.ContainerWithDeps, 0, len(list))
 
 	// Cache resolved IDs for newRefs to avoid repeated API calls
 	targetImageIDs := map[string][]string{}
@@ -1203,7 +1205,7 @@ func (s *UpdaterService) restartContainersUsingOldIDs(ctx context.Context, oldID
 		}
 
 		// Skip containers with opt-out label
-		if arcaneupdater.IsUpdateDisabled(c.Labels) {
+		if libupdater.IsUpdateDisabled(c.Labels) {
 			continue
 		}
 
@@ -1213,7 +1215,7 @@ func (s *UpdaterService) restartContainersUsingOldIDs(ctx context.Context, oldID
 		}
 
 		name := s.getContainerName(c)
-		containersWithDeps = append(containersWithDeps, arcaneupdater.ContainerWithDeps{
+		containersWithDeps = append(containersWithDeps, libupdater.ContainerWithDeps{
 			Container: c,
 			Name:      name,
 		})
@@ -1253,7 +1255,7 @@ func (s *UpdaterService) restartContainersUsingOldIDs(ctx context.Context, oldID
 				continue
 			}
 			inspect := inspectResult.Container
-			containersWithDeps[i] = arcaneupdater.ExtractContainerDeps(ctx, dcli, cwd.Container, inspect)
+			containersWithDeps[i] = libupdater.ExtractContainerDeps(ctx, dcli, cwd.Container, inspect)
 
 			if p, ok := plansByName[containersWithDeps[i].Name]; ok {
 				inspectCopy := inspect
@@ -1264,7 +1266,7 @@ func (s *UpdaterService) restartContainersUsingOldIDs(ctx context.Context, oldID
 
 	// Propagate implicit restarts: if a dependency is restarting, restart dependents too.
 	for {
-		added := arcaneupdater.UpdateImplicitRestart(containersWithDeps, markedForRestart)
+		added := libupdater.UpdateImplicitRestart(containersWithDeps, markedForRestart)
 		if len(added) == 0 {
 			break
 		}
@@ -1285,14 +1287,14 @@ func (s *UpdaterService) restartContainersUsingOldIDs(ctx context.Context, oldID
 	}
 
 	// Build the set of containers that will be restarted and sort them by dependency order.
-	candidates := make([]arcaneupdater.ContainerWithDeps, 0, len(containersWithDeps))
+	candidates := make([]libupdater.ContainerWithDeps, 0, len(containersWithDeps))
 	for _, cd := range containersWithDeps {
 		if markedForRestart[cd.Name] {
 			candidates = append(candidates, cd)
 		}
 	}
 
-	sorter := arcaneupdater.NewContainerSorter(candidates)
+	sorter := libupdater.NewContainerSorter(candidates)
 	sorted, sortErr := sorter.Sort()
 	_, _ = sorter.SortReverse() // keep method used; reverse order may be useful for future stop-first flows
 	if sortErr != nil {
@@ -1354,14 +1356,11 @@ func (s *UpdaterService) restartContainersUsingOldIDs(ctx context.Context, oldID
 			endProjectStatus := s.beginProjectUpdateInternal(composeProjectNameFromLabelsInternal(labels))
 			defer endProjectStatus()
 
-			// Check if this is Arcane self-update - use CLI upgrade instead
-			if arcaneupdater.IsArcaneContainer(labels) && s.upgradeService != nil {
-				slog.InfoContext(ctx, "restartContainersUsingOldIDs: detected Arcane self-update, using CLI upgrade method", "containerId", p.cnt.ID, "container", name)
-
-				if err := s.upgradeService.TriggerUpgradeViaCLI(ctx, systemUser); err != nil {
+			// Arcane self-updates must go through the detached CLI upgrader.
+			if libupdater.IsArcaneContainer(labels) {
+				if err := s.triggerSelfUpdateViaCLIInternal(ctx, "restartContainersUsingOldIDs", p.cnt.ID, name, labels); err != nil {
 					res.Status = "failed"
-					res.Error = fmt.Sprintf("CLI upgrade failed: %v", err)
-					slog.WarnContext(ctx, "restartContainersUsingOldIDs: CLI upgrade failed", "containerId", p.cnt.ID, "err", err)
+					res.Error = err.Error()
 				} else {
 					res.Status = "updated"
 					res.UpdateAvailable = true
@@ -1390,6 +1389,44 @@ func (s *UpdaterService) restartContainersUsingOldIDs(ctx context.Context, oldID
 	}
 	slog.DebugContext(ctx, "restartContainersUsingOldIDs: completed scanning", "results", len(results))
 	return results, nil
+}
+
+func (s *UpdaterService) triggerSelfUpdateViaCLIInternal(ctx context.Context, source, containerID, containerName string, labels map[string]string) error {
+	if !libupdater.IsArcaneContainer(labels) {
+		return fmt.Errorf("%s: container is not an Arcane self-update target", source)
+	}
+
+	instanceType := "server"
+	if libupdater.IsArcaneAgentContainer(labels) {
+		instanceType = "agent"
+	}
+
+	if s.upgradeService == nil {
+		err := fmt.Errorf("%s self-update requires CLI upgrade service", instanceType)
+		slog.ErrorContext(ctx, source+": missing CLI upgrade service for Arcane self-update",
+			"containerId", containerID,
+			"container", containerName,
+			"instanceType", instanceType,
+			"err", err)
+		return err
+	}
+
+	slog.InfoContext(ctx, source+": detected Arcane self-update, using CLI upgrade method",
+		"containerId", containerID,
+		"container", containerName,
+		"instanceType", instanceType)
+
+	if err := s.upgradeService.TriggerUpgradeViaCLI(ctx, systemUser); err != nil {
+		wrappedErr := fmt.Errorf("CLI upgrade failed: %w", err)
+		slog.WarnContext(ctx, source+": CLI upgrade failed",
+			"containerId", containerID,
+			"container", containerName,
+			"instanceType", instanceType,
+			"err", err)
+		return wrappedErr
+	}
+
+	return nil
 }
 
 func (s *UpdaterService) beginContainerUpdateInternal(containerID string) func() {

--- a/backend/internal/services/updater_service_test.go
+++ b/backend/internal/services/updater_service_test.go
@@ -18,7 +18,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/getarcaneapp/arcane/backend/internal/models"
-	"github.com/getarcaneapp/arcane/backend/internal/utils/arcaneupdater"
+	libupdater "github.com/getarcaneapp/arcane/backend/pkg/libarcane/updater"
 )
 
 // mockSystemUpgradeService is a simple mock implementation for testing
@@ -54,7 +54,7 @@ func TestUpdaterService_ArcaneLabel_TriggersCLIUpgrade(t *testing.T) {
 	}
 
 	// Verify that IsArcaneContainer correctly identifies the label
-	isArcane := arcaneupdater.IsArcaneContainer(labels)
+	isArcane := libupdater.IsArcaneContainer(labels)
 	assert.True(t, isArcane, "IsArcaneContainer should return true for Arcane label")
 
 	// Simulate the logic from restartContainersUsingOldIDs:
@@ -65,6 +65,23 @@ func TestUpdaterService_ArcaneLabel_TriggersCLIUpgrade(t *testing.T) {
 
 	// Verify CLI upgrade was called
 	assert.True(t, mockUpgrade.triggerCalled, "TriggerUpgradeViaCLI should have been called for Arcane container")
+}
+
+func TestUpdaterService_ArcaneAgentLabel_TriggersCLIUpgrade(t *testing.T) {
+	ctx := context.Background()
+	mockUpgrade := &mockSystemUpgradeService{}
+	service := &UpdaterService{upgradeService: mockUpgrade}
+
+	labels := map[string]string{
+		libupdater.LabelArcaneAgent: "true",
+	}
+
+	err := service.triggerSelfUpdateViaCLIInternal(ctx, "test", "container-1", "arcane-agent", labels)
+
+	require.NoError(t, err)
+	assert.True(t, mockUpgrade.triggerCalled, "TriggerUpgradeViaCLI should have been called for Arcane agent container")
+	assert.NotNil(t, mockUpgrade.capturedUser)
+	assert.Equal(t, systemUser.ID, mockUpgrade.capturedUser.ID)
 }
 
 // TestUpdaterService_NonArcaneLabel_DoesNotTriggerCLI verifies that containers without
@@ -81,7 +98,7 @@ func TestUpdaterService_NonArcaneLabel_DoesNotTriggerCLI(t *testing.T) {
 	}
 
 	// Verify that IsArcaneContainer returns false
-	isArcane := arcaneupdater.IsArcaneContainer(labels)
+	isArcane := libupdater.IsArcaneContainer(labels)
 	assert.False(t, isArcane, "IsArcaneContainer should return false for non-Arcane container")
 
 	// Simulate the logic from restartContainersUsingOldIDs
@@ -91,6 +108,22 @@ func TestUpdaterService_NonArcaneLabel_DoesNotTriggerCLI(t *testing.T) {
 
 	// Verify CLI upgrade was NOT called
 	assert.False(t, mockUpgrade.triggerCalled, "TriggerUpgradeViaCLI should not have been called for non-Arcane container")
+}
+
+func TestUpdaterService_TriggerSelfUpdateViaCLI_NonArcaneContainer(t *testing.T) {
+	ctx := context.Background()
+	mockUpgrade := &mockSystemUpgradeService{}
+	service := &UpdaterService{upgradeService: mockUpgrade}
+
+	labels := map[string]string{
+		"some.other.label": "true",
+	}
+
+	err := service.triggerSelfUpdateViaCLIInternal(ctx, "test", "container-1", "not-arcane", labels)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "container is not an Arcane self-update target")
+	assert.False(t, mockUpgrade.triggerCalled, "non-Arcane containers must not trigger the CLI upgrade path")
 }
 
 // TestUpdaterService_ArcaneLabelWithError_PropagatesError verifies that CLI upgrade errors
@@ -108,7 +141,7 @@ func TestUpdaterService_ArcaneLabelWithError_PropagatesError(t *testing.T) {
 		"com.getarcaneapp.arcane": "true",
 	}
 
-	isArcane := arcaneupdater.IsArcaneContainer(labels)
+	isArcane := libupdater.IsArcaneContainer(labels)
 	assert.True(t, isArcane, "Should detect Arcane container")
 
 	// Call the upgrade method
@@ -126,19 +159,31 @@ func TestUpdaterService_ArcaneLabelWithError_PropagatesError(t *testing.T) {
 // TestUpdaterService_NilUpgradeService_GracefulHandling verifies graceful handling
 // when upgrade service is nil
 func TestUpdaterService_NilUpgradeService_GracefulHandling(t *testing.T) {
-	var mockUpgrade *mockSystemUpgradeService = nil
+	ctx := context.Background()
+	service := &UpdaterService{}
 
 	labels := map[string]string{
-		"com.getarcaneapp.arcane": "true",
+		libupdater.LabelArcane: "true",
 	}
 
-	isArcane := arcaneupdater.IsArcaneContainer(labels)
-	assert.True(t, isArcane, "Should detect Arcane container")
+	err := service.triggerSelfUpdateViaCLIInternal(ctx, "test", "container-1", "arcane", labels)
 
-	// When upgradeService is nil, ensure we don't attempt to call it.
-	assert.Nil(t, mockUpgrade, "Upgrade service should be nil; should not attempt to call it")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server self-update requires CLI upgrade service")
+}
 
-	// Test passes if no panic occurs
+func TestUpdaterService_ArcaneAgentLabel_MissingUpgradeServiceReturnsError(t *testing.T) {
+	ctx := context.Background()
+	service := &UpdaterService{}
+
+	labels := map[string]string{
+		libupdater.LabelArcaneAgent: "true",
+	}
+
+	err := service.triggerSelfUpdateViaCLIInternal(ctx, "test", "container-1", "arcane-agent", labels)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent self-update requires CLI upgrade service")
 }
 
 // TestUpdaterService_ArcaneLabelVariations tests various label formats
@@ -189,7 +234,7 @@ func TestUpdaterService_ArcaneLabelVariations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			isArcane := arcaneupdater.IsArcaneContainer(tt.labels)
+			isArcane := libupdater.IsArcaneContainer(tt.labels)
 			assert.Equal(t, tt.expectedArcane, isArcane, tt.description)
 		})
 	}
@@ -205,7 +250,7 @@ func TestUpdaterService_CLICalledWithSystemUser(t *testing.T) {
 		"com.getarcaneapp.arcane": "true",
 	}
 
-	isArcane := arcaneupdater.IsArcaneContainer(labels)
+	isArcane := libupdater.IsArcaneContainer(labels)
 	assert.True(t, isArcane)
 
 	if isArcane {
@@ -229,7 +274,7 @@ func TestUpdaterService_UpgradeServiceNotNilCheck(t *testing.T) {
 
 	// Test with non-nil upgrade service
 	mockUpgrade := &mockSystemUpgradeService{}
-	isArcane := arcaneupdater.IsArcaneContainer(labels)
+	isArcane := libupdater.IsArcaneContainer(labels)
 
 	// This is the actual logic from restartContainersUsingOldIDs
 	if isArcane {
@@ -545,7 +590,7 @@ func TestCollectUsedImagesFromComposeContainersInternal(t *testing.T) {
 			Image: "redis:7",
 			Labels: map[string]string{
 				"com.docker.compose.project": "myapp",
-				arcaneupdater.LabelUpdater:   "false",
+				libupdater.LabelUpdater:      "false",
 			},
 		},
 		{

--- a/backend/internal/services/version_service.go
+++ b/backend/internal/services/version_service.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/getarcaneapp/arcane/backend/buildables"
 	"github.com/getarcaneapp/arcane/backend/internal/config"
-	"github.com/getarcaneapp/arcane/backend/internal/utils/arcaneupdater"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/cache"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/docker"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
+	libupdater "github.com/getarcaneapp/arcane/backend/pkg/libarcane/updater"
 	"github.com/getarcaneapp/arcane/types/version"
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
@@ -331,7 +331,7 @@ func (s *VersionService) detectContainerID(ctx context.Context, dockerClient *cl
 // findArcaneContainerByLabel searches for the Arcane container using labels
 func (s *VersionService) findArcaneContainerByLabel(ctx context.Context, dockerClient *client.Client) string {
 	f := make(client.Filters)
-	f = f.Add("label", arcaneupdater.LabelArcane+"=true")
+	f = f.Add("label", libupdater.LabelArcane+"=true")
 	list, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: true, Filters: f})
 	if err != nil {
 		slog.Debug("findArcaneContainerByLabel: failed to list containers", "error", err)

--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -22,11 +22,11 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
-	"github.com/getarcaneapp/arcane/backend/internal/utils/arcaneupdater"
 	dockerutils "github.com/getarcaneapp/arcane/backend/internal/utils/docker"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/pagination"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/timeouts"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
+	libupdater "github.com/getarcaneapp/arcane/backend/pkg/libarcane/updater"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils/stdcopy"
 	"github.com/getarcaneapp/arcane/types/vulnerability"
 	containertypes "github.com/moby/moby/api/types/container"
@@ -1739,7 +1739,7 @@ func findArcaneContainerByLabelInternal(ctx context.Context, dockerClient *clien
 	}
 
 	filters := make(client.Filters)
-	filters = filters.Add("label", arcaneupdater.LabelArcane+"=true")
+	filters = filters.Add("label", libupdater.LabelArcane+"=true")
 
 	containerList, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{
 		All:     true,

--- a/backend/pkg/libarcane/updater/digest.go
+++ b/backend/pkg/libarcane/updater/digest.go
@@ -1,4 +1,4 @@
-package arcaneupdater
+package updater
 
 import (
 	"context"

--- a/backend/pkg/libarcane/updater/digest_test.go
+++ b/backend/pkg/libarcane/updater/digest_test.go
@@ -1,4 +1,4 @@
-package arcaneupdater
+package updater
 
 import (
 	"testing"

--- a/backend/pkg/libarcane/updater/labels.go
+++ b/backend/pkg/libarcane/updater/labels.go
@@ -1,11 +1,12 @@
-package arcaneupdater
+package updater
 
 import "strings"
 
 const (
 	// Core labels
-	LabelArcane  = "com.getarcaneapp.arcane"         // Identifies the Arcane container itself
-	LabelUpdater = "com.getarcaneapp.arcane.updater" // Enable/disable updates (true/false)
+	LabelArcane      = "com.getarcaneapp.arcane"         // Identifies the Arcane container itself
+	LabelArcaneAgent = "com.getarcaneapp.arcane.agent"   // Identifies an Arcane agent container
+	LabelUpdater     = "com.getarcaneapp.arcane.updater" // Enable/disable updates (true/false)
 
 	// Dependency labels
 	LabelDependsOn  = "com.getarcaneapp.arcane.depends-on"  // Comma-separated list of container names this depends on
@@ -14,18 +15,12 @@ const (
 
 // IsArcaneContainer checks if the container is the Arcane application itself
 func IsArcaneContainer(labels map[string]string) bool {
-	if labels == nil {
-		return false
-	}
-	for k, v := range labels {
-		if strings.EqualFold(k, LabelArcane) {
-			switch strings.TrimSpace(strings.ToLower(v)) {
-			case "true", "1", "yes", "on":
-				return true
-			}
-		}
-	}
-	return false
+	return hasTruthyLabelInternal(labels, LabelArcane) || IsArcaneAgentContainer(labels)
+}
+
+// IsArcaneAgentContainer checks if the container is an Arcane agent container.
+func IsArcaneAgentContainer(labels map[string]string) bool {
+	return hasTruthyLabelInternal(labels, LabelArcaneAgent)
 }
 
 // IsUpdateDisabled returns true if the special label is present and evaluates to false.
@@ -58,4 +53,27 @@ func GetStopSignal(labels map[string]string) string {
 		}
 	}
 	return ""
+}
+
+func hasTruthyLabelInternal(labels map[string]string, target string) bool {
+	if labels == nil {
+		return false
+	}
+
+	for k, v := range labels {
+		if strings.EqualFold(k, target) && isTruthyLabelValueInternal(v) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isTruthyLabelValueInternal(v string) bool {
+	switch strings.TrimSpace(strings.ToLower(v)) {
+	case "true", "1", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }

--- a/backend/pkg/libarcane/updater/labels_test.go
+++ b/backend/pkg/libarcane/updater/labels_test.go
@@ -1,4 +1,4 @@
-package arcaneupdater
+package updater
 
 import (
 	"testing"
@@ -60,12 +60,69 @@ func TestIsArcaneContainer(t *testing.T) {
 			labels: map[string]string{"COM.GETARCANEAPP.ARCANE": "true"},
 			want:   true,
 		},
+		{
+			name:   "agent label true",
+			labels: map[string]string{LabelArcaneAgent: "true"},
+			want:   true,
+		},
+		{
+			name:   "agent label with whitespace",
+			labels: map[string]string{LabelArcaneAgent: "  yes  "},
+			want:   true,
+		},
+		{
+			name:   "agent label false",
+			labels: map[string]string{LabelArcaneAgent: "false"},
+			want:   false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsArcaneContainer(tt.labels); got != tt.want {
 				t.Errorf("IsArcaneContainer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsArcaneAgentContainer(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{
+			name:   "nil labels",
+			labels: nil,
+			want:   false,
+		},
+		{
+			name:   "agent label true",
+			labels: map[string]string{LabelArcaneAgent: "true"},
+			want:   true,
+		},
+		{
+			name:   "agent label case insensitive key",
+			labels: map[string]string{"COM.GETARCANEAPP.ARCANE.AGENT": "on"},
+			want:   true,
+		},
+		{
+			name:   "core arcane label only",
+			labels: map[string]string{LabelArcane: "true"},
+			want:   false,
+		},
+		{
+			name:   "agent label false",
+			labels: map[string]string{LabelArcaneAgent: "off"},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsArcaneAgentContainer(tt.labels); got != tt.want {
+				t.Errorf("IsArcaneAgentContainer() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/backend/pkg/libarcane/updater/logfile.go
+++ b/backend/pkg/libarcane/updater/logfile.go
@@ -1,4 +1,4 @@
-package arcaneupdater
+package updater
 
 import (
 	"context"

--- a/backend/pkg/libarcane/updater/logfile_test.go
+++ b/backend/pkg/libarcane/updater/logfile_test.go
@@ -1,4 +1,4 @@
-package arcaneupdater
+package updater
 
 import (
 	"bytes"

--- a/backend/pkg/libarcane/updater/sorter.go
+++ b/backend/pkg/libarcane/updater/sorter.go
@@ -1,4 +1,4 @@
-package arcaneupdater
+package updater
 
 import (
 	"context"

--- a/backend/pkg/libarcane/updater/sorter_test.go
+++ b/backend/pkg/libarcane/updater/sorter_test.go
@@ -1,4 +1,4 @@
-package arcaneupdater
+package updater
 
 import (
 	"testing"


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2074

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a root cause identified in issue #2074: the Docker images for the Arcane manager and agent were missing the `com.getarcaneapp.arcane=true` label that the auto-updater relies on to identify itself. Alongside the workflow label additions, the `arcaneupdater` internal utility package is promoted to `backend/pkg/libarcane/updater`, a new `LabelArcaneAgent` / `IsArcaneAgentContainer` API is added, and self-update dispatch is consolidated into the new `triggerSelfUpdateViaCLIInternal` helper.

Key changes:
- **Workflow fixes** (`release.yml`, `build-pr-images.yml`, `build-next-images.yml`): `com.getarcaneapp.arcane=true` added to manager image metadata; both `com.getarcaneapp.arcane=true` and `com.getarcaneapp.arcane.agent=true` added to agent image metadata.
- **Package promotion**: `backend/internal/utils/arcaneupdater` → `backend/pkg/libarcane/updater` to make it accessible across modules.
- **`IsArcaneContainer` semantics expanded**: now returns `true` for containers carrying either the base label or the agent label — this ensures old agent images (that only had `LabelArcaneAgent`) are also correctly classified as self-update targets and excluded from bulk `StopAllContainers`.
- **`triggerSelfUpdateViaCLIInternal`**: centralises the nil-guard, logging, instance-type detection, and error wrapping that was previously duplicated at two call sites.
- **`selfUpgradeService` interface**: allows the `upgradeService` field to be easily mocked in tests.
- **Test gap**: `TestUpdaterService_ArcaneLabelWithError_PropagatesError` was not updated to exercise `triggerSelfUpdateViaCLIInternal`; it still calls the mock directly and would give a false-positive if the service's error-wrapping behaviour regressed.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge — the core label and routing logic is correct and well-tested; one existing test does not exercise the new error-wrapping path but this is non-blocking.
- All three build workflows now consistently apply the missing labels. The `IsArcaneContainer` semantic expansion is correct and backward-compatible. The `triggerSelfUpdateViaCLIInternal` refactor is clean and properly guarded. The one point deducted is for `TestUpdaterService_ArcaneLabelWithError_PropagatesError`, which bypasses the new helper and leaves error-wrapping untested — a real regression in this area could go undetected.
- backend/internal/services/updater_service_test.go — `TestUpdaterService_ArcaneLabelWithError_PropagatesError` should be updated to call `service.triggerSelfUpdateViaCLIInternal` rather than the mock directly.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-next-images.yml | Adds `com.getarcaneapp.arcane=true` to agent image metadata; manager image already had the label — consistent with the other workflow files. |
| .github/workflows/build-pr-images.yml | Adds `com.getarcaneapp.arcane=true` to both manager and agent image metadata, and `com.getarcaneapp.arcane.agent=true` to the agent image — previously both labels were missing. |
| .github/workflows/release.yml | Adds `com.getarcaneapp.arcane=true` to manager image metadata and both labels to agent image metadata — consistent with `build-pr-images.yml`. |
| backend/pkg/libarcane/updater/labels.go | Package moved from `internal/utils/arcaneupdater`; adds `LabelArcaneAgent`, `IsArcaneAgentContainer`, and internal helpers `hasTruthyLabelInternal`/`isTruthyLabelValueInternal`; `IsArcaneContainer` now returns true for agent containers too. |
| backend/internal/services/updater_service.go | Introduces `selfUpgradeService` interface and extracts `triggerSelfUpdateViaCLIInternal` helper; nil-guard now returns an error; all `arcaneupdater` references migrated to `libupdater`. |
| backend/internal/services/updater_service_test.go | New agent-label and nil-guard tests added; however `TestUpdaterService_ArcaneLabelWithError_PropagatesError` still calls the mock directly instead of through `triggerSelfUpdateViaCLIInternal`, leaving error-wrapping behaviour untested. |
| backend/internal/services/system_upgrade_service.go | Inline agent-label check replaced by `determineUpgradeBinaryPathInternal` which delegates to `libupdater.IsArcaneAgentContainer`; cleaner and now covered by a dedicated test. |
| backend/internal/services/system_upgrade_service_test.go | New table-driven test for `determineUpgradeBinaryPathInternal` covers agent, main, and no-label cases — well structured. |
| backend/pkg/libarcane/updater/labels_test.go | New `TestIsArcaneAgentContainer` suite and additional `TestIsArcaneContainer` cases (agent label, false agent label) provide good coverage of the new helper functions. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `.github/workflows/release.yml`, line 77-88 ([link](https://github.com/getarcaneapp/arcane/blob/9dbf66dc3260950ee50aa005adcbbb128b2b51b2/.github/workflows/release.yml#L77-L88)) 

   **Manager image still missing `com.getarcaneapp.arcane=true` label**

   The PR adds the `com.getarcaneapp.arcane=true` and `com.getarcaneapp.arcane.agent=true` labels to the **agent** image metadata in `release.yml`, but the **manager** image metadata (lines 77-88) still has no `com.getarcaneapp.arcane=true` label. The same issue exists in `build-pr-images.yml` (lines 54-64).

   Without this label, production release manager images won't be recognized by the auto-updater via labels, and detection will fall through to the image-name heuristic fallback. Since `build-next-images.yml` already has the label on its manager image (line 109), this appears to be an oversight.

   Add `com.getarcaneapp.arcane=true` to the manager image labels in both `release.yml` and `build-pr-images.yml`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/release.yml
   Line: 77-88

   Comment:
   **Manager image still missing `com.getarcaneapp.arcane=true` label**

   The PR adds the `com.getarcaneapp.arcane=true` and `com.getarcaneapp.arcane.agent=true` labels to the **agent** image metadata in `release.yml`, but the **manager** image metadata (lines 77-88) still has no `com.getarcaneapp.arcane=true` label. The same issue exists in `build-pr-images.yml` (lines 54-64).

   Without this label, production release manager images won't be recognized by the auto-updater via labels, and detection will fall through to the image-name heuristic fallback. Since `build-next-images.yml` already has the label on its manager image (line 109), this appears to be an oversight.

   Add `com.getarcaneapp.arcane=true` to the manager image labels in both `release.yml` and `build-pr-images.yml`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Frelease.yml%0ALine%3A%2077-88%0A%0AComment%3A%0A**Manager%20image%20still%20missing%20%60com.getarcaneapp.arcane%3Dtrue%60%20label**%0A%0AThe%20PR%20adds%20the%20%60com.getarcaneapp.arcane%3Dtrue%60%20and%20%60com.getarcaneapp.arcane.agent%3Dtrue%60%20labels%20to%20the%20**agent**%20image%20metadata%20in%20%60release.yml%60%2C%20but%20the%20**manager**%20image%20metadata%20%28lines%2077-88%29%20still%20has%20no%20%60com.getarcaneapp.arcane%3Dtrue%60%20label.%20The%20same%20issue%20exists%20in%20%60build-pr-images.yml%60%20%28lines%2054-64%29.%0A%0AWithout%20this%20label%2C%20production%20release%20manager%20images%20won't%20be%20recognized%20by%20the%20auto-updater%20via%20labels%2C%20and%20detection%20will%20fall%20through%20to%20the%20image-name%20heuristic%20fallback.%20Since%20%60build-next-images.yml%60%20already%20has%20the%20label%20on%20its%20manager%20image%20%28line%20109%29%2C%20this%20appears%20to%20be%20an%20oversight.%0A%0AAdd%20%60com.getarcaneapp.arcane%3Dtrue%60%20to%20the%20manager%20image%20labels%20in%20both%20%60release.yml%60%20and%20%60build-pr-images.yml%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

2. `backend/internal/services/updater_service_test.go`, line 147-156 ([link](https://github.com/getarcaneapp/arcane/blob/ff7df92ce0ef13f1ce5165a4c648dd068d679304/backend/internal/services/updater_service_test.go#L147-L156)) 

   **Error propagation test bypasses the new service method**

   The test title says it "verifies that CLI upgrade errors are properly propagated", but the body calls `mockUpgrade.TriggerUpgradeViaCLI` directly (line 150) instead of going through `service.triggerSelfUpdateViaCLIInternal`. The new function wraps the error with `fmt.Errorf("CLI upgrade failed: %w", err)`, so:

   1. The wrapping behaviour is completely untested.
   2. If this test were rewritten to call `service.triggerSelfUpdateViaCLIInternal(...)`, `assert.Equal(t, expectedErr, err)` would fail because the returned error is wrapped and no longer equal to `expectedErr`.

   A corrected version would be:

   ```go
   service := &UpdaterService{upgradeService: mockUpgrade}
   err := service.triggerSelfUpdateViaCLIInternal(ctx, "test", "container-1", "arcane", labels)
   require.Error(t, err)
   assert.True(t, errors.Is(err, expectedErr), "original error should be chain-accessible via errors.Is")
   assert.ErrorContains(t, err, "CLI upgrade failed")
   ```

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fupdater_service_test.go%3A147-156%0A**Error%20propagation%20test%20bypasses%20the%20new%20service%20method**%0A%0AThe%20test%20title%20says%20it%20%22verifies%20that%20CLI%20upgrade%20errors%20are%20properly%20propagated%22%2C%20but%20the%20body%20calls%20%60mockUpgrade.TriggerUpgradeViaCLI%60%20directly%20%28line%20150%29%20instead%20of%20going%20through%20%60service.triggerSelfUpdateViaCLIInternal%60.%20The%20new%20function%20wraps%20the%20error%20with%20%60fmt.Errorf%28%22CLI%20upgrade%20failed%3A%20%25w%22%2C%20err%29%60%2C%20so%3A%0A%0A1.%20The%20wrapping%20behaviour%20is%20completely%20untested.%0A2.%20If%20this%20test%20were%20rewritten%20to%20call%20%60service.triggerSelfUpdateViaCLIInternal%28...%29%60%2C%20%60assert.Equal%28t%2C%20expectedErr%2C%20err%29%60%20would%20fail%20because%20the%20returned%20error%20is%20wrapped%20and%20no%20longer%20equal%20to%20%60expectedErr%60.%0A%0AA%20corrected%20version%20would%20be%3A%0A%0A%60%60%60go%0Aservice%20%3A%3D%20%26UpdaterService%7BupgradeService%3A%20mockUpgrade%7D%0Aerr%20%3A%3D%20service.triggerSelfUpdateViaCLIInternal%28ctx%2C%20%22test%22%2C%20%22container-1%22%2C%20%22arcane%22%2C%20labels%29%0Arequire.Error%28t%2C%20err%29%0Aassert.True%28t%2C%20errors.Is%28err%2C%20expectedErr%29%2C%20%22original%20error%20should%20be%20chain-accessible%20via%20errors.Is%22%29%0Aassert.ErrorContains%28t%2C%20err%2C%20%22CLI%20upgrade%20failed%22%29%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/updater_service_test.go
Line: 147-156

Comment:
**Error propagation test bypasses the new service method**

The test title says it "verifies that CLI upgrade errors are properly propagated", but the body calls `mockUpgrade.TriggerUpgradeViaCLI` directly (line 150) instead of going through `service.triggerSelfUpdateViaCLIInternal`. The new function wraps the error with `fmt.Errorf("CLI upgrade failed: %w", err)`, so:

1. The wrapping behaviour is completely untested.
2. If this test were rewritten to call `service.triggerSelfUpdateViaCLIInternal(...)`, `assert.Equal(t, expectedErr, err)` would fail because the returned error is wrapped and no longer equal to `expectedErr`.

A corrected version would be:

```go
service := &UpdaterService{upgradeService: mockUpgrade}
err := service.triggerSelfUpdateViaCLIInternal(ctx, "test", "container-1", "arcane", labels)
require.Error(t, err)
assert.True(t, errors.Is(err, expectedErr), "original error should be chain-accessible via errors.Is")
assert.ErrorContains(t, err, "CLI upgrade failed")
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ff7df92</sub>

<!-- /greptile_comment -->