### PR TITLE
fix: image update inspection fallback to manual vs using mobys distribution inspect

### DIFF
--- a/backend/internal/services/container_registry_service.go
+++ b/backend/internal/services/container_registry_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -18,10 +19,10 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/utils/mapper"
 	"github.com/getarcaneapp/arcane/backend/internal/utils/pagination"
 	utilsregistry "github.com/getarcaneapp/arcane/backend/internal/utils/registry"
+	utilsdistribution "github.com/getarcaneapp/arcane/backend/pkg/utils/distribution"
 	"github.com/getarcaneapp/arcane/types/containerregistry"
 	dockerregistry "github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
-	ref "go.podman.io/image/v5/docker/reference"
 )
 
 const (
@@ -50,17 +51,19 @@ type resolvedRegistryCredential struct {
 }
 
 type ContainerRegistryService struct {
-	db           *database.DB
-	dockerClient registryDaemonGetter
-	cache        map[string]*cache.Cache[string] // imageRef -> digest cache
-	cacheMu      sync.RWMutex
+	db                     *database.DB
+	dockerClient           registryDaemonGetter
+	distributionHTTPClient *http.Client
+	cache                  map[string]*cache.Cache[string] // imageRef -> digest cache
+	cacheMu                sync.RWMutex
 }
 
 func NewContainerRegistryService(db *database.DB, dockerClient registryDaemonGetter) *ContainerRegistryService {
 	return &ContainerRegistryService{
-		db:           db,
-		dockerClient: dockerClient,
-		cache:        make(map[string]*cache.Cache[string]),
+		db:                     db,
+		dockerClient:           dockerClient,
+		distributionHTTPClient: utilsdistribution.NewRegistryHTTPClient(),
+		cache:                  make(map[string]*cache.Cache[string]),
 	}
 }
 
@@ -346,11 +349,36 @@ func (s *ContainerRegistryService) GetImageDigest(ctx context.Context, imageRef 
 }
 
 func (s *ContainerRegistryService) inspectImageDigestInternal(ctx context.Context, imageRef string, externalCreds []containerregistry.Credential) (*registryDigestResult, error) {
-	normalizedRef, registryHost, err := normalizeImageReferenceForDistributionInternal(imageRef)
+	parts, err := normalizeDistributionReferenceInternal(imageRef)
 	if err != nil {
 		return nil, err
 	}
 
+	result, err := s.inspectImageDigestViaDaemonInternal(ctx, parts.NormalizedRef, parts.RegistryHost, externalCreds)
+	if err == nil {
+		return result, nil
+	}
+	if !isDistributionFallbackEligibleInternal(err) {
+		return result, err
+	}
+
+	slog.WarnContext(ctx, "distribution inspect unavailable, falling back to direct registry digest lookup",
+		"imageRef", parts.NormalizedRef,
+		"registry", parts.RegistryHost,
+		"error", err.Error())
+
+	fallbackResult, fallbackErr := s.inspectImageDigestViaRegistryInternal(ctx, parts.RegistryHost, parts.Repository, parts.Tag, externalCreds)
+	if fallbackErr == nil {
+		return fallbackResult, nil
+	}
+
+	return fallbackResult, fmt.Errorf(
+		"daemon digest lookup failed; registry fallback failed: %w",
+		errors.Join(err, fallbackErr),
+	)
+}
+
+func (s *ContainerRegistryService) inspectImageDigestViaDaemonInternal(ctx context.Context, normalizedRef, registryHost string, externalCreds []containerregistry.Credential) (*registryDigestResult, error) {
 	dockerClient, err := s.getDockerClientInternal(ctx)
 	if err != nil {
 		return nil, err
@@ -375,7 +403,8 @@ func (s *ContainerRegistryService) inspectImageDigestInternal(ctx context.Contex
 
 	credentials, credErr := s.getMatchingRegistryCredentialsInternal(ctx, registryHost, externalCreds)
 	if credErr != nil {
-		return &registryDigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}, credErr
+		return &registryDigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost},
+			fmt.Errorf("distribution inspect: anonymous access unauthorized; credential lookup failed: %w", errors.Join(err, credErr))
 	}
 
 	lastErr := err
@@ -421,6 +450,55 @@ func (s *ContainerRegistryService) inspectImageDigestInternal(ctx context.Contex
 		partial.UsedCredential = true
 	}
 	return partial, fmt.Errorf("distribution inspect failed for %s: %w", normalizedRef, lastErr)
+}
+
+func (s *ContainerRegistryService) inspectImageDigestViaRegistryInternal(ctx context.Context, registryHost, repository, tag string, externalCreds []containerregistry.Credential) (*registryDigestResult, error) {
+	digest, err := s.fetchDigestFromRegistryInternal(ctx, registryHost, repository, tag, nil)
+	if err == nil {
+		return &registryDigestResult{
+			Digest:       digest,
+			AuthMethod:   "anonymous",
+			AuthRegistry: registryHost,
+		}, nil
+	}
+	if !isUnauthorizedRegistryErrorInternal(err) {
+		return &registryDigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost},
+			fmt.Errorf("registry manifest inspect failed for %s/%s:%s: %w", registryHost, repository, tag, err)
+	}
+
+	credentials, credErr := s.getMatchingRegistryCredentialsInternal(ctx, registryHost, externalCreds)
+	if credErr != nil {
+		return &registryDigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost},
+			fmt.Errorf("registry manifest inspect: anonymous access unauthorized; credential lookup failed: %w", errors.Join(err, credErr))
+	}
+
+	lastErr := err
+	var lastCred resolvedRegistryCredential
+	for _, credential := range credentials {
+		lastCred = credential
+
+		digest, err = s.fetchDigestFromRegistryInternal(ctx, registryHost, repository, tag, &credential)
+		if err == nil {
+			return &registryDigestResult{
+				Digest:         digest,
+				AuthMethod:     "credential",
+				AuthUsername:   credential.Username,
+				AuthRegistry:   registryHost,
+				UsedCredential: true,
+			}, nil
+		}
+
+		lastErr = err
+	}
+
+	partial := &registryDigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}
+	if lastCred.Username != "" {
+		partial.AuthMethod = "credential"
+		partial.AuthUsername = lastCred.Username
+		partial.UsedCredential = true
+	}
+
+	return partial, fmt.Errorf("registry manifest inspect failed for %s/%s:%s: %w", registryHost, repository, tag, lastErr)
 }
 
 func (s *ContainerRegistryService) getDockerClientInternal(ctx context.Context) (RegistryDaemonClient, error) {
@@ -608,25 +686,17 @@ func (s *ContainerRegistryService) deleteUnsyncedInternal(ctx context.Context, e
 	return nil
 }
 
+func normalizeDistributionReferenceInternal(imageRef string) (*utilsdistribution.Reference, error) {
+	return utilsdistribution.NormalizeReference(imageRef)
+}
+
 func normalizeImageReferenceForDistributionInternal(imageRef string) (string, string, error) {
-	named, err := ref.ParseNormalizedNamed(strings.TrimSpace(imageRef))
+	parts, err := normalizeDistributionReferenceInternal(imageRef)
 	if err != nil {
-		return "", "", fmt.Errorf("invalid image reference %q: %w", imageRef, err)
+		return "", "", err
 	}
 
-	if _, ok := named.(ref.Digested); ok {
-		return "", "", fmt.Errorf("digest-pinned references are not supported for distribution inspect: %q", imageRef)
-	}
-
-	registryHost := utilsregistry.NormalizeRegistryForComparison(ref.Domain(named))
-	repository := ref.Path(named)
-
-	tag := "latest"
-	if tagged, ok := named.(ref.NamedTagged); ok {
-		tag = tagged.Tag()
-	}
-
-	return registryHost + "/" + repository + ":" + tag, registryHost, nil
+	return parts.NormalizedRef, parts.RegistryHost, nil
 }
 
 func normalizeRegistryServerAddressInternal(registryURL string) string {
@@ -662,6 +732,10 @@ func isUnauthorizedRegistryErrorInternal(err error) bool {
 		"no basic auth credentials",
 		"access denied",
 		"incorrect username or password",
+		"status: 401",
+		"status 401",
+		"status: 403",
+		"status 403",
 	}
 
 	for _, indicator := range indicators {
@@ -671,4 +745,31 @@ func isUnauthorizedRegistryErrorInternal(err error) bool {
 	}
 
 	return false
+}
+
+func isDistributionFallbackEligibleInternal(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return utilsdistribution.IsFallbackEligibleDaemonError(err)
+}
+
+func (s *ContainerRegistryService) fetchDigestFromRegistryInternal(ctx context.Context, registryHost, repository, tag string, credential *resolvedRegistryCredential) (string, error) {
+	var distributionCredential *utilsdistribution.Credentials
+	if credential != nil {
+		distributionCredential = &utilsdistribution.Credentials{
+			Username: strings.TrimSpace(credential.Username),
+			Token:    strings.TrimSpace(credential.Token),
+		}
+	}
+
+	return utilsdistribution.FetchDigestWithHTTPClient(
+		ctx,
+		registryHost,
+		repository,
+		tag,
+		distributionCredential,
+		s.distributionHTTPClient,
+	)
 }

--- a/backend/internal/services/container_registry_service_test.go
+++ b/backend/internal/services/container_registry_service_test.go
@@ -2,7 +2,12 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	dockerregistry "github.com/moby/moby/api/types/registry"
@@ -18,6 +23,12 @@ type fakeRegistryDaemonClient struct {
 	distributionInspectFn func(ctx context.Context, imageRef string, options client.DistributionInspectOptions) (client.DistributionInspectResult, error)
 }
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func (f *fakeRegistryDaemonClient) RegistryLogin(ctx context.Context, options client.RegistryLoginOptions) (client.RegistryLoginResult, error) {
 	if f.registryLoginFn == nil {
 		return client.RegistryLoginResult{}, nil
@@ -30,6 +41,29 @@ func (f *fakeRegistryDaemonClient) DistributionInspect(ctx context.Context, imag
 		return client.DistributionInspectResult{}, nil
 	}
 	return f.distributionInspectFn(ctx, imageRef, options)
+}
+
+func newTestDockerClient(t *testing.T, server *httptest.Server) *client.Client {
+	t.Helper()
+
+	httpClient := server.Client()
+	cli, err := client.New(
+		client.WithHost(server.URL),
+		client.WithVersion("1.41"),
+		client.WithHTTPClient(httpClient),
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = cli.Close()
+	})
+
+	return cli
+}
+
+func TestNewContainerRegistryService_InitializesDistributionHTTPClient(t *testing.T) {
+	svc := NewContainerRegistryService(nil, nil)
+	require.NotNil(t, svc.distributionHTTPClient)
 }
 
 func TestContainerRegistryService_GetAllRegistryAuthConfigs_NormalizesHosts(t *testing.T) {
@@ -189,4 +223,231 @@ func TestContainerRegistryService_InspectImageDigest_RetriesWithStoredCredential
 	assert.Equal(t, "credential", result.AuthMethod)
 	assert.Equal(t, "docker-user", result.AuthUsername)
 	assert.True(t, result.UsedCredential)
+}
+
+func TestContainerRegistryService_InspectImageDigest_FallsBackWhenDistributionNotFound(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/team/app/manifests/1.2.3" {
+			w.Header().Set("Docker-Content-Digest", "sha256:fallback404")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	var calls int
+	svc := NewContainerRegistryService(nil, func(context.Context) (RegistryDaemonClient, error) {
+		return &fakeRegistryDaemonClient{
+			distributionInspectFn: func(ctx context.Context, imageRef string, options client.DistributionInspectOptions) (client.DistributionInspectResult, error) {
+				calls++
+				assert.Equal(t, serverURL.Host+"/team/app:1.2.3", imageRef)
+				assert.Empty(t, options.EncodedRegistryAuth)
+				return client.DistributionInspectResult{}, errors.New("Error response from daemon: Not Found")
+			},
+		}, nil
+	})
+	svc.distributionHTTPClient = server.Client()
+
+	result, err := svc.inspectImageDigestInternal(context.Background(), serverURL.Host+"/team/app:1.2.3", nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "sha256:fallback404", result.Digest)
+	assert.Equal(t, "anonymous", result.AuthMethod)
+	assert.Equal(t, serverURL.Host, result.AuthRegistry)
+}
+
+func TestContainerRegistryService_InspectImageDigest_FallsBackWhenDistributionForbidden(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/team/app/manifests/1.2.3" {
+			w.Header().Set("Docker-Content-Digest", "sha256:fallback403")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	var calls int
+	svc := NewContainerRegistryService(nil, func(context.Context) (RegistryDaemonClient, error) {
+		return &fakeRegistryDaemonClient{
+			distributionInspectFn: func(ctx context.Context, imageRef string, options client.DistributionInspectOptions) (client.DistributionInspectResult, error) {
+				calls++
+				assert.Equal(t, serverURL.Host+"/team/app:1.2.3", imageRef)
+				assert.Empty(t, options.EncodedRegistryAuth)
+				return client.DistributionInspectResult{}, errors.New("Error response from daemon: <html><body><h1>403 Forbidden</h1> Request forbidden by administrative rules. </body></html>")
+			},
+		}, nil
+	})
+	svc.distributionHTTPClient = server.Client()
+
+	result, err := svc.inspectImageDigestInternal(context.Background(), serverURL.Host+"/team/app:1.2.3", nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "sha256:fallback403", result.Digest)
+	assert.Equal(t, "anonymous", result.AuthMethod)
+	assert.Equal(t, serverURL.Host, result.AuthRegistry)
+}
+
+func TestContainerRegistryService_InspectImageDigest_RetriesStoredCredentialsAfterRegistryAuth403(t *testing.T) {
+	_, db := setupImageServiceAuthTest(t)
+
+	var authHeaders []string
+	var tokenURL string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/team/app/manifests/1.2.3":
+			authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+			switch len(authHeaders) {
+			case 1:
+				w.Header().Set("WWW-Authenticate", `Bearer realm="`+tokenURL+`",service="registry.example.com"`)
+				w.WriteHeader(http.StatusUnauthorized)
+			case 2:
+				w.WriteHeader(http.StatusForbidden)
+			case 3:
+				w.Header().Set("Docker-Content-Digest", "sha256:stored-credential")
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Fatalf("unexpected manifest call %d", len(authHeaders))
+			}
+		case "/token":
+			username, password, ok := r.BasicAuth()
+			if !ok {
+				require.Equal(t, "", r.Header.Get("Authorization"))
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]string{
+					"token": "anonymous-token",
+				}))
+				return
+			}
+
+			require.Equal(t, "stored-user", username)
+			require.Equal(t, "stored-token", password)
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{
+				"token": "credential-token",
+			}))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	server := httptest.NewTLSServer(handler)
+	defer server.Close()
+	tokenURL = server.URL + "/token"
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	createTestPullRegistry(t, db, server.URL, "stored-user", "stored-token")
+
+	svc := NewContainerRegistryService(db, func(context.Context) (RegistryDaemonClient, error) {
+		return &fakeRegistryDaemonClient{
+			distributionInspectFn: func(ctx context.Context, imageRef string, options client.DistributionInspectOptions) (client.DistributionInspectResult, error) {
+				return client.DistributionInspectResult{}, errors.New("Error response from daemon: Not Found")
+			},
+		}, nil
+	})
+	svc.distributionHTTPClient = server.Client()
+
+	result, err := svc.inspectImageDigestInternal(context.Background(), serverURL.Host+"/team/app:1.2.3", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "sha256:stored-credential", result.Digest)
+	assert.Equal(t, "credential", result.AuthMethod)
+	assert.Equal(t, "stored-user", result.AuthUsername)
+	assert.True(t, result.UsedCredential)
+	require.Len(t, authHeaders, 3)
+	assert.Equal(t, "", authHeaders[0])
+	assert.Equal(t, "Bearer anonymous-token", authHeaders[1])
+	assert.Equal(t, "Basic c3RvcmVkLXVzZXI6c3RvcmVkLXRva2Vu", authHeaders[2])
+}
+
+func TestContainerRegistryService_InspectImageDigest_DoesNotFallbackOnTLSFailure(t *testing.T) {
+	svc := NewContainerRegistryService(nil, func(context.Context) (RegistryDaemonClient, error) {
+		return &fakeRegistryDaemonClient{
+			distributionInspectFn: func(ctx context.Context, imageRef string, options client.DistributionInspectOptions) (client.DistributionInspectResult, error) {
+				assert.Equal(t, "registry.example.com/team/app:1.2.3", imageRef)
+				assert.Empty(t, options.EncodedRegistryAuth)
+				return client.DistributionInspectResult{}, errors.New("tls: failed to verify certificate: x509: certificate signed by unknown authority")
+			},
+		}, nil
+	})
+
+	result, err := svc.inspectImageDigestInternal(context.Background(), "registry.example.com/team/app:1.2.3", nil)
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Contains(t, strings.ToLower(err.Error()), "x509")
+	assert.NotContains(t, err.Error(), "registry fallback failed")
+	assert.Equal(t, "anonymous", result.AuthMethod)
+	assert.Equal(t, "registry.example.com", result.AuthRegistry)
+}
+
+func TestContainerRegistryService_InspectImageDigest_PreservesDaemonAndFallbackErrors(t *testing.T) {
+	daemonErr := errors.New("Error response from daemon: Not Found")
+	fallbackErr := errors.New("dial tcp: i/o timeout")
+
+	svc := NewContainerRegistryService(nil, func(context.Context) (RegistryDaemonClient, error) {
+		return &fakeRegistryDaemonClient{
+			distributionInspectFn: func(ctx context.Context, imageRef string, options client.DistributionInspectOptions) (client.DistributionInspectResult, error) {
+				return client.DistributionInspectResult{}, daemonErr
+			},
+		}, nil
+	})
+	svc.distributionHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, fallbackErr
+		}),
+	}
+
+	result, err := svc.inspectImageDigestInternal(context.Background(), "registry.example.com/team/app:1.2.3", nil)
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.ErrorIs(t, err, daemonErr)
+	assert.ErrorIs(t, err, fallbackErr)
+}
+
+func TestContainerRegistryService_InspectImageDigest_PreservesAnonymousUnauthorizedWhenCredentialLookupFails(t *testing.T) {
+	_, db := setupImageServiceAuthTest(t)
+	sqlDB, err := db.DB.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	var tokenURL string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/team/app/manifests/1.2.3":
+			w.Header().Set("WWW-Authenticate", `Bearer realm="`+tokenURL+`",service="registry.example.com"`)
+			w.WriteHeader(http.StatusUnauthorized)
+		case "/token":
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{
+				"token": "anonymous-token",
+			}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	tokenURL = server.URL + "/token"
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	svc := NewContainerRegistryService(db, func(context.Context) (RegistryDaemonClient, error) {
+		return &fakeRegistryDaemonClient{
+			distributionInspectFn: func(ctx context.Context, imageRef string, options client.DistributionInspectOptions) (client.DistributionInspectResult, error) {
+				return client.DistributionInspectResult{}, errors.New("Error response from daemon: Not Found")
+			},
+		}, nil
+	})
+	svc.distributionHTTPClient = server.Client()
+
+	result, err := svc.inspectImageDigestInternal(context.Background(), serverURL.Host+"/team/app:1.2.3", nil)
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "anonymous", result.AuthMethod)
+	assert.Contains(t, err.Error(), "anonymous access unauthorized")
+	assert.Contains(t, err.Error(), "status: 401")
+	assert.Contains(t, err.Error(), "failed to load enabled registries")
 }

