### PR TITLE
fix: save button inconsistent state upon saving

### DIFF
--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -28,17 +28,21 @@
 	import ProjectsLogsPanel from '../components/ProjectLogsPanel.svelte';
 	import ResizableSplit from '$lib/components/resizable-split.svelte';
 	import SwitchWithLabel from '$lib/components/form/labeled-switch.svelte';
+	import { IsTablet } from '$lib/hooks/is-tablet.svelte.js';
 	import { untrack } from 'svelte';
 	import { projectService } from '$lib/services/project-service';
 	import { gitOpsSyncService } from '$lib/services/gitops-sync-service';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
+	import { queryKeys } from '$lib/query/query-keys';
 	import { RefreshIcon } from '$lib/icons';
 	import IconImage from '$lib/components/icon-image.svelte';
+	import { useQueryClient } from '@tanstack/svelte-query';
 
 	let { data } = $props();
 	let projectId = $derived(data.projectId);
 	let project = $state(untrack(() => data.project));
-	let editorState = $derived(data.editorState);
+	const queryClient = useQueryClient();
+	const isTablet = new IsTablet();
 
 	let isLoading = $state({
 		deploying: false,
@@ -73,13 +77,13 @@
 		envContent: z.string().optional().default('')
 	});
 
-	let formData = $derived({
-		name: editorState.name,
-		composeContent: editorState.composeContent,
-		envContent: editorState.envContent || ''
-	});
+	const initialFormData = untrack(() => ({
+		name: data.editorState.originalName,
+		composeContent: data.editorState.originalComposeContent,
+		envContent: data.editorState.originalEnvContent || ''
+	}));
 
-	let { inputs, ...form } = $derived(createForm<typeof formSchema>(formSchema, formData));
+	const { inputs, ...form } = createForm<typeof formSchema>(formSchema, initialFormData);
 
 	let hasChanges = $derived(
 		$inputs.name.value !== originalName ||
@@ -171,13 +175,123 @@
 	};
 
 	let prefs: PersistedState<ComposeUIPrefs> | null = null;
