### PR TITLE
feat: collapse containers ports

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -497,6 +497,8 @@
 	"containers_env_vars_description": "Runtime environment variables for your container",
 	"containers_no_env_vars": "No environment variables",
 	"containers_no_ports": "No ports",
+	"containers_show_fewer_ports": "Show fewer ports",
+	"containers_show_more_ports": "Show {count} more ports",
 	"containers_no_labels_defined": "No labels defined",
 	"containers_labels_description": "Enter metadata labels as key=value pairs, one per line",
 	"containers_networks_title": "Networks",

--- a/frontend/src/lib/components/badges/port-badge.svelte
+++ b/frontend/src/lib/components/badges/port-badge.svelte
@@ -131,7 +131,6 @@
 				<ArcaneTooltip.Trigger>
 					<button
 						onclick={() => (expanded = !expanded)}
-						aria-label={expanded ? 'Show fewer ports' : `Show ${hiddenCount} more ports`}
 						class="bg-muted hover:bg-muted/80 text-muted-foreground inline-flex items-center rounded-lg border px-2 py-1 text-[11px] font-medium shadow-sm transition-colors cursor-pointer"
 					>
 						{expanded ? '−' : `+${hiddenCount}`}
@@ -139,7 +138,7 @@
 				</ArcaneTooltip.Trigger>
 				<ArcaneTooltip.Content>
 					<p class="text-xs">
-						{expanded ? 'Show fewer ports' : `Show ${hiddenCount} more ports`}
+						{expanded ? m.containers_show_fewer_ports() : m.containers_show_more_ports({ count: hiddenCount })}
 					</p>
 				</ArcaneTooltip.Content>
 			</ArcaneTooltip.Root>


### PR DESCRIPTION
## Checklist

  - [x] This PR is **not** opened from my fork's `main` branch

  ## What This PR Implements

  <!-- Overview of this change -->

  When a container has many ports (e.g., 3+), the Ports column in the containers table becomes visually large and breaks row alignment. This PR makes the port list collapsible, showing at most 3 ports by
  default with a `+N` badge to expand the rest.

  <!-- All PRs should reference an existing issue. Use "Fixes #1234" or "Addresses #1234". -->
  Addresses #2048 
  <!-- For minor documentation fixes, explain why the change is needed. -->

  Fixes:

  ## Changes Made

  <!-- List specific changes with brief explanations -->

  - Added optional `collapsible` (default `true`) and `maxVisible` (default `2`) props to `PortBadge` component for controlling truncation behavior
  - Added `expanded` local state with a derived `visiblePorts` list that slices to `maxVisible` when collapsed
  - Added a `+N` / `−` toggle button styled consistently with existing port badges to expand/collapse the full port list
  - Fully backwards-compatible — all existing usages work without changes

  ## Testing Done

  <!-- Check all that apply and describe what you tested -->

  - [x] Development environment started: `./scripts/development/dev.sh start`
  - [x] Frontend verified at http://localhost:3000
  - [x] Backend verified at http://localhost:3552
  - [x] Manual testing completed (describe): Tested with multiple ports and with one port.
  - [x] No linting errors (e.g., `just lint all`)
  - [x] Backend tests pass: `just test backend`

  ## AI Tool Used (if applicable)

  <!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

  AI Tool: Claude
  Assistance Level: Minor
  What AI helped with: Implementation and tests of the collapsible ports feature in `port-badge.svelte`
  I reviewed and edited all AI-generated output: Yes
  I ran all required tests and manually verified changes: Yes

  ## Additional Context

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a collapsible port list to the `PortBadge` component, addressing visual clutter in the containers table when a container exposes many ports. The core logic is sound — ports are sliced via a `$derived` expression and a toggle button switches between the collapsed and expanded views — and the change is fully backwards-compatible with all existing usages.

Key observations:

- The default `maxVisible = 2` means a container with just **3 ports** will already show a `+1` button, which may feel overly aggressive. The PR description itself mentions "at most **3** ports by default," suggesting `maxVisible = 3` was the original intent.
- The toggle button (`+N` / `−`) has no `aria-label`, making it opaque to assistive technologies.
- The `expanded` local state is never reset when the `ports` prop changes reactively, so after a live data refresh the component can remain unexpectedly expanded.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with minor accessibility and UX polish remaining.
- The implementation is logically correct, backwards-compatible, and uses idiomatic Svelte 5 patterns (`$derived` for computed values, `$state` for user-toggled state). No runtime errors or breaking changes are introduced. The deductions are for: a missing `aria-label` on the toggle button, the `expanded` state not resetting on reactive port updates, and the `maxVisible` default (2) being inconsistent with the PR description (3), which may produce a mildly surprising UX for containers with exactly 3 ports.
- frontend/src/lib/components/badges/port-badge.svelte — review the `maxVisible` default, add `aria-label` to the toggle button, and consider whether `expanded` should reset on port changes.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/lib/components/badges/port-badge.svelte | Adds collapsible port list with `collapsible` and `maxVisible` props; logic is correct and backwards-compatible, but the toggle button lacks an `aria-label`, the `expanded` state doesn't reset on port changes, and the default `maxVisible = 2` contradicts the PR description's "at most 3 ports". |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ports prop received] --> B[uniquePorts: normalize & deduplicate]
    B --> C[allPorts: sorted, published first]
    C --> D{collapsible && !expanded && allPorts.length > maxVisible?}
    D -- Yes --> E[visiblePorts = allPorts.slice 0 to maxVisible]
    D -- No --> F[visiblePorts = allPorts]
    E --> G[published = visiblePorts.filter isPublished]
    F --> G
    E --> H[exposedOnly = visiblePorts.filter !isPublished]
    F --> H
    E --> I[hiddenCount = allPorts.length - maxVisible]
    F --> J[hiddenCount = 0]
    G --> K[Render published port badges as links]
    H --> L[Render exposed-only port badges]
    I --> M{collapsible && allPorts.length > maxVisible?}
    J --> M
    M -- Yes, expanded=false --> N[Show +N button]
    M -- Yes, expanded=true --> O[Show − button]
    M -- No --> P[No toggle button]
    N -->|click| Q[expanded = true]
    O -->|click| R[expanded = false]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/lib/components/badges/port-badge.svelte
Line: 130-135

Comment:
**Missing accessible label on toggle button**

The toggle button only contains `+N` or `−` as its text content. Screen readers will read this literally, which gives no context about what the button does. Adding an `aria-label` that describes the action would make this accessible.

```suggestion
		<button
			onclick={() => (expanded = !expanded)}
			aria-label={expanded ? 'Show fewer ports' : `Show ${hiddenCount} more ports`}
			class="bg-muted hover:bg-muted/80 text-muted-foreground inline-flex items-center rounded-lg border px-2 py-1 text-[11px] font-medium shadow-sm transition-colors cursor-pointer"
		>
			{expanded ? '−' : `+${hiddenCount}`}
		</button>
```

**Rule Used:** JavaScript/TypeScript Best Practices

Use const/le... ([source](https://app.greptile.com/review/custom-context?memory=68c6ab5b-40de-4e3c-a803-95d60efb41a6))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: frontend/src/lib/components/badges/port-badge.svelte
Line: 129-136

Comment:
**Toggle button renders when only 1 extra port is hidden**

With the default `maxVisible = 2`, a container with exactly 3 ports will show 2 port badges + a `+1` button. The user has to click to reveal a single additional port, which may feel like unnecessary friction. Consider using `maxVisible = 3` (as mentioned in the PR description: "showing at most 3 ports by default") so the button only appears when 2 or more ports would be hidden, reducing noise for the common case.

```suggestion
	let {
		ports = [] as ContainerPorts[],
		collapsible = true,
		maxVisible = 3
	} = $props<{
		ports?: ContainerPorts[];
		collapsible?: boolean;
		maxVisible?: number;
	}>();
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: frontend/src/lib/components/badges/port-badge.svelte
Line: 18

Comment:
**`expanded` state not reset on port changes**

`expanded` is local `$state` and will never be reset when the `ports` prop changes reactively (e.g., when the container list refreshes in the background). If a user expands the port list and then the underlying ports update to a set that still has more than `maxVisible` entries, the component will remain in the expanded state unexpectedly.

The cleanest fix without violating the no-`$state`-in-`$effect` rule is to key the component at the call site on a stable identifier derived from the ports, forcing a re-mount when the port list changes. For example in the parent template:

```svelte
<PortBadge {ports} />
<!-- add a Svelte keyed block in the parent wrapping this component -->
{#key container.id}
  <PortBadge {ports} />
{/key}
```

This ensures the component always starts in the collapsed state for any new port set.

**Rule Used:** What: Avoid updating `$state` inside `$effect` blo... ([source](https://app.greptile.com/review/custom-context?memory=8e0bee41-b073-4a49-a01c-2c2c8782b420))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 6cbc2a8</sub>

> Greptile also left **3 inline comments** on this PR.

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Rule used - What: Avoid updating `$state` inside `$effect` blo... ([source](https://app.greptile.com/review/custom-context?memory=8e0bee41-b073-4a49-a01c-2c2c8782b420))
- Rule used - JavaScript/TypeScript Best Practices

Use const/le... ([source](https://app.greptile.com/review/custom-context?memory=68c6ab5b-40de-4e3c-a803-95d60efb41a6))

<!-- /greptile_comment -->