--- a/backend/internal/services/image_update_service_test.go
+++ b/backend/internal/services/image_update_service_test.go
@@ -2,7 +2,13 @@ package services
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +17,7 @@ import (
 	"github.com/getarcaneapp/arcane/types/imageupdate"
 	glsqlite "github.com/glebarez/sqlite"
 	dockertypesimage "github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ref "go.podman.io/image/v5/docker/reference"
@@ -349,8 +356,123 @@ func setupImageUpdateTestDB(t *testing.T) *database.DB {
 	dsn := fmt.Sprintf("file:image-update-test-%d?mode=memory&cache=shared", time.Now().UnixNano())
 	db, err := gorm.Open(glsqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.ImageUpdateRecord{}))
+	require.NoError(t, db.AutoMigrate(&models.ImageUpdateRecord{}, &models.Event{}))
 	return &database.DB{DB: db}
+}
+
+func newImageUpdateFallbackServer(t *testing.T, repositoryTag, localDigest, remoteDigest string) *httptest.Server {
+	t.Helper()
+
+	repository := repositoryTag
+	tag := "latest"
+	if tagIndex := strings.LastIndex(repositoryTag, ":"); tagIndex > strings.LastIndex(repositoryTag, "/") {
+		repository = repositoryTag[:tagIndex]
+		tag = repositoryTag[tagIndex+1:]
+	}
+	manifestPath := fmt.Sprintf("/v2/%s/manifests/%s", repository, tag)
+
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/images/") && strings.HasSuffix(r.URL.Path, "/json"):
+			imageRef := r.Host + "/" + repositoryTag
+			repositoryRef := imageRef
+			if tagIndex := strings.LastIndex(imageRef, ":"); tagIndex > strings.LastIndex(imageRef, "/") {
+				repositoryRef = imageRef[:tagIndex]
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(dockertypesimage.InspectResponse{
+				ID:          "sha256:local-image-id",
+				RepoTags:    []string{imageRef},
+				RepoDigests: []string{repositoryRef + "@" + localDigest},
+			}))
+			return
+		case r.URL.Path == manifestPath:
+			w.Header().Set("Docker-Content-Digest", remoteDigest)
+			w.WriteHeader(http.StatusOK)
+			return
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestImageUpdateService_CheckImageUpdate_UsesRegistryFallback(t *testing.T) {
+	db := setupImageUpdateTestDB(t)
+
+	server := newImageUpdateFallbackServer(t, "team/app:1.2.3", "sha256:localdigest", "sha256:remotedigest")
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	imageRef := serverURL.Host + "/team/app:1.2.3"
+
+	registryService := NewContainerRegistryService(db, func(context.Context) (RegistryDaemonClient, error) {
+		return &fakeRegistryDaemonClient{
+			distributionInspectFn: func(ctx context.Context, imageRef string, options client.DistributionInspectOptions) (client.DistributionInspectResult, error) {
+				return client.DistributionInspectResult{}, errors.New("Error response from daemon: Not Found")
+			},
+		}, nil
+	})
+	registryService.distributionHTTPClient = server.Client()
+
+	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
+	eventService := NewEventService(db, nil, nil)
+	svc := NewImageUpdateService(db, nil, registryService, dockerService, eventService, nil)
+
+	result, err := svc.CheckImageUpdate(context.Background(), imageRef)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.HasUpdate)
+	assert.Equal(t, "digest", result.UpdateType)
+	assert.Equal(t, "sha256:localdigest", result.CurrentDigest)
+	assert.Equal(t, "sha256:remotedigest", result.LatestDigest)
+	assert.Equal(t, "anonymous", result.AuthMethod)
+	assert.Equal(t, serverURL.Host, result.AuthRegistry)
+
+	var saved models.ImageUpdateRecord
+	require.NoError(t, db.WithContext(context.Background()).Where("id = ?", "sha256:local-image-id").First(&saved).Error)
+	assert.Equal(t, "sha256:remotedigest", stringPtrToString(saved.LatestDigest))
+}
+
+func TestImageUpdateService_CheckMultipleImages_UsesRegistryFallback(t *testing.T) {
+	db := setupImageUpdateTestDB(t)
+
+	server := newImageUpdateFallbackServer(t, "team/app:1.2.3", "sha256:batchlocal", "sha256:batchremote")
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	imageRef := serverURL.Host + "/team/app:1.2.3"
+
+	registryService := NewContainerRegistryService(db, func(context.Context) (RegistryDaemonClient, error) {
+		return &fakeRegistryDaemonClient{
+			distributionInspectFn: func(ctx context.Context, imageRef string, options client.DistributionInspectOptions) (client.DistributionInspectResult, error) {
+				return client.DistributionInspectResult{}, errors.New("Error response from daemon: <html><body><h1>403 Forbidden</h1> Request forbidden by administrative rules. </body></html>")
+			},
+		}, nil
+	})
+	registryService.distributionHTTPClient = server.Client()
+
+	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
+	eventService := NewEventService(db, nil, nil)
+	svc := NewImageUpdateService(db, nil, registryService, dockerService, eventService, nil)
+
+	results, err := svc.CheckMultipleImages(context.Background(), []string{imageRef}, nil)
+	require.NoError(t, err)
+	require.Contains(t, results, imageRef)
+
+	result := results[imageRef]
+	require.NotNil(t, result)
+	assert.True(t, result.HasUpdate)
+	assert.Equal(t, "sha256:batchlocal", result.CurrentDigest)
+	assert.Equal(t, "sha256:batchremote", result.LatestDigest)
+	assert.Equal(t, "anonymous", result.AuthMethod)
+	assert.Equal(t, serverURL.Host, result.AuthRegistry)
+
+	var saved models.ImageUpdateRecord
+	require.NoError(t, db.WithContext(context.Background()).Where("id = ?", "sha256:local-image-id").First(&saved).Error)
+	assert.Equal(t, "sha256:batchremote", stringPtrToString(saved.LatestDigest))
 }
 
 // TestNotificationSentLogic tests the notification_sent flag behavior

