### PR TITLE
fix: global env not be resolved on project edits

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/compose-spec/compose-go/v2/dotenv"
 	"github.com/compose-spec/compose-go/v2/loader"
 	composetypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/compose/v5/pkg/api"
@@ -1874,7 +1875,7 @@ func (s *ProjectService) ApplyGitSyncProjectFiles(ctx context.Context, projectID
 		return nil, fmt.Errorf("failed to resolve git env state: %w", err)
 	}
 
-	if err := s.validateComposeContentForUpdate(ctx, proj.Path, proj.Name, composeContent, envUpdate.effectiveContent); err != nil {
+	if err := s.validateComposeContentForUpdate(ctx, projectsDirectory, proj.Path, proj.Name, composeContent, envUpdate.effectiveContent); err != nil {
 		return nil, fmt.Errorf("invalid compose file: %w", err)
 	}
 
@@ -1952,7 +1953,7 @@ func (s *ProjectService) persistUpdatedProjectFiles(ctx context.Context, proj *m
 		if err != nil {
 			return fmt.Errorf("invalid compose file: %w", err)
 		}
-		if err := s.validateComposeContentForUpdate(ctx, proj.Path, proj.Name, *composeContent, effectiveEnvContent); err != nil {
+		if err := s.validateComposeContentForUpdate(ctx, projectsDirectory, proj.Path, proj.Name, *composeContent, effectiveEnvContent); err != nil {
 			return fmt.Errorf("invalid compose file: %w", err)
 		}
 		if err := projects.WriteComposeFile(projectsDirectory, proj.Path, *composeContent); err != nil {
@@ -1974,35 +1975,16 @@ func (s *ProjectService) persistUpdatedProjectFiles(ctx context.Context, proj *m
 	return nil
 }
 
-func (s *ProjectService) validateComposeContentForUpdate(ctx context.Context, projectPath, projectName, composeContent string, effectiveEnvContent *string) (err error) {
+func (s *ProjectService) validateComposeContentForUpdate(ctx context.Context, projectsDirectory, projectPath, projectName, composeContent string, effectiveEnvContent *string) (err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			err = fmt.Errorf("compose file contains invalid syntax: %v", recovered)
 		}
 	}()
 
-	// Load safe environment variables for ${VAR} interpolation during validation.
-	// Only the project's own .env is used — host process env and .env.global are
-	// both intentionally excluded to prevent leaking Arcane secrets.
-	fullEnvMap := make(projects.EnvMap)
-	if absWorkdir, absErr := filepath.Abs(projectPath); absErr == nil {
-		fullEnvMap["PWD"] = absWorkdir
-	}
-
-	// Prefer the provided effective environment content if available, otherwise read from disk.
-	if effectiveEnvContent != nil {
-		if fileEnv, envErr := projects.ParseProjectEnvContent(*effectiveEnvContent, fullEnvMap); envErr != nil {
-			return fmt.Errorf("parse provided env content: %w", envErr)
-		} else {
-			maps.Copy(fullEnvMap, fileEnv)
-		}
-	} else {
-		projectEnvPath := filepath.Join(projectPath, ".env")
-		if fileEnv, envErr := projects.ParseProjectEnvFile(projectEnvPath, fullEnvMap); envErr != nil {
-			return fmt.Errorf("parse project env file: %w", envErr)
-		} else {
-			maps.Copy(fullEnvMap, fileEnv)
-		}
+	fullEnvMap, envErr := buildComposeValidationEnvironment(projectsDirectory, projectPath, effectiveEnvContent)
+	if envErr != nil {
+		return envErr
 	}
 
 	validationProjectName := normalizeComposeProjectName(projectName)
@@ -2025,6 +2007,72 @@ func (s *ProjectService) validateComposeContentForUpdate(ctx context.Context, pr
 	})
 
 	return err
+}
+
+func buildComposeValidationEnvironment(projectsDirectory, projectPath string, effectiveEnvContent *string) (projects.EnvMap, error) {
+	// Validation should match project-visible env sources without inheriting the
+	// Arcane process environment, which may contain unrelated secrets.
+	fullEnvMap := make(projects.EnvMap)
+	if absWorkdir, absErr := filepath.Abs(projectPath); absErr == nil {
+		fullEnvMap["PWD"] = absWorkdir
+	} else {
+		fullEnvMap["PWD"] = projectPath
+	}
+
+	globalEnvPath := filepath.Join(projectsDirectory, projects.GlobalEnvFileName)
+	globalEnv, err := parseComposeValidationEnvFile(globalEnvPath, fullEnvMap)
+	if err != nil {
+		return nil, fmt.Errorf("parse global env file: %w", err)
+	}
+	maps.Copy(fullEnvMap, globalEnv)
+
+	if effectiveEnvContent != nil {
+		projectEnv, err := parseComposeValidationEnvContent(*effectiveEnvContent, fullEnvMap)
+		if err != nil {
+			return nil, fmt.Errorf("parse provided env content: %w", err)
+		}
+		maps.Copy(fullEnvMap, projectEnv)
+		return fullEnvMap, nil
+	}
+
+	projectEnvPath := filepath.Join(projectPath, ".env")
+	projectEnv, err := parseComposeValidationEnvFile(projectEnvPath, fullEnvMap)
+	if err != nil {
+		return nil, fmt.Errorf("parse project env file: %w", err)
+	}
+	maps.Copy(fullEnvMap, projectEnv)
+
+	return fullEnvMap, nil
+}
+
+func parseComposeValidationEnvFile(path string, contextEnv projects.EnvMap) (projects.EnvMap, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat file: %w", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+
+	return parseComposeValidationEnvContent(string(content), contextEnv)
+}
+
+func parseComposeValidationEnvContent(content string, contextEnv projects.EnvMap) (projects.EnvMap, error) {
+	lookupFn := func(key string) (string, bool) {
+		value, ok := contextEnv[key]
+		return value, ok
+	}
+
+	envMap, err := dotenv.ParseWithLookup(strings.NewReader(content), lookupFn)
+	if err != nil {
+		return nil, fmt.Errorf("parse env: %w", err)
+	}
+
+	return projects.EnvMap(envMap), nil
 }
 
 func withTransientValidationEnvFile(projectPath string, effectiveEnvContent *string, run func() error) (err error) {

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -716,6 +716,97 @@ func TestProjectService_UpdateProject_ReturnsEnvParseErrorDuringComposeValidatio
 	assert.Contains(t, err.Error(), "parse env")
 }
 
+func TestProjectService_UpdateProject_UsesGlobalEnvDuringComposeValidation(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil)
+
+	dirName := "global-env-update"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, projects.GlobalEnvFileName), []byte("DATA_NAS_FOLDER=/srv/media\nMYPATH=/containers/\n"), 0o600))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-global-env-update"},
+		Name:      dirName,
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	compose := `services:
+  cats:
+    image: mikesir87/cats:1.0
+    volumes:
+      - ${DATA_NAS_FOLDER}:/data
+      - ${MYPATH}cats/templates:/app/templates
+`
+
+	updated, err := svc.UpdateProject(ctx, project.ID, nil, new(compose), nil, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	composeBytes, readErr := os.ReadFile(filepath.Join(projectPath, "compose.yaml"))
+	require.NoError(t, readErr)
+	assert.Equal(t, compose, string(composeBytes))
+}
+
+func TestProjectService_UpdateProject_DoesNotResolveHostEnvThroughGlobalEnvDuringComposeValidation(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+	t.Setenv("HOST_ONLY_PATH", "/host/secret")
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil)
+
+	dirName := "host-env-guard"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, projects.GlobalEnvFileName), []byte("DATA_NAS_FOLDER=${HOST_ONLY_PATH}\n"), 0o600))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-host-env-guard"},
+		Name:      dirName,
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	compose := `services:
+  app:
+    image: nginx:alpine
+    volumes:
+      - ${DATA_NAS_FOLDER}:/data
+`
+
+	updated, err := svc.UpdateProject(ctx, project.ID, nil, new(compose), nil, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.Error(t, err)
+	assert.Nil(t, updated)
+	assert.Contains(t, err.Error(), "invalid compose file")
+}
+
 func TestProjectService_UpdateProject_DerivesProjectOverrideEnvWhenGitSourceExists(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()
@@ -1005,6 +1096,53 @@ func TestProjectService_ApplyGitSyncProjectFiles_RemovesGitEnvSource(t *testing.
 	effectiveBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
 	require.NoError(t, readErr)
 	assert.Equal(t, "BASE=git\n", string(effectiveBytes))
+}
+
+func TestProjectService_ApplyGitSyncProjectFiles_UsesGlobalEnvDuringComposeValidation(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil)
+
+	dirName := "git-sync-global-env"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, projects.GlobalEnvFileName), []byte("DATA_NAS_FOLDER=/srv/media\nMYPATH=/containers/\n"), 0o600))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-git-sync-global-env"},
+		Name:      dirName,
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	compose := `services:
+  cats:
+    image: mikesir87/cats:1.0
+    volumes:
+      - ${DATA_NAS_FOLDER}:/data
+      - ${MYPATH}cats/templates:/app/templates
+`
+
+	updated, err := svc.ApplyGitSyncProjectFiles(ctx, project.ID, compose, nil, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	composeBytes, readErr := os.ReadFile(filepath.Join(projectPath, "compose.yaml"))
+	require.NoError(t, readErr)
+	assert.Equal(t, compose, string(composeBytes))
 }
 
 func TestProjectService_PersistGitSyncEnvFiles_UsesPreparedState(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2071

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the global environment file (`.env.global`) was not consulted when validating compose content during project edits or git-sync applies, causing validation to fail for projects that relied on variables defined globally.

Key changes:
- `validateComposeContentForUpdate` now accepts `projectsDirectory` so it can locate `.env.global`.
- A new `buildComposeValidationEnvironment` helper assembles the env map in the correct precedence order: `PWD` → global env → project env, mirroring what `EnvLoader.LoadEnvironment` does at runtime.
- Two private parsing helpers (`parseComposeValidationEnvFile`, `parseComposeValidationEnvContent`) intentionally restrict variable expansion to the already-loaded context env, preventing host process secrets from leaking through global env interpolation — a sound security boundary.
- Four new integration tests cover the global-env resolution path, the host-env isolation guarantee, and the git-sync variant.
- Style: the three new unexported functions should carry the `Internal` suffix per the project convention, and the deliberate divergence from `projects.ParseProjectEnv*` helpers (no `os.LookupEnv` fallback) should be documented with a comment to guard against future regressions.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with only minor style issues; the logic is correct and well-tested.
- The core fix is sound: global env is now included in compose validation, and the host-env isolation is correctly enforced by a restricted lookup function. Four new tests cover both the happy path and the security boundary. The only issues are style-level: missing "Internal" suffix on new unexported functions and an undocumented intentional divergence from shared helpers — neither blocks correctness.
- No files require special attention beyond the style notes on `project_service.go`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/internal/services/project_service.go | Introduces `buildComposeValidationEnvironment` and two private helpers to include the global `.env.global` file when validating compose content during project edits; correctly isolates the lookup from the host process environment, with two style issues: missing "Internal" suffix on unexported functions and undocumented intentional divergence from shared parse helpers. |
| backend/internal/services/project_service_test.go | Adds four well-structured integration tests covering the happy path (global env resolves compose vars), the security boundary (host env vars are not resolved through global env), and the git-sync path; tests are table-free but appropriately scoped and follow existing project test patterns. |

</details>

</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A2009-2011%0A**Naming%20convention%3A%20unexported%20functions%20missing%20%22Internal%22%20suffix**%0A%0AThe%20three%20new%20unexported%20functions%20%E2%80%94%20%60buildComposeValidationEnvironment%60%2C%20%60parseComposeValidationEnvFile%60%2C%20and%20%60parseComposeValidationEnvContent%60%20%E2%80%94%20do%20not%20follow%20the%20project's%20naming%20convention%20that%20requires%20all%20unexported%20functions%20to%20carry%20the%20%60Internal%60%20suffix.%20Existing%20helpers%20in%20this%20file%20already%20follow%20the%20pattern%20%28e.g.%2C%20%60persistGitSyncEnvFilesInternal%60%2C%20%60persistEffectiveEnvContentInternal%60%2C%20%60ensureEffectiveEnvFileInternal%60%29.%0A%0AAll%20three%20should%20be%20renamed%3A%0A%0A%60%60%60suggestion%0Afunc%20buildComposeValidationEnvironmentInternal%28projectsDirectory%2C%20projectPath%20string%2C%20effectiveEnvContent%20*string%29%20%28projects.EnvMap%2C%20error%29%20%7B%0A%60%60%60%0A%0ASimilarly%2C%20%60parseComposeValidationEnvFile%60%20%E2%86%92%20%60parseComposeValidationEnvFileInternal%60%20and%20%60parseComposeValidationEnvContent%60%20%E2%86%92%20%60parseComposeValidationEnvContentInternal%60%2C%20along%20with%20their%20call-sites%20inside%20%60buildComposeValidationEnvironmentInternal%60.%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A2057-2080%0A**Duplicated%20env-parsing%20logic%20diverges%20silently%20from%20the%20shared%20%60projects%60%20package%20helpers**%0A%0A%60parseComposeValidationEnvFile%60%20and%20%60parseComposeValidationEnvContent%60%20re-implement%20what%20%60projects.ParseProjectEnvFile%60%20%2F%20%60projects.ParseProjectEnvContent%60%20already%20do%2C%20but%20with%20one%20deliberate%20difference%3A%20the%20lookup%20function%20in%20the%20new%20helpers%20only%20consults%20%60contextEnv%60%2C%20while%20the%20shared%20helpers%20fall%20back%20to%20%60os.LookupEnv%60.%20This%20security%20distinction%20is%20intentional%20%28and%20correct%29%2C%20but%20it%20is%20silent%20%E2%80%94%20there%20are%20no%20code%20comments%20explaining%20why%20new%20helpers%20were%20introduced%20rather%20than%20reusing%20the%20shared%20ones.%0A%0AConsider%20adding%20a%20comment%20to%20both%20new%20functions%20explaining%20why%20they%20intentionally%20do%20not%20fall%20back%20to%20the%20host%20process%20environment.%20This%20prevents%20a%20future%20contributor%20from%20%22simplifying%22%20them%20back%20to%20the%20shared%20helpers%20and%20re-introducing%20the%20host-env%20leakage%20bug.%0A%0A%60%60%60go%0A%2F%2F%20parseComposeValidationEnvContent%20parses%20env%20content%20with%20variable%20expansion%0A%2F%2F%20using%20ONLY%20the%20provided%20contextEnv%20%E2%80%94%20it%20deliberately%20does%20NOT%20fall%20back%20to%0A%2F%2F%20os.LookupEnv%20so%20that%20host%20process%20secrets%20cannot%20be%20resolved%20during%20validation.%0Afunc%20parseComposeValidationEnvContent%28content%20string%2C%20contextEnv%20projects.EnvMap%29%20%28projects.EnvMap%2C%20error%29%20%7B%0A%60%60%60%0A%0A**Rule%20Used%3A**%20%23%20Go%20Development%20Patterns%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/project_service.go
Line: 2009-2011

Comment:
**Naming convention: unexported functions missing "Internal" suffix**

The three new unexported functions — `buildComposeValidationEnvironment`, `parseComposeValidationEnvFile`, and `parseComposeValidationEnvContent` — do not follow the project's naming convention that requires all unexported functions to carry the `Internal` suffix. Existing helpers in this file already follow the pattern (e.g., `persistGitSyncEnvFilesInternal`, `persistEffectiveEnvContentInternal`, `ensureEffectiveEnvFileInternal`).

All three should be renamed:

```suggestion
func buildComposeValidationEnvironmentInternal(projectsDirectory, projectPath string, effectiveEnvContent *string) (projects.EnvMap, error) {
```

Similarly, `parseComposeValidationEnvFile` → `parseComposeValidationEnvFileInternal` and `parseComposeValidationEnvContent` → `parseComposeValidationEnvContentInternal`, along with their call-sites inside `buildComposeValidationEnvironmentInternal`.

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/services/project_service.go
Line: 2057-2080

Comment:
**Duplicated env-parsing logic diverges silently from the shared `projects` package helpers**

`parseComposeValidationEnvFile` and `parseComposeValidationEnvContent` re-implement what `projects.ParseProjectEnvFile` / `projects.ParseProjectEnvContent` already do, but with one deliberate difference: the lookup function in the new helpers only consults `contextEnv`, while the shared helpers fall back to `os.LookupEnv`. This security distinction is intentional (and correct), but it is silent — there are no code comments explaining why new helpers were introduced rather than reusing the shared ones.

Consider adding a comment to both new functions explaining why they intentionally do not fall back to the host process environment. This prevents a future contributor from "simplifying" them back to the shared helpers and re-introducing the host-env leakage bug.

```go
// parseComposeValidationEnvContent parses env content with variable expansion
// using ONLY the provided contextEnv — it deliberately does NOT fall back to
// os.LookupEnv so that host process secrets cannot be resolved during validation.
func parseComposeValidationEnvContent(content string, contextEnv projects.EnvMap) (projects.EnvMap, error) {
```

**Rule Used:** # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: global env not ..."](https://github.com/getarcaneapp/arcane/commit/3942444eff278c7c0524ac67d49295d674d7768c)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
- Rule used - # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

<!-- /greptile_comment -->