+	let lastAppliedProjectId = $state<string | null>(null);
+	let lastSeenProjectSignature = $state<string | null>(null);
+	let lastPrefsProjectId = $state<string | null>(null);
+
+	type ApplyProjectMode = 'initialize' | 'saved' | 'refresh';
+
+	function buildProjectSyncSignature(details: Project): string {
+		return JSON.stringify({
+			id: details.id,
+			name: details.name,
+			status: details.status,
+			statusReason: details.statusReason,
+			runningCount: details.runningCount,
+			serviceCount: details.serviceCount,
+			updatedAt: details.updatedAt,
+			composeContent: details.composeContent ?? '',
+			envContent: details.envContent ?? '',
+			includeFiles: (details.includeFiles ?? []).map((file) => ({
+				relativePath: file.relativePath,
+				content: file.content
+			})),
+			runtimeServices: (details.runtimeServices ?? []).map((service) => ({
+				name: service.name,
+				status: service.status,
+				containerId: service.containerId,
+				containerName: service.containerName
+			}))
+		});
+	}
+
+	function buildIncludeFilesMap(details: Project): Record<string, string> {
+		return Object.fromEntries((details.includeFiles ?? []).map((file) => [file.relativePath, file.content]));
+	}
+
+	function syncIncludeFileUiState(details: Project) {
+		const nextPanelStates: Record<string, boolean> = {};
+		const nextErrors: Record<string, boolean> = {};
+		const nextValidationReady: Record<string, boolean> = {};
+
+		for (const file of details.includeFiles ?? []) {
+			nextPanelStates[file.relativePath] = includeFilesPanelStates[file.relativePath] ?? true;
+			nextErrors[file.relativePath] = includeFilesHasErrors[file.relativePath] ?? false;
+			nextValidationReady[file.relativePath] = includeFilesValidationReady[file.relativePath] ?? true;
+		}
+
+		includeFilesPanelStates = nextPanelStates;
+		includeFilesHasErrors = nextErrors;
+		includeFilesValidationReady = nextValidationReady;
+
+		if (selectedIncludeTab && !(selectedIncludeTab in nextPanelStates)) {
+			selectedIncludeTab = null;
+		}
+		if (selectedFile !== 'compose' && selectedFile !== 'env' && !(selectedFile in nextPanelStates)) {
+			selectedFile = 'compose';
+		}
+	}
+
+	function applyProjectDetailsToEditor(details: Project, mode: ApplyProjectMode) {
+		project = details;
+		lastSeenProjectSignature = buildProjectSyncSignature(details);
+		syncIncludeFileUiState(details);
+
+		const nextName = details.name || '';
+		const nextComposeContent = details.composeContent || '';
+		const nextEnvContent = details.envContent || '';
+		const nextIncludeFiles = buildIncludeFilesMap(details);
+		const shouldSyncEditorState = mode === 'initialize' || mode === 'saved' || lastAppliedProjectId !== details.id || !hasChanges;
+
+		if (shouldSyncEditorState) {
+			originalName = nextName;
+			originalComposeContent = nextComposeContent;
+			originalEnvContent = nextEnvContent;
+			originalIncludeFiles = { ...nextIncludeFiles };
+			$inputs.name.value = nextName;
+			$inputs.composeContent.value = nextComposeContent;
+			$inputs.envContent.value = nextEnvContent;
+			includeFilesState = { ...nextIncludeFiles };
+		}
+
+		lastAppliedProjectId = details.id;
+	}
+
+	async function syncProjectQueries(updatedProject: Project) {
+		const currentEnvId = envId ?? (await environmentStore.getCurrentEnvironmentId());
+
+		queryClient.setQueryData(queryKeys.projects.detail(currentEnvId, updatedProject.id), updatedProject);
+		await Promise.all([
+			queryClient.invalidateQueries({ queryKey: ['projects', currentEnvId] }),
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.statusCounts(currentEnvId) })
+		]);
+	}
 
 	$effect(() => {
-		project = data.project;
+		const incomingProject = data.project;
+		if (!incomingProject) return;
+
+		const incomingProjectSignature = buildProjectSyncSignature(incomingProject);
+		const previousSignature = untrack(() => lastSeenProjectSignature);
+		if (incomingProjectSignature === previousSignature) return;
+
+		lastSeenProjectSignature = incomingProjectSignature;
+
+		const projectChanged = untrack(() => lastAppliedProjectId) !== incomingProject.id;
+		if (projectChanged || !hasChanges) {
+			applyProjectDetailsToEditor(incomingProject, projectChanged ? 'initialize' : 'refresh');
+			return;
+		}
+
+		project = incomingProject;
+		syncIncludeFileUiState(incomingProject);
 	});
 
 	$effect(() => {
 		if (!project?.id) return;
+		if (lastPrefsProjectId === project.id) return;
+
+		lastPrefsProjectId = project.id;
 		prefs = new PersistedState<ComposeUIPrefs>(`arcane.compose.ui:${project.id}`, defaultComposeUIPrefs, {
 			storage: 'session',
 			syncTabs: false
@@ -193,25 +307,6 @@
 		const hasIncludes = project?.includeFiles && project.includeFiles.length > 0;
 		const defaultMode = hasIncludes ? 'tree' : 'classic';
 		layoutMode = cur.layoutMode ?? defaultMode;
-
-		// Initialize include file states
-		if (project?.includeFiles) {
-			const newIncludeState: Record<string, string> = {};
-			project.includeFiles.forEach((file) => {
-				newIncludeState[file.relativePath] = file.content;
-				if (!(file.relativePath in includeFilesPanelStates)) {
-					includeFilesPanelStates[file.relativePath] = true;
-				}
-				if (!(file.relativePath in includeFilesHasErrors)) {
-					includeFilesHasErrors[file.relativePath] = false;
-				}
-				if (!(file.relativePath in includeFilesValidationReady)) {
-					includeFilesValidationReady[file.relativePath] = true;
-				}
-			});
-			includeFilesState = newIncludeState;
-			originalIncludeFiles = { ...newIncludeState };
-		}
 	});
 
 	async function handleSaveChanges() {
@@ -229,13 +324,13 @@
 		const namePayload = isGitOpsManaged ? undefined : name;
 		const composePayload = isGitOpsManaged ? undefined : composeContent;
 
-		// First update the main project files
 		handleApiResultWithCallbacks({
 			result: await tryCatch(projectService.updateProject(projectId, namePayload, composePayload, envContent)),
 			message: m.common_save_failed(),
 			setLoadingState: (value) => (isLoading.saving = value),
-			onSuccess: async (updatedStack: Project) => {
-				// Then update any changed include files
+			onSuccess: async (updatedProject: Project) => {
+				let savedProject = updatedProject;
+
 				for (const relativePath of Object.keys(includeFilesState)) {
 					if (includeFilesState[relativePath] !== originalIncludeFiles[relativePath]) {
 						const includeResult = await tryCatch(
@@ -245,16 +340,13 @@
 							toast.error(includeResult.error.message || m.common_update_failed({ resource: relativePath }));
 							return;
 						}
+						savedProject = includeResult.data;
 					}
 				}
 
+				applyProjectDetailsToEditor(savedProject, 'saved');
+				await syncProjectQueries(savedProject);
 				toast.success(m.common_update_success({ resource: m.project() }));
-				originalName = updatedStack.name;
-				originalComposeContent = $inputs.composeContent.value;
-				originalEnvContent = $inputs.envContent.value;
-				originalIncludeFiles = { ...includeFilesState };
-				await new Promise((resolve) => setTimeout(resolve, 200));
-				await invalidateAll();
 			}
 		});
 	}
@@ -300,7 +392,13 @@
 			result: await tryCatch(projectService.getProject(projectId)),
 			message: m.common_refresh_failed({ resource: m.project() }),
 			onSuccess: (updatedProject) => {
-				project = updatedProject;
+				if (hasChanges && lastAppliedProjectId === updatedProject.id) {
+					project = updatedProject;
+					syncIncludeFileUiState(updatedProject);
+					return;
+				}
+
+				applyProjectDetailsToEditor(updatedProject, 'refresh');
 			}
 		});
 	}