--- a/backend/pkg/utils/distribution/distribution.go
+++ b/backend/pkg/utils/distribution/distribution.go
@@ -1,0 +1,421 @@
+package distribution
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	ref "go.podman.io/image/v5/docker/reference"
+)
+
+const defaultRegistryHost = "index.docker.io"
+
+type Credentials struct {
+	Username string
+	Token    string
+}
+
+type Reference struct {
+	NormalizedRef string
+	RegistryHost  string
+	Repository    string
+	Tag           string
+}
+
+func NormalizeReference(imageRef string) (*Reference, error) {
+	named, err := ref.ParseNormalizedNamed(strings.TrimSpace(imageRef))
+	if err != nil {
+		return nil, fmt.Errorf("invalid image reference %q: %w", imageRef, err)
+	}
+
+	if _, ok := named.(ref.Digested); ok {
+		return nil, fmt.Errorf("digest-pinned references are not supported for distribution inspect: %q", imageRef)
+	}
+
+	registryHost := normalizeRegistryForComparisonInternal(ref.Domain(named))
+	repository := ref.Path(named)
+
+	tag := "latest"
+	if tagged, ok := named.(ref.NamedTagged); ok {
+		tag = tagged.Tag()
+	}
+
+	return &Reference{
+		NormalizedRef: registryHost + "/" + repository + ":" + tag,
+		RegistryHost:  registryHost,
+		Repository:    repository,
+		Tag:           tag,
+	}, nil
+}
+
+func IsFallbackEligibleDaemonError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errLower := strings.ToLower(err.Error())
+	if strings.Contains(errLower, "unauthorized") ||
+		strings.Contains(errLower, "authentication required") ||
+		strings.Contains(errLower, "no basic auth credentials") ||
+		strings.Contains(errLower, "access denied") ||
+		strings.Contains(errLower, "incorrect username or password") ||
+		strings.Contains(errLower, "status: 401") ||
+		strings.Contains(errLower, "status 401") {
+		return false
+	}
+
+	if strings.Contains(errLower, "x509") || strings.Contains(errLower, "certificate") || strings.Contains(errLower, "tls") {
+		return false
+	}
+
+	// Network-level daemon errors are intentionally not fallback-eligible.
+	// If the daemon cannot reach the registry at all, the backend's direct HTTP
+	// client is also unlikely to succeed, so only registry/API capability
+	// failures are allowed to trigger fallback.
+	indicators := []string{
+		"not found",
+		" 404 ",
+		"status: 404",
+		"status 404",
+		"403 forbidden",
+		"status: 403",
+		"status 403",
+		"administrative rules",
+		"not implemented",
+		"unsupported",
+		"distribution disabled",
+		"distribution api",
+	}
+
+	for _, indicator := range indicators {
+		if strings.Contains(errLower, indicator) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func FetchDigest(ctx context.Context, registryHost, repository, tag string, credential *Credentials) (string, error) {
+	return FetchDigestWithHTTPClient(ctx, registryHost, repository, tag, credential, nil)
+}
+
+func FetchDigestWithHTTPClient(ctx context.Context, registryHost, repository, tag string, credential *Credentials, httpClient *http.Client) (string, error) {
+	if httpClient == nil {
+		httpClient = NewRegistryHTTPClient()
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	authHeader := ""
+	if credential != nil && strings.TrimSpace(credential.Username) != "" && strings.TrimSpace(credential.Token) != "" {
+		authHeader = basicAuthHeaderInternal(credential.Username, credential.Token)
+	}
+
+	resp, err := manifestRequestInternal(requestCtx, httpClient, registryHost, repository, tag, authHeader)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		challenge := resp.Header.Get("WWW-Authenticate")
+		if challenge == "" {
+			return "", fmt.Errorf("manifest request failed with status: %d", resp.StatusCode)
+		}
+		return fetchWithTokenAuthInternal(requestCtx, httpClient, registryHost, repository, tag, challenge, credential)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("manifest request failed with status: %d", resp.StatusCode)
+	}
+
+	digest := extractDigestFromHeadersInternal(resp.Header)
+	if digest == "" {
+		return "", fmt.Errorf("no digest header found in response")
+	}
+
+	return digest, nil
+}
+
+func fetchWithTokenAuthInternal(ctx context.Context, httpClient *http.Client, registryHost, repository, tag, challenge string, credential *Credentials) (string, error) {
+	realm, service := parseWWWAuthInternal(challenge)
+	if realm == "" {
+		return "", fmt.Errorf("no auth realm found")
+	}
+
+	token, err := fetchRegistryTokenInternal(ctx, httpClient, realm, service, repository, credential)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := manifestRequestInternal(ctx, httpClient, registryHost, repository, tag, token)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("authenticated manifest request failed with status: %d", resp.StatusCode)
+	}
+
+	digest := extractDigestFromHeadersInternal(resp.Header)
+	if digest == "" {
+		return "", fmt.Errorf("no digest header found in authenticated response")
+	}
+
+	return digest, nil
+}
+
+func fetchRegistryTokenInternal(ctx context.Context, httpClient *http.Client, authURL, service, repository string, credential *Credentials) (string, error) {
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid auth url: %w", err)
+	}
+
+	query := parsed.Query()
+	if query.Get("service") == "" {
+		if strings.TrimSpace(service) != "" {
+			query.Set("service", strings.TrimSpace(service))
+		} else {
+			query.Set("service", serviceNameFromAuthURLInternal(authURL))
+		}
+	}
+	query.Add("scope", fmt.Sprintf("repository:%s:pull", repository))
+	parsed.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("create token request: %w", err)
+	}
+	if credential != nil && strings.TrimSpace(credential.Username) != "" && strings.TrimSpace(credential.Token) != "" {
+		req.SetBasicAuth(strings.TrimSpace(credential.Username), strings.TrimSpace(credential.Token))
+	}
+
+	resp, err := httpClient.Do(req) //nolint:gosec // authURL comes from the registry challenge for the current image
+	if err != nil {
+		return "", fmt.Errorf("token request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token request failed with status: %d", resp.StatusCode)
+	}
+
+	var tokenResponse struct {
+		Token  string `json:"token"`
+		Legacy string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResponse); err != nil {
+		return "", fmt.Errorf("decode token response: %w", err)
+	}
+
+	token := strings.TrimSpace(tokenResponse.Token)
+	if token == "" {
+		token = strings.TrimSpace(tokenResponse.Legacy)
+	}
+	if token == "" {
+		return "", fmt.Errorf("no token in response")
+	}
+
+	return token, nil
+}
+
+func manifestRequestInternal(ctx context.Context, httpClient *http.Client, registryHost, repository, tag, authHeader string) (*http.Response, error) {
+	manifestURL := fmt.Sprintf("%s/v2/%s/manifests/%s", registryBaseURLInternal(registryHost), repository, tag)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, manifestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create manifest request: %w", err)
+	}
+	addManifestRequestHeadersInternal(req, authHeader)
+
+	resp, err := httpClient.Do(req) //nolint:gosec // manifestURL is derived from the normalized image reference
+	if err != nil {
+		return nil, fmt.Errorf("manifest request failed: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusMethodNotAllowed:
+		// Retry with GET only when the registry rejects HEAD as an unsupported method.
+		_ = resp.Body.Close()
+
+		getReq, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create manifest fallback request: %w", err)
+		}
+		addManifestRequestHeadersInternal(getReq, authHeader)
+
+		getResp, err := httpClient.Do(getReq) //nolint:gosec // manifestURL is derived from the normalized image reference
+		if err != nil {
+			return nil, fmt.Errorf("manifest fallback request failed: %w", err)
+		}
+
+		return getResp, nil
+	default:
+		return resp, nil
+	}
+}
+
+// NewRegistryHTTPClient returns the shared transport configuration used for
+// direct registry digest lookups.
+func NewRegistryHTTPClient() *http.Client {
+	var transport *http.Transport
+	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = defaultTransport.Clone()
+	} else {
+		transport = &http.Transport{}
+	}
+	transport.Proxy = http.ProxyFromEnvironment
+
+	return &http.Client{Transport: transport}
+}
+
+func registryBaseURLInternal(registryHost string) string {
+	trimmed := strings.TrimSpace(registryHost)
+	if strings.HasPrefix(trimmed, "http://") || strings.HasPrefix(trimmed, "https://") {
+		if parsed, err := url.Parse(trimmed); err == nil && parsed.Host != "" && normalizeRegistryForComparisonInternal(parsed.Host) == "docker.io" {
+			return "https://" + defaultRegistryHost
+		}
+		return strings.TrimSuffix(trimmed, "/")
+	}
+
+	normalizedHost := normalizeRegistryForComparisonInternal(trimmed)
+	if normalizedHost == "docker.io" {
+		return "https://" + defaultRegistryHost
+	}
+
+	return "https://" + normalizedHost
+}
+
+func addManifestRequestHeadersInternal(req *http.Request, authHeader string) {
+	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json")
+	req.Header.Set("User-Agent", "Arcane")
+	if strings.TrimSpace(authHeader) != "" {
+		req.Header.Set("Authorization", buildAuthHeaderInternal(authHeader))
+	}
+}
+
+func buildAuthHeaderInternal(authHeader string) string {
+	trimmed := strings.TrimSpace(authHeader)
+	if trimmed == "" {
+		return ""
+	}
+
+	lower := strings.ToLower(trimmed)
+	if strings.HasPrefix(lower, "bearer ") || strings.HasPrefix(lower, "basic ") {
+		return trimmed
+	}
+
+	return "Bearer " + trimmed
+}
+
+func basicAuthHeaderInternal(username, token string) string {
+	raw := strings.TrimSpace(username) + ":" + strings.TrimSpace(token)
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(raw))
+}
+
+func extractDigestFromHeadersInternal(headers http.Header) string {
+	if digest := headers.Get("Docker-Content-Digest"); digest != "" {
+		return digest
+	}
+
+	etag := strings.Trim(headers.Get("ETag"), `"`)
+	if strings.HasPrefix(etag, "sha256:") {
+		return etag
+	}
+
+	return ""
+}
+
+func parseWWWAuthInternal(header string) (string, string) {
+	lower := strings.ToLower(header)
+	if !strings.HasPrefix(lower, "bearer ") {
+		return "", ""
+	}
+
+	_, after, ok := strings.Cut(header, " ")
+	if !ok {
+		return "", ""
+	}
+
+	var realm string
+	var service string
+	for _, part := range splitBearerDirectivesInternal(after) {
+		part = strings.TrimSpace(part)
+		lowerPart := strings.ToLower(part)
+
+		switch {
+		case strings.HasPrefix(lowerPart, "realm="):
+			realm = strings.Trim(part[len("realm="):], `"`)
+		case strings.HasPrefix(lowerPart, "service="):
+			service = strings.Trim(part[len("service="):], `"`)
+		}
+	}
+
+	return realm, service
+}
+
+func splitBearerDirectivesInternal(value string) []string {
+	var parts []string
+	var current strings.Builder
+	inQuote := false
+
+	for _, r := range value {
+		switch {
+		case r == '"':
+			inQuote = !inQuote
+			current.WriteRune(r)
+		case r == ',' && !inQuote:
+			parts = append(parts, current.String())
+			current.Reset()
+		default:
+			current.WriteRune(r)
+		}
+	}
+
+	if current.Len() > 0 {
+		parts = append(parts, current.String())
+	}
+
+	return parts
+}
+
+func serviceNameFromAuthURLInternal(authURL string) string {
+	if strings.Contains(authURL, "auth.docker.io") {
+		return "registry.docker.io"
+	}
+
+	trimmed := strings.TrimPrefix(authURL, "https://")
+	trimmed = strings.TrimPrefix(trimmed, "http://")
+	host, _, _ := strings.Cut(trimmed, "/")
+	if host == "" {
+		return "registry"
+	}
+
+	return host
+}
+
+func normalizeRegistryForComparisonInternal(raw string) string {
+	value := strings.TrimSpace(strings.ToLower(raw))
+	value = strings.TrimPrefix(value, "https://")
+	value = strings.TrimPrefix(value, "http://")
+	value = strings.TrimSuffix(value, "/")
+
+	if slash := strings.Index(value, "/"); slash != -1 {
+		value = value[:slash]
+	}
+
+	switch value {
+	case "docker.io", "registry-1.docker.io", "index.docker.io":
+		return "docker.io"
+	default:
+		return value
+	}
+}

