### PR TITLE
feat: show document title for Project detail pages

### DIFF
--- a/frontend/src/routes/(app)/projects/+layout.svelte
+++ b/frontend/src/routes/(app)/projects/+layout.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { m } from '$lib/paraglide/messages';
+
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children: Snippet } = $props();
+
+	const pageTitle = $derived(`${m.layout_title()} | ${m.projects_title()}`);
+</script>
+
+<svelte:head><title>{pageTitle}</title></svelte:head>
+
+{@render children()}

--- a/frontend/src/routes/(app)/projects/[projectId]/+layout.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+layout.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { m } from '$lib/paraglide/messages';
+
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children: Snippet } = $props();
+
+	const projectName = $derived(page.data.project.name);
+	const pageTitle = $derived(`${m.layout_title()} | ${m.projects_title()} | ${projectName}`);
+</script>
+
+<svelte:head><title>{pageTitle}</title></svelte:head>
+
+{@render children()}

--- a/frontend/src/routes/(app)/projects/new/+layout.svelte
+++ b/frontend/src/routes/(app)/projects/new/+layout.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { m } from '$lib/paraglide/messages';
+
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children: Snippet } = $props();
+
+	const projectName = $derived(m.compose_project_name_placeholder());
+	const pageTitle = $derived(`${m.layout_title()} | ${m.projects_title()} | ${projectName}`);
+</script>
+
+<svelte:head><title>{pageTitle}</title></svelte:head>
+
+{@render children()}

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -251,6 +251,10 @@ test.describe('New Compose Project Page', () => {
 		await page.getByRole('textbox', { name: 'My New Project' }).press('Enter');
 	});
 
+	test('should have a head title', async ({ page }) => {
+		await expect(page).toHaveTitle('Arcane | Projects | My New Project');
+	});
+
 	test('should enable Create Project after entering a valid name', async ({ page }) => {
 		const observedErrors: string[] = [];
 		page.on('pageerror', (err) => observedErrors.push(String(err?.message ?? err)));


### PR DESCRIPTION
## Checklist

- [X] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

Show document.head title of Project detail pages

Fixes: #2090

## Changes Made

- Add a +layout.svelte under /(app)/projects/
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [X] Development environment started: `./scripts/development/dev.sh start`
- [X] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [X] Manual testing completed (describe):
- [X] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

no

## Additional Context

See #2090

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a new `+layout.svelte` at the `(app)/projects/` level to set a dynamic `<svelte:head><title>` for project pages, and adds a Playwright test asserting the title on the new-project page.

- **Layout placement** — placing the layout at `(app)/projects/` causes it to wrap `/projects` (list), `/projects/new`, and `/projects/[projectId]` alike. On the list page `page.data.project` is always `undefined`, so the title permanently reads `"Arcane | Projects | My New Project"` (the placeholder), which is misleading.
- **`||` vs `??`** — `page.data?.project?.name || m.compose_project_name_placeholder()` treats an empty-string project name as falsy and falls back to the placeholder; `??` would be the correct operator here.
- **Test scope** — the new test (`'should have a head title'`) lives in the `New Compose Project Page` describe block, which is always on `/projects/new` where `page.data.project` is `undefined`. The test will pass because it asserts the placeholder value, but it does not verify that the detail page (`/projects/[projectId]`) shows the actual project name — the stated goal of the PR.
- The `$derived` reactive declarations and `{@render children()}` usage are idiomatic Svelte 5 patterns.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- The PR achieves its goal on the detail page but introduces an unintended side-effect on the projects list page and lacks a meaningful title test for the detail page.
- The layout scope is broader than intended — `/projects` (list page) will permanently display the placeholder "My New Project" in the document title. The `||` operator also silently swallows empty-string project names. The new test passes but only validates the fallback path, leaving the detail-page title (the PR's stated goal) without coverage. These issues lower the confidence from an otherwise straightforward change.
- frontend/src/routes/(app)/projects/+layout.svelte — layout placement and `||` operator need attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/routes/(app)/projects/+layout.svelte | Adds a shared layout that derives a `<title>` from `page.data.project.name` with a placeholder fallback; because it is placed at the `(app)/projects/` level it applies to all three sub-routes (`/projects`, `/projects/new`, `/projects/[projectId]`), producing a misleading "My New Project" title on the projects list page, and uses `||` instead of `??` so an empty-string project name silently falls back to the placeholder. |
| tests/spec/project.spec.ts | Adds a title assertion test inside the "New Compose Project Page" describe block; the test correctly matches the placeholder fallback ("My New Project") and will pass, but it only validates the fallback behavior on `/projects/new` rather than an actual project name on the detail page, leaving the PR's primary goal untested. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Browser navigates to /projects/*] --> B{Which route?}
    B -->|/projects| C[page.data = projects, counts]
    B -->|/projects/new| D[page.data = templates, envTemplate]
    B -->|/projects/projectId| E[page.data = project, editorState]

    C --> F{page.data?.project?.name}
    D --> F
    E --> F

    F -->|undefined| G[Fallback: 'My New Project']
    F -->|empty string via OR| G
    F -->|real name| H[Use project.name]

    G --> I["Title: 'Arcane | Projects | My New Project'"]
    H --> J["Title: 'Arcane | Projects | actual-name'"]

    I -->|⚠️ misleading on /projects list| K[svelte:head title set]
    I -->|✓ correct on /projects/new| K
    J -->|✓ correct on detail page| K
```
</details>

<sub>Last reviewed commit: b495010</sub>

**Context used:**

- Rule used - What: Avoid updating `$state` inside `$effect` blo... ([source](https://app.greptile.com/review/custom-context?memory=8e0bee41-b073-4a49-a01c-2c2c8782b420))

<!-- /greptile_comment -->