@@ -532,118 +630,8 @@
 
 					<div class="min-h-0 flex-1">
 						{#if layoutMode === 'tree'}
-							<div class="flex h-full min-h-0 flex-col gap-4 lg:hidden">
-								<Card.Root class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-									<Card.Header icon={FileTextIcon} class="shrink-0 items-center">
-										<Card.Title>
-											<h2>{m.project_files()}</h2>
-										</Card.Title>
-									</Card.Header>
-									<Card.Content class="min-h-0 flex-1 overflow-auto p-2">
-										<TreeView.Root class="min-w-max p-2 whitespace-nowrap">
-											<TreeView.File
-												name="compose.yaml"
-												onclick={() => (selectedFile = 'compose')}
-												class={selectedFile === 'compose' ? 'bg-accent' : ''}
-											>
-												{#snippet icon()}
-													<FileTextIcon class="size-4 text-blue-500" />
-												{/snippet}
-											</TreeView.File>
-
-											<TreeView.File
-												name=".env"
-												onclick={() => (selectedFile = 'env')}
-												class={selectedFile === 'env' ? 'bg-accent' : ''}
-											>
-												{#snippet icon()}
-													<FileTextIcon class="size-4 text-green-500" />
-												{/snippet}
-											</TreeView.File>
-
-											{#if project?.includeFiles && project.includeFiles.length > 0}
-												<TreeView.Folder name={m.project_includes()}>
-													{#each project.includeFiles as includeFile (includeFile.relativePath)}
-														<TreeView.File
-															name={includeFile.relativePath}
-															onclick={() => (selectedFile = includeFile.relativePath)}
-															class={selectedFile === includeFile.relativePath ? 'bg-accent' : ''}
-														>
-															{#snippet icon()}
-																<FileTextIcon class="size-4 text-amber-500" />
-															{/snippet}
-														</TreeView.File>
-													{/each}
-												</TreeView.Folder>
-											{/if}
-										</TreeView.Root>
-									</Card.Content>
-								</Card.Root>
-
-								<div class="flex min-h-0 flex-1 flex-col">
-									{#if selectedFile === 'compose'}
-										<CodePanel
-											bind:open={composeOpen}
-											title="compose.yaml"
-											language="yaml"
-											bind:value={$inputs.composeContent.value}
-											error={$inputs.composeContent.error ?? undefined}
-											readOnly={!canEditCompose}
-											bind:hasErrors={composeHasErrors}
-											bind:validationReady={composeValidationReady}
-											fileId={`project:${projectId}:compose`}
-											originalValue={originalComposeContent}
-											enableDiff={true}
-											editorContext={codeEditorContext}
-										/>
-									{:else if selectedFile === 'env'}
-										<CodePanel
-											bind:open={envOpen}
-											title=".env"
-											language="env"
-											bind:value={$inputs.envContent.value}
-											error={$inputs.envContent.error ?? undefined}
-											readOnly={!canEditEnv}
-											bind:hasErrors={envHasErrors}
-											bind:validationReady={envValidationReady}
-											fileId={`project:${projectId}:env`}
-											originalValue={originalEnvContent}
-											enableDiff={true}
-											editorContext={codeEditorContext}
-										/>
-									{:else}
-										{@const includeFile = project?.includeFiles?.find((f) => f.relativePath === selectedFile)}
-										{#if includeFile}
-											<CodePanel
-												bind:open={includeFilesPanelStates[includeFile.relativePath]}
-												title={includeFile.relativePath}
-												language="yaml"
-												bind:value={includeFilesState[includeFile.relativePath]}
-												bind:hasErrors={includeFilesHasErrors[includeFile.relativePath]}
-												bind:validationReady={includeFilesValidationReady[includeFile.relativePath]}
-												fileId={`project:${projectId}:include:${includeFile.relativePath}`}
-												originalValue={originalIncludeFiles[includeFile.relativePath]}
-												enableDiff={true}
-												editorContext={codeEditorContext}
-											/>
-										{/if}
-									{/if}
-								</div>
-							</div>
-
-							<ResizableSplit
-								class="hidden h-full min-h-0 lg:flex lg:gap-2"
-								firstClass="flex min-h-0 flex-col"
-								secondClass="flex min-h-0 flex-col"
-								bind:size={treePaneWidth}
-								minSize={minTreePaneWidth}
-								minSecondSize={minEditorPaneWidth}
-								defaultRatio={0.3}
-								ariaLabel="Resize project files panel"
-								persistKey={`arcane.compose.split:${project.id}:tree`}
-								onResizeEnd={persistPrefs}
-							>
-								{#snippet first()}
+							{#if isTablet.current}
+								<div class="flex h-full min-h-0 flex-col gap-4">
 									<Card.Root class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
 										<Card.Header icon={FileTextIcon} class="shrink-0 items-center">
 											<Card.Title>
@@ -690,10 +678,8 @@
 											</TreeView.Root>
 										</Card.Content>
 									</Card.Root>
-								{/snippet}
 
-								{#snippet second()}
-									<div class="flex h-full min-h-0 flex-1 flex-col">
+									<div class="flex min-h-0 flex-1 flex-col">
 										{#if selectedFile === 'compose'}
 											<CodePanel
 												bind:open={composeOpen}
@@ -742,8 +728,122 @@
 											{/if}
 										{/if}
 									</div>
-								{/snippet}
-							</ResizableSplit>
+								</div>
+							{:else}
+								<ResizableSplit
+									class="h-full min-h-0 lg:gap-2"
+									firstClass="flex min-h-0 flex-col"
+									secondClass="flex min-h-0 flex-col"
+									bind:size={treePaneWidth}
+									minSize={minTreePaneWidth}
+									minSecondSize={minEditorPaneWidth}
+									defaultRatio={0.3}
+									ariaLabel="Resize project files panel"
+									persistKey={`arcane.compose.split:${project.id}:tree`}
+									onResizeEnd={persistPrefs}
+								>
+									{#snippet first()}
+										<Card.Root class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+											<Card.Header icon={FileTextIcon} class="shrink-0 items-center">
+												<Card.Title>
+													<h2>{m.project_files()}</h2>
+												</Card.Title>
+											</Card.Header>
+											<Card.Content class="min-h-0 flex-1 overflow-auto p-2">
+												<TreeView.Root class="min-w-max p-2 whitespace-nowrap">
+													<TreeView.File
+														name="compose.yaml"
+														onclick={() => (selectedFile = 'compose')}
+														class={selectedFile === 'compose' ? 'bg-accent' : ''}
+													>
+														{#snippet icon()}
+															<FileTextIcon class="size-4 text-blue-500" />
+														{/snippet}
+													</TreeView.File>
+
+													<TreeView.File
+														name=".env"
+														onclick={() => (selectedFile = 'env')}
+														class={selectedFile === 'env' ? 'bg-accent' : ''}
+													>
+														{#snippet icon()}
+															<FileTextIcon class="size-4 text-green-500" />
+														{/snippet}
+													</TreeView.File>
+
+													{#if project?.includeFiles && project.includeFiles.length > 0}
+														<TreeView.Folder name={m.project_includes()}>
+															{#each project.includeFiles as includeFile (includeFile.relativePath)}
+																<TreeView.File
+																	name={includeFile.relativePath}
+																	onclick={() => (selectedFile = includeFile.relativePath)}
+																	class={selectedFile === includeFile.relativePath ? 'bg-accent' : ''}
+																>
+																	{#snippet icon()}
+																		<FileTextIcon class="size-4 text-amber-500" />
+																	{/snippet}
+																</TreeView.File>
+															{/each}
+														</TreeView.Folder>
+													{/if}
+												</TreeView.Root>
+											</Card.Content>
+										</Card.Root>
+									{/snippet}
+
+									{#snippet second()}
+										<div class="flex h-full min-h-0 flex-1 flex-col">
+											{#if selectedFile === 'compose'}
+												<CodePanel
+													bind:open={composeOpen}
+													title="compose.yaml"
+													language="yaml"
+													bind:value={$inputs.composeContent.value}
+													error={$inputs.composeContent.error ?? undefined}
+													readOnly={!canEditCompose}
+													bind:hasErrors={composeHasErrors}
+													bind:validationReady={composeValidationReady}
+													fileId={`project:${projectId}:compose`}
+													originalValue={originalComposeContent}
+													enableDiff={true}
+													editorContext={codeEditorContext}
+												/>
+											{:else if selectedFile === 'env'}
+												<CodePanel
+													bind:open={envOpen}
+													title=".env"
+													language="env"
+													bind:value={$inputs.envContent.value}
+													error={$inputs.envContent.error ?? undefined}
+													readOnly={!canEditEnv}
+													bind:hasErrors={envHasErrors}
+													bind:validationReady={envValidationReady}
+													fileId={`project:${projectId}:env`}
+													originalValue={originalEnvContent}
+													enableDiff={true}
+													editorContext={codeEditorContext}
+												/>
+											{:else}
+												{@const includeFile = project?.includeFiles?.find((f) => f.relativePath === selectedFile)}
+												{#if includeFile}
+													<CodePanel
+														bind:open={includeFilesPanelStates[includeFile.relativePath]}
+														title={includeFile.relativePath}
+														language="yaml"
+														bind:value={includeFilesState[includeFile.relativePath]}
+														bind:hasErrors={includeFilesHasErrors[includeFile.relativePath]}
+														bind:validationReady={includeFilesValidationReady[includeFile.relativePath]}
+														fileId={`project:${projectId}:include:${includeFile.relativePath}`}
+														originalValue={originalIncludeFiles[includeFile.relativePath]}
+														enableDiff={true}
+														editorContext={codeEditorContext}
+													/>
+												{/if}
+											{/if}
+										</div>
+									{/snippet}
+								</ResizableSplit>
+							{/if}
 						{:else}
 							<div class="flex h-full min-h-0 flex-col gap-4">
 								{#if project?.includeFiles && project.includeFiles.length > 0}
@@ -783,8 +883,8 @@
 											editorContext={codeEditorContext}
 										/>
 									{/if}
-								{:else}
-									<div class="flex min-h-0 flex-1 flex-col gap-4 lg:hidden">
+								{:else if isTablet.current}
+									<div class="flex min-h-0 flex-1 flex-col gap-4">
 										<CodePanel
 											bind:open={composeOpen}
 											title="compose.yaml"
@@ -814,9 +914,9 @@
 											editorContext={codeEditorContext}
 										/>
 									</div>
-
+								{:else}
 									<ResizableSplit
-										class="hidden min-h-0 flex-1 lg:flex lg:gap-2"
+										class="min-h-0 flex-1 lg:gap-2"
 										firstClass="flex min-h-0 flex-col"
 										secondClass="flex min-h-0 flex-col"
 										bind:size={composeSplitWidth}

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -48,9 +48,10 @@ async function createProjectViaUI(page: Page, projectName: string) {
 	const createButton = page
 		.getByRole('button', { name: 'Create Project' })
 		.locator('[data-slot="arcane-button"]');
+	await expect(createButton).toBeEnabled();
 	await createButton.click();
 
-	await page.waitForURL(/\/projects\/.+/, { timeout: 10000 });
+	await page.waitForURL(/\/projects\/(?!new$).+/, { timeout: 10000 });
 	await expect(page.getByRole('button', { name: projectName })).toBeVisible();
 
 	return new URL(page.url()).pathname.split('/').pop()!;


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2073

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the save button's inconsistent state after saving a project (issue #2073) by replacing the blunt `invalidateAll()` + `setTimeout` approach with targeted TanStack Query cache updates and a signature-based deduplication mechanism for incoming project data.

- Introduces `applyProjectDetailsToEditor` to centralize editor state synchronization, ensuring original values and form inputs stay consistent after save, refresh, or project navigation
- Adds `buildProjectSyncSignature` to compare incoming project data and skip redundant re-renders
- Replaces `invalidateAll()` in save flow with `syncProjectQueries`, which updates the query cache for the specific project and invalidates related list queries
- Swaps CSS-only responsive layout (`lg:hidden` / `hidden lg:flex`) for the `IsTablet` media query hook, making the mobile/desktop split programmatic
- Test improvements: waits for Create Project button to be enabled before clicking, and tightens URL regex to reject `/projects/new` as a false-positive redirect match
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge — the state management refactor is well-structured, and the targeted query invalidation is a clear improvement over `invalidateAll()`.
- The changes are logically sound and address a real UX bug. The new signature-based dedup and centralized state sync are correct, with proper handling of edge cases (project switching, hasChanges guard, include file updates). The only minor concern is the double-execution of the `$effect` due to reading and writing the same `$state`, which is harmless but slightly wasteful. Test changes improve reliability.
- Pay close attention to `frontend/src/routes/(app)/projects/[projectId]/+page.svelte` — the `$effect` blocks have subtle re-trigger behavior from reading and writing the same `$state` variables.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/routes/(app)/projects/[projectId]/+page.svelte | Major refactor of project editor state management: replaces `invalidateAll()` with targeted query cache updates, introduces signature-based dedup for incoming project data, extracts `applyProjectDetailsToEditor` for consistent state synchronization, and switches from CSS-based responsive layout to the `IsTablet` media query hook. |
| tests/spec/project.spec.ts | Two small reliability improvements: waits for the Create Project button to be enabled before clicking, and tightens the URL regex to exclude `/projects/new` from matching as a successful project creation redirect. |

</details>

</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fprojects%2F%5BprojectId%5D%2F%2Bpage.svelte%3A270-287%0A**Effect%20reads%20and%20writes%20same%20%60%24state%60**%0A%0AThis%20%60%24effect%60%20reads%20%60lastSeenProjectSignature%60%20on%20line%20275%20and%20writes%20to%20it%20on%20line%20277%20%28and%20again%20indirectly%20via%20%60applyProjectDetailsToEditor%60%20on%20line%20281%29.%20Since%20Svelte%205%20tracks%20%60lastSeenProjectSignature%60%20as%20a%20dependency%2C%20the%20effect%20will%20re-trigger%20after%20it%20runs%2C%20executing%20a%20second%20time%20before%20hitting%20the%20early-return%20guard.%20The%20same%20applies%20to%20%60lastAppliedProjectId%60%20%28read%20on%20line%20279%2C%20written%20inside%20%60applyProjectDetailsToEditor%60%29.%20%0A%0AThis%20double-execution%20is%20harmless%20%E2%80%94%20the%20second%20run%20exits%20immediately%20%E2%80%94%20but%20it's%20worth%20being%20aware%20of.%20If%20this%20becomes%20a%20performance%20concern%20%28e.g.%2C%20%60buildProjectSyncSignature%60%20is%20called%20twice%20per%20incoming%20change%29%2C%20you%20could%20wrap%20the%20reads%20in%20%60untrack%28%29%60%3A%0A%0A%60%60%60%0Aconst%20incomingProjectSignature%20%3D%20buildProjectSyncSignature%28incomingProject%29%3B%0Aif%20%28incomingProjectSignature%20%3D%3D%3D%20untrack%28%28%29%20%3D%3E%20lastSeenProjectSignature%29%29%20return%3B%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20Avoid%20updating%20%60%24state%60%20inside%20%60%24effect%60%20blo...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D8e0bee41-b073-4a49-a01c-2c2c8782b420%29%29%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/routes/(app)/projects/[projectId]/+page.svelte
Line: 270-287

Comment:
**Effect reads and writes same `$state`**

This `$effect` reads `lastSeenProjectSignature` on line 275 and writes to it on line 277 (and again indirectly via `applyProjectDetailsToEditor` on line 281). Since Svelte 5 tracks `lastSeenProjectSignature` as a dependency, the effect will re-trigger after it runs, executing a second time before hitting the early-return guard. The same applies to `lastAppliedProjectId` (read on line 279, written inside `applyProjectDetailsToEditor`). 

This double-execution is harmless — the second run exits immediately — but it's worth being aware of. If this becomes a performance concern (e.g., `buildProjectSyncSignature` is called twice per incoming change), you could wrap the reads in `untrack()`:

```
const incomingProjectSignature = buildProjectSyncSignature(incomingProject);
if (incomingProjectSignature === untrack(() => lastSeenProjectSignature)) return;
```

**Rule Used:** What: Avoid updating `$state` inside `$effect` blo... ([source](https://app.greptile.com/review/custom-context?memory=8e0bee41-b073-4a49-a01c-2c2c8782b420))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 34305ae</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->