--- a/backend/pkg/utils/distribution/distribution_test.go
+++ b/backend/pkg/utils/distribution/distribution_test.go
@@ -1,0 +1,97 @@
+package distribution
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchDigestWithHTTPClient_FallsBackToGetOnMethodNotAllowed(t *testing.T) {
+	var headCalls int
+	var getCalls int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			headCalls++
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		case http.MethodGet:
+			getCalls++
+			w.Header().Set("Docker-Content-Digest", "sha256:method-not-allowed")
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	digest, err := FetchDigestWithHTTPClient(
+		context.Background(),
+		server.URL,
+		"team/app",
+		"1.2.3",
+		nil,
+		server.Client(),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "sha256:method-not-allowed", digest)
+	assert.Equal(t, 1, headCalls)
+	assert.Equal(t, 1, getCalls)
+}
+
+func TestFetchDigestWithHTTPClient_DoesNotFallbackToGetOnResourceErrors(t *testing.T) {
+	testCases := []struct {
+		name   string
+		status int
+	}{
+		{name: "not found", status: http.StatusNotFound},
+		{name: "forbidden", status: http.StatusForbidden},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var headCalls int
+			var getCalls int
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodHead:
+					headCalls++
+					w.WriteHeader(tc.status)
+				case http.MethodGet:
+					getCalls++
+					w.Header().Set("Docker-Content-Digest", "sha256:unexpected-get")
+					w.WriteHeader(http.StatusOK)
+				default:
+					t.Fatalf("unexpected method %s", r.Method)
+				}
+			}))
+			defer server.Close()
+
+			digest, err := FetchDigestWithHTTPClient(
+				context.Background(),
+				server.URL,
+				"team/app",
+				"1.2.3",
+				nil,
+				server.Client(),
+			)
+			require.Error(t, err)
+			assert.Empty(t, digest)
+			assert.Equal(t, fmt.Sprintf("manifest request failed with status: %d", tc.status), err.Error())
+			assert.Equal(t, 1, headCalls)
+			assert.Equal(t, 0, getCalls)
+		})
+	}
+}
+
+func TestParseWWWAuthInternal_AllowsCommasInsideQuotedRealm(t *testing.T) {
+	realm, service := parseWWWAuthInternal(`Bearer realm="https://auth.example.com/token?a=1,b=2",service="registry.example.com"`)
+	assert.Equal(t, "https://auth.example.com/token?a=1,b=2", realm)
+	assert.Equal(t, "registry.example.com", service)
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2068

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces Moby's `DistributionInspect` daemon call as the sole source of image digest information with a two-step approach: the daemon is tried first, and when it returns a known "capability gap" error (404/403 from a registry proxy, distribution disabled, etc.), the Arcane backend falls back to its own direct HTTP registry manifest lookup via the new `distribution` package. This fixes a class of false-negative update checks on installations where the Docker daemon lacks network access to certain registries but the backend itself does.

Key changes:
- **New `backend/pkg/utils/distribution` package** — implements direct OCI/Docker manifest HEAD (with GET fallback on 405), bearer token auth, quote-aware `WWW-Authenticate` parsing, and safe `http.DefaultTransport` cloning.
- **`ContainerRegistryService` extended** — a shared `*http.Client` is injected at construction time; `inspectImageDigestInternal` now delegates to `inspectImageDigestViaDaemonInternal` first and `inspectImageDigestViaRegistryInternal` on fallback-eligible errors.
- **`isUnauthorizedRegistryErrorInternal` now includes `"status: 403"` / `"status 403"`** — so registries that return HTTP 403 on the authenticated manifest request correctly trigger a stored-credential retry.
- **Comprehensive test coverage** — both unit tests for each path and integration-style tests that wire up a TLS `httptest.Server` as both a Docker-daemon mock and a real registry.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge after addressing the missing fast-fail guard in the registry fallback credential loop.
- The overall design is sound and previous review comments have all been addressed. One logic inconsistency remains: the credential retry loop in `inspectImageDigestViaRegistryInternal` does not short-circuit on non-auth errors the way the equivalent daemon path does, which could cause unnecessary retries and increased latency when a transient non-auth failure occurs during fallback with multiple credentials configured.
- backend/internal/services/container_registry_service.go — the credential retry loop in `inspectImageDigestViaRegistryInternal` (lines 477–491).
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/container_registry_service.go | Major refactor: adds a `distributionHTTPClient` field and a new `inspectImageDigestViaRegistryInternal` fallback path for digest lookups. The credential retry loop in the registry fallback path is missing the fast-fail guard on non-auth errors that the daemon path enforces. |
| backend/pkg/utils/distribution/distribution.go | New package providing direct HTTP registry digest lookups. Correctly uses the comma-ok idiom for transport cloning, a quote-aware bearer directive splitter, and HEAD-to-GET fallback only on 405. Logic and patterns look solid. |
| backend/internal/services/container_registry_service_test.go | Comprehensive table of new unit tests covering anonymous success, credential retry, TLS-failure non-fallback, both 404/403 daemon-error fallback triggers, and combined error preservation. Coverage looks thorough. |
| backend/internal/services/image_update_service_test.go | Adds two integration-style tests for the full `CheckImageUpdate` / `CheckMultipleImages` fallback flow using a TLS test server. The manifest path is now correctly derived from the `repositoryTag` argument instead of being hardcoded. |
| backend/pkg/utils/distribution/distribution_test.go | Three focused tests: HEAD→GET fallback on 405, no fallback on 404/403, and quoted-realm comma parsing. All verify the key behavior changes. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `backend/internal/services/container_registry_service_test.go`, line 192-203 ([link](https://github.com/getarcaneapp/arcane/blob/9486ec9d55aeb91bb63ca0015b6eead897eb16fd/backend/internal/services/container_registry_service_test.go#L192-L203)) 

   **Global `http.DefaultTransport` mutation is unsafe for parallel tests**

   `useRegistryHTTPTransport` replaces the process-wide `http.DefaultTransport`, which is a shared global. While `t.Cleanup` restores the original value, any test that runs concurrently with one that calls this helper (or any test that relies on the real `DefaultTransport`) will see the replaced value during that window.

   Since `newRegistryHTTPClient` in `distribution.go` clones `http.DefaultTransport`, injecting the TLS-enabled test transport through this global is the current approach — but it couples all tests that touch `FetchDigest` to this global mutation. Consider whether the `distribution` package could accept an `*http.Client` or `http.RoundTripper` parameter on `FetchDigest`/`newRegistryHTTPClient` to allow per-test injection without touching the global.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/container_registry_service_test.go
   Line: 192-203

   Comment:
   **Global `http.DefaultTransport` mutation is unsafe for parallel tests**

   `useRegistryHTTPTransport` replaces the process-wide `http.DefaultTransport`, which is a shared global. While `t.Cleanup` restores the original value, any test that runs concurrently with one that calls this helper (or any test that relies on the real `DefaultTransport`) will see the replaced value during that window.

   Since `newRegistryHTTPClient` in `distribution.go` clones `http.DefaultTransport`, injecting the TLS-enabled test transport through this global is the current approach — but it couples all tests that touch `FetchDigest` to this global mutation. Consider whether the `distribution` package could accept an `*http.Client` or `http.RoundTripper` parameter on `FetchDigest`/`newRegistryHTTPClient` to allow per-test injection without touching the global.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fcontainer_registry_service_test.go%0ALine%3A%20192-203%0A%0AComment%3A%0A**Global%20%60http.DefaultTransport%60%20mutation%20is%20unsafe%20for%20parallel%20tests**%0A%0A%60useRegistryHTTPTransport%60%20replaces%20the%20process-wide%20%60http.DefaultTransport%60%2C%20which%20is%20a%20shared%20global.%20While%20%60t.Cleanup%60%20restores%20the%20original%20value%2C%20any%20test%20that%20runs%20concurrently%20with%20one%20that%20calls%20this%20helper%20%28or%20any%20test%20that%20relies%20on%20the%20real%20%60DefaultTransport%60%29%20will%20see%20the%20replaced%20value%20during%20that%20window.%0A%0ASince%20%60newRegistryHTTPClient%60%20in%20%60distribution.go%60%20clones%20%60http.DefaultTransport%60%2C%20injecting%20the%20TLS-enabled%20test%20transport%20through%20this%20global%20is%20the%20current%20approach%20%E2%80%94%20but%20it%20couples%20all%20tests%20that%20touch%20%60FetchDigest%60%20to%20this%20global%20mutation.%20Consider%20whether%20the%20%60distribution%60%20package%20could%20accept%20an%20%60*http.Client%60%20or%20%60http.RoundTripper%60%20parameter%20on%20%60FetchDigest%60%2F%60newRegistryHTTPClient%60%20to%20allow%20per-test%20injection%20without%20touching%20the%20global.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

2. `backend/internal/services/container_registry_service.go`, line 61-67 ([link](https://github.com/getarcaneapp/arcane/blob/e56cf6f93eb19981bcadb1fd619e3b11a64e9494/backend/internal/services/container_registry_service.go#L61-L67)) 

   **`distributionHTTPClient` not initialized — connection pooling lost**

   `NewContainerRegistryService` does not set `distributionHTTPClient`, so the field stays `nil` in production. Every call to `fetchDigestFromRegistryInternal` passes `nil` to `FetchDigestWithHTTPClient`, which responds by calling `newRegistryHTTPClient()` — creating a brand-new `*http.Client` and a cloned `*http.Transport` for every single fallback request. Because `http.Transport` maintains its own connection pool, a fresh transport has no pooled connections and each fallback DNS-resolves, TCP-connects, and TLS-handshakes from scratch, negating the keep-alive connection reuse that Go's HTTP stack provides.

   The fix is to initialize the shared client once in the constructor:
   ```go
   func NewContainerRegistryService(db *database.DB, dockerClient registryDaemonGetter) *ContainerRegistryService {
       return &ContainerRegistryService{
           db:                     db,
           dockerClient:           dockerClient,
           distributionHTTPClient: utilsdistribution.NewRegistryHTTPClient(), // or newRegistryHTTPClient() promoted
           cache:                  make(map[string]*cache.Cache[string]),
       }
   }
   ```
   Alternatively, expose `newRegistryHTTPClient` from the `distribution` package (exported) so the constructor can call it once.

   **Rule Used:** # Go Development Patterns
   
   **What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/container_registry_service.go
   Line: 61-67
   
   Comment:
   **`distributionHTTPClient` not initialized — connection pooling lost**
   
   `NewContainerRegistryService` does not set `distributionHTTPClient`, so the field stays `nil` in production. Every call to `fetchDigestFromRegistryInternal` passes `nil` to `FetchDigestWithHTTPClient`, which responds by calling `newRegistryHTTPClient()` — creating a brand-new `*http.Client` and a cloned `*http.Transport` for every single fallback request. Because `http.Transport` maintains its own connection pool, a fresh transport has no pooled connections and each fallback DNS-resolves, TCP-connects, and TLS-handshakes from scratch, negating the keep-alive connection reuse that Go's HTTP stack provides.
   
   The fix is to initialize the shared client once in the constructor:
   ```go
   func NewContainerRegistryService(db *database.DB, dockerClient registryDaemonGetter) *ContainerRegistryService {
       return &ContainerRegistryService{
           db:                     db,
           dockerClient:           dockerClient,
           distributionHTTPClient: utilsdistribution.NewRegistryHTTPClient(), // or newRegistryHTTPClient() promoted
           cache:                  make(map[string]*cache.Cache[string]),
       }
   }
   ```
   Alternatively, expose `newRegistryHTTPClient` from the `distribution` package (exported) so the constructor can call it once.
   
   **Rule Used:** # Go Development Patterns
   
   **What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fcontainer_registry_service.go%0ALine%3A%2061-67%0A%0AComment%3A%0A**%60distributionHTTPClient%60%20not%20initialized%20%E2%80%94%20connection%20pooling%20lost**%0A%0A%60NewContainerRegistryService%60%20does%20not%20set%20%60distributionHTTPClient%60%2C%20so%20the%20field%20stays%20%60nil%60%20in%20production.%20Every%20call%20to%20%60fetchDigestFromRegistryInternal%60%20passes%20%60nil%60%20to%20%60FetchDigestWithHTTPClient%60%2C%20which%20responds%20by%20calling%20%60newRegistryHTTPClient%28%29%60%20%E2%80%94%20creating%20a%20brand-new%20%60*http.Client%60%20and%20a%20cloned%20%60*http.Transport%60%20for%20every%20single%20fallback%20request.%20Because%20%60http.Transport%60%20maintains%20its%20own%20connection%20pool%2C%20a%20fresh%20transport%20has%20no%20pooled%20connections%20and%20each%20fallback%20DNS-resolves%2C%20TCP-connects%2C%20and%20TLS-handshakes%20from%20scratch%2C%20negating%20the%20keep-alive%20connection%20reuse%20that%20Go's%20HTTP%20stack%20provides.%0A%0AThe%20fix%20is%20to%20initialize%20the%20shared%20client%20once%20in%20the%20constructor%3A%0A%60%60%60go%0Afunc%20NewContainerRegistryService%28db%20*database.DB%2C%20dockerClient%20registryDaemonGetter%29%20*ContainerRegistryService%20%7B%0A%20%20%20%20return%20%26ContainerRegistryService%7B%0A%20%20%20%20%20%20%20%20db%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20db%2C%0A%20%20%20%20%20%20%20%20dockerClient%3A%20%20%20%20%20%20%20%20%20%20%20dockerClient%2C%0A%20%20%20%20%20%20%20%20distributionHTTPClient%3A%20utilsdistribution.NewRegistryHTTPClient%28%29%2C%20%2F%2F%20or%20newRegistryHTTPClient%28%29%20promoted%0A%20%20%20%20%20%20%20%20cache%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20make%28map%5Bstring%5D*cache.Cache%5Bstring%5D%29%2C%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0AAlternatively%2C%20expose%20%60newRegistryHTTPClient%60%20from%20the%20%60distribution%60%20package%20%28exported%29%20so%20the%20constructor%20can%20call%20it%20once.%0A%0A**Rule%20Used%3A**%20%23%20Go%20Development%20Patterns%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

3. `backend/internal/services/container_registry_service.go`, line 69 ([link](https://github.com/getarcaneapp/arcane/blob/e56cf6f93eb19981bcadb1fd619e3b11a64e9494/backend/internal/services/container_registry_service.go#L69)) 

   **Daemon error not wrapped — inaccessible via `errors.Is`/`errors.As`**

   When both the daemon path and the registry fallback fail, the combined error is built as:

   ```go
   return fallbackResult, fmt.Errorf("daemon digest lookup failed (%s); registry fallback failed: %w", err.Error(), fallbackErr)
   ```

   `err` (the daemon error) is interpolated with `%s` rather than wrapped with `%w`. This means `errors.Unwrap` chains to `fallbackErr` only — any caller using `errors.Is(err, specificDaemonErr)` or `errors.As(...)` to inspect the original daemon failure will silently miss it.

   Consider wrapping both errors, for example using `errors.Join`:
   ```go
   return fallbackResult, fmt.Errorf("daemon digest lookup failed; registry fallback failed: %w", errors.Join(err, fallbackErr))
   ```
   or using a custom multi-error type so both causes remain programmatically inspectable.

   **Rule Used:** # Go Development Patterns
   
   **What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/container_registry_service.go
   Line: 69
   
   Comment:
   **Daemon error not wrapped — inaccessible via `errors.Is`/`errors.As`**
   
   When both the daemon path and the registry fallback fail, the combined error is built as:
   
   ```go
   return fallbackResult, fmt.Errorf("daemon digest lookup failed (%s); registry fallback failed: %w", err.Error(), fallbackErr)
   ```
   
   `err` (the daemon error) is interpolated with `%s` rather than wrapped with `%w`. This means `errors.Unwrap` chains to `fallbackErr` only — any caller using `errors.Is(err, specificDaemonErr)` or `errors.As(...)` to inspect the original daemon failure will silently miss it.
   
   Consider wrapping both errors, for example using `errors.Join`:
   ```go
   return fallbackResult, fmt.Errorf("daemon digest lookup failed; registry fallback failed: %w", errors.Join(err, fallbackErr))
   ```
   or using a custom multi-error type so both causes remain programmatically inspectable.
   
   **Rule Used:** # Go Development Patterns
   
   **What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fcontainer_registry_service.go%0ALine%3A%2069%0A%0AComment%3A%0A**Daemon%20error%20not%20wrapped%20%E2%80%94%20inaccessible%20via%20%60errors.Is%60%2F%60errors.As%60**%0A%0AWhen%20both%20the%20daemon%20path%20and%20the%20registry%20fallback%20fail%2C%20the%20combined%20error%20is%20built%20as%3A%0A%0A%60%60%60go%0Areturn%20fallbackResult%2C%20fmt.Errorf%28%22daemon%20digest%20lookup%20failed%20%28%25s%29%3B%20registry%20fallback%20failed%3A%20%25w%22%2C%20err.Error%28%29%2C%20fallbackErr%29%0A%60%60%60%0A%0A%60err%60%20%28the%20daemon%20error%29%20is%20interpolated%20with%20%60%25s%60%20rather%20than%20wrapped%20with%20%60%25w%60.%20This%20means%20%60errors.Unwrap%60%20chains%20to%20%60fallbackErr%60%20only%20%E2%80%94%20any%20caller%20using%20%60errors.Is%28err%2C%20specificDaemonErr%29%60%20or%20%60errors.As%28...%29%60%20to%20inspect%20the%20original%20daemon%20failure%20will%20silently%20miss%20it.%0A%0AConsider%20wrapping%20both%20errors%2C%20for%20example%20using%20%60errors.Join%60%3A%0A%60%60%60go%0Areturn%20fallbackResult%2C%20fmt.Errorf%28%22daemon%20digest%20lookup%20failed%3B%20registry%20fallback%20failed%3A%20%25w%22%2C%20errors.Join%28err%2C%20fallbackErr%29%29%0A%60%60%60%0Aor%20using%20a%20custom%20multi-error%20type%20so%20both%20causes%20remain%20programmatically%20inspectable.%0A%0A**Rule%20Used%3A**%20%23%20Go%20Development%20Patterns%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

4. `backend/internal/services/container_registry_service.go`, line 381-385 ([link](https://github.com/getarcaneapp/arcane/blob/0581c102b7d0ca26da17cf395c117e16a905509b/backend/internal/services/container_registry_service.go#L381-L385)) 

   **Nil result returned on docker client failure breaks caller contract**

   `inspectImageDigestViaDaemonInternal` returns `(nil, err)` when `getDockerClientInternal` fails. Every other error exit in this function — and in `inspectImageDigestViaRegistryInternal` — returns a non-nil partial `*registryDigestResult`, so callers reasonably expect a non-nil result alongside any error.

   In `inspectImageDigestInternal`, when this `nil` result is returned with a non-fallback-eligible error (which "docker client unavailable" is), the nil is propagated directly to callers. Any caller that inspects fields such as `result.AuthRegistry` without first checking the error will panic.

   ```go
   func (s *ContainerRegistryService) inspectImageDigestViaDaemonInternal(...) (*registryDigestResult, error) {
       dockerClient, err := s.getDockerClientInternal(ctx)
       if err != nil {
   -       return nil, err
   +       return &registryDigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}, err
       }
   ```

   This keeps the return contract consistent with every other error path in the file.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/container_registry_service.go
   Line: 381-385

   Comment:
   **Nil result returned on docker client failure breaks caller contract**

   `inspectImageDigestViaDaemonInternal` returns `(nil, err)` when `getDockerClientInternal` fails. Every other error exit in this function — and in `inspectImageDigestViaRegistryInternal` — returns a non-nil partial `*registryDigestResult`, so callers reasonably expect a non-nil result alongside any error.

   In `inspectImageDigestInternal`, when this `nil` result is returned with a non-fallback-eligible error (which "docker client unavailable" is), the nil is propagated directly to callers. Any caller that inspects fields such as `result.AuthRegistry` without first checking the error will panic.

   ```go
   func (s *ContainerRegistryService) inspectImageDigestViaDaemonInternal(...) (*registryDigestResult, error) {
       dockerClient, err := s.getDockerClientInternal(ctx)
       if err != nil {
   -       return nil, err
   +       return &registryDigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}, err
       }
   ```

   This keeps the return contract consistent with every other error path in the file.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fcontainer_registry_service.go%0ALine%3A%20381-385%0A%0AComment%3A%0A**Nil%20result%20returned%20on%20docker%20client%20failure%20breaks%20caller%20contract**%0A%0A%60inspectImageDigestViaDaemonInternal%60%20returns%20%60%28nil%2C%20err%29%60%20when%20%60getDockerClientInternal%60%20fails.%20Every%20other%20error%20exit%20in%20this%20function%20%E2%80%94%20and%20in%20%60inspectImageDigestViaRegistryInternal%60%20%E2%80%94%20returns%20a%20non-nil%20partial%20%60*registryDigestResult%60%2C%20so%20callers%20reasonably%20expect%20a%20non-nil%20result%20alongside%20any%20error.%0A%0AIn%20%60inspectImageDigestInternal%60%2C%20when%20this%20%60nil%60%20result%20is%20returned%20with%20a%20non-fallback-eligible%20error%20%28which%20%22docker%20client%20unavailable%22%20is%29%2C%20the%20nil%20is%20propagated%20directly%20to%20callers.%20Any%20caller%20that%20inspects%20fields%20such%20as%20%60result.AuthRegistry%60%20without%20first%20checking%20the%20error%20will%20panic.%0A%0A%60%60%60go%0Afunc%20%28s%20*ContainerRegistryService%29%20inspectImageDigestViaDaemonInternal%28...%29%20%28*registryDigestResult%2C%20error%29%20%7B%0A%20%20%20%20dockerClient%2C%20err%20%3A%3D%20s.getDockerClientInternal%28ctx%29%0A%20%20%20%20if%20err%20!%3D%20nil%20%7B%0A-%20%20%20%20%20%20%20return%20nil%2C%20err%0A%2B%20%20%20%20%20%20%20return%20%26registryDigestResult%7BAuthMethod%3A%20%22anonymous%22%2C%20AuthRegistry%3A%20registryHost%7D%2C%20err%0A%20%20%20%20%7D%0A%60%60%60%0A%0AThis%20keeps%20the%20return%20contract%20consistent%20with%20every%20other%20error%20path%20in%20the%20file.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fcontainer_registry_service.go%3A477-491%0A**Missing%20fast-fail%20on%20non-auth%20errors%20in%20credential%20retry%20loop**%0A%0AThe%20credential%20retry%20loop%20in%20%60inspectImageDigestViaRegistryInternal%60%20does%20not%20check%20whether%20an%20error%20is%20authorization-related%20before%20continuing%20to%20the%20next%20credential.%20This%20is%20inconsistent%20with%20the%20analogous%20loop%20in%20%60inspectImageDigestViaDaemonInternal%60%20%28lines%20436%E2%80%93443%29%2C%20which%20immediately%20returns%20on%20non-unauthorized%20errors%20%28e.g.%2C%20network%20timeouts%2C%205xx%20server%20errors%29.%0A%0AIf%20a%20credential-authenticated%20request%20fails%20with%20a%20network%20error%20or%20other%20transient%20non-auth%20error%2C%20the%20loop%20will%20continue%20trying%20every%20remaining%20credential%20unnecessarily%2C%20compounding%20latency.%20In%20the%20daemon%20path%20this%20is%20guarded%3A%0A%0A%60%60%60go%0AlastErr%20%3D%20err%0Aif%20!isUnauthorizedRegistryErrorInternal%28err%29%20%7B%0A%20%20%20%20return%20%26registryDigestResult%7B...%7D%2C%20fmt.Errorf%28%22distribution%20inspect%20failed%20for%20%25s%20with%20credentials%3A%20%25w%22%2C%20...%29%0A%7D%0A%60%60%60%0A%0AThe%20registry%20fallback%20path%20should%20apply%20the%20same%20guard%3A%0A%0A%60%60%60go%0A%09for%20_%2C%20credential%20%3A%3D%20range%20credentials%20%7B%0A%09%09lastCred%20%3D%20credential%0A%0A%09%09digest%2C%20err%20%3D%20s.fetchDigestFromRegistryInternal%28ctx%2C%20registryHost%2C%20repository%2C%20tag%2C%20%26credential%29%0A%09%09if%20err%20%3D%3D%20nil%20%7B%0A%09%09%09return%20%26registryDigestResult%7B%0A%09%09%09%09Digest%3A%20%20%20%20%20%20%20%20%20digest%2C%0A%09%09%09%09AuthMethod%3A%20%20%20%20%20%22credential%22%2C%0A%09%09%09%09AuthUsername%3A%20%20%20credential.Username%2C%0A%09%09%09%09AuthRegistry%3A%20%20%20registryHost%2C%0A%09%09%09%09UsedCredential%3A%20true%2C%0A%09%09%09%7D%2C%20nil%0A%09%09%7D%0A%0A%09%09lastErr%20%3D%20err%0A%09%09if%20!isUnauthorizedRegistryErrorInternal%28err%29%20%7B%0A%09%09%09partial%20%3A%3D%20%26registryDigestResult%7B%0A%09%09%09%09AuthMethod%3A%20%20%20%20%20%22credential%22%2C%0A%09%09%09%09AuthUsername%3A%20%20%20credential.Username%2C%0A%09%09%09%09AuthRegistry%3A%20%20%20registryHost%2C%0A%09%09%09%09UsedCredential%3A%20true%2C%0A%09%09%09%7D%0A%09%09%09return%20partial%2C%20fmt.Errorf%28%22registry%20manifest%20inspect%20failed%20for%20%25s%2F%25s%3A%25s%20with%20credentials%3A%20%25w%22%2C%20registryHost%2C%20repository%2C%20tag%2C%20err%29%0A%09%09%7D%0A%09%7D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20%23%20Golang%20Pro%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/container_registry_service.go
Line: 477-491

Comment:
**Missing fast-fail on non-auth errors in credential retry loop**

The credential retry loop in `inspectImageDigestViaRegistryInternal` does not check whether an error is authorization-related before continuing to the next credential. This is inconsistent with the analogous loop in `inspectImageDigestViaDaemonInternal` (lines 436–443), which immediately returns on non-unauthorized errors (e.g., network timeouts, 5xx server errors).

If a credential-authenticated request fails with a network error or other transient non-auth error, the loop will continue trying every remaining credential unnecessarily, compounding latency. In the daemon path this is guarded:

```go
lastErr = err
if !isUnauthorizedRegistryErrorInternal(err) {
    return &registryDigestResult{...}, fmt.Errorf("distribution inspect failed for %s with credentials: %w", ...)
}
```

The registry fallback path should apply the same guard:

```go
	for _, credential := range credentials {
		lastCred = credential

		digest, err = s.fetchDigestFromRegistryInternal(ctx, registryHost, repository, tag, &credential)
		if err == nil {
			return &registryDigestResult{
				Digest:         digest,
				AuthMethod:     "credential",
				AuthUsername:   credential.Username,
				AuthRegistry:   registryHost,
				UsedCredential: true,
			}, nil
		}

		lastErr = err
		if !isUnauthorizedRegistryErrorInternal(err) {
			partial := &registryDigestResult{
				AuthMethod:     "credential",
				AuthUsername:   credential.Username,
				AuthRegistry:   registryHost,
				UsedCredential: true,
			}
			return partial, fmt.Errorf("registry manifest inspect failed for %s/%s:%s with credentials: %w", registryHost, repository, tag, err)
		}
	}
```

**Rule Used:** # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: abc34e4</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->