### PR TITLE
fix: ipv6 parsing failing on cert docker api versions

### DIFF
--- a/backend/internal/services/docker_client_service.go
+++ b/backend/internal/services/docker_client_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/config"
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	docker "github.com/getarcaneapp/arcane/backend/pkg/dockerutil"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/timeouts"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/image"
@@ -200,7 +201,7 @@ func (s *DockerClientService) GetAllNetworks(ctx context.Context) (_ []network.S
 		}
 	}
 
-	networkList, err := dockerClient.NetworkList(apiCtx, client.NetworkListOptions{})
+	networkList, err := libarcane.NetworkListWithCompatibility(apiCtx, dockerClient, client.NetworkListOptions{})
 	if err != nil {
 		return nil, 0, 0, 0, fmt.Errorf("failed to list Docker networks: %w", err)
 	}

--- a/backend/internal/services/network_service.go
+++ b/backend/internal/services/network_service.go
@@ -150,7 +150,7 @@ func (s *NetworkService) ListNetworksPaginated(ctx context.Context, params pagin
 
 	inUseByID, inUseByName := s.buildNetworkUsageMaps(containers)
 
-	networkList, err := dockerClient.NetworkList(ctx, client.NetworkListOptions{})
+	networkList, err := libarcane.NetworkListWithCompatibility(ctx, dockerClient, client.NetworkListOptions{})
 	if err != nil {
 		return nil, pagination.Response{}, networktypes.UsageCounts{}, fmt.Errorf("failed to list Docker networks: %w", err)
 	}

--- a/backend/pkg/libarcane/inspect_compat.go
+++ b/backend/pkg/libarcane/inspect_compat.go
@@ -47,6 +47,10 @@ func (c *inspectCompatibilityClient) NetworkInspect(ctx context.Context, network
 	return NetworkInspectWithCompatibility(ctx, c.APIClient, networkID, options)
 }
 
+func (c *inspectCompatibilityClient) NetworkList(ctx context.Context, options client.NetworkListOptions) (client.NetworkListResult, error) {
+	return NetworkListWithCompatibility(ctx, c.APIClient, options)
+}
+
 // ContainerInspectWithCompatibility retries inspect decoding against raw daemon
 // JSON when the primary typed decode fails on a ParseAddr-style CIDR issue.
 func ContainerInspectWithCompatibility(ctx context.Context, apiClient client.APIClient, containerID string, options client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
@@ -123,6 +127,43 @@ func NetworkInspectWithCompatibility(ctx context.Context, apiClient client.APICl
 	return client.NetworkInspectResult{
 		Network: repaired,
 		Raw:     normalized,
+	}, nil
+}
+
+// NetworkListWithCompatibility retries list decoding against raw daemon JSON
+// when the primary typed decode fails on a ParseAddr-style CIDR issue.
+func NetworkListWithCompatibility(ctx context.Context, apiClient client.APIClient, options client.NetworkListOptions) (client.NetworkListResult, error) {
+	if apiClient == nil {
+		return client.NetworkListResult{}, fmt.Errorf("docker api client is nil")
+	}
+
+	result, err := apiClient.NetworkList(ctx, options)
+	if err == nil || !isInspectAddressParseErrorInternal(err) {
+		return result, err
+	}
+
+	query, queryErr := buildNetworkListQueryInternal(options)
+	if queryErr != nil {
+		return client.NetworkListResult{}, err
+	}
+
+	raw, fetchErr := fetchDockerAPIJSONInternal(ctx, apiClient, "/networks", query)
+	if fetchErr != nil {
+		return client.NetworkListResult{}, err
+	}
+
+	normalized, changed, normalizeErr := normalizeNetworkListRawJSONInternal(raw)
+	if normalizeErr != nil || !changed {
+		return client.NetworkListResult{}, err
+	}
+
+	var repaired []networktypes.Summary
+	if unmarshalErr := json.Unmarshal(normalized, &repaired); unmarshalErr != nil {
+		return client.NetworkListResult{}, err
+	}
+
+	return client.NetworkListResult{
+		Items: repaired,
 	}, nil
 }
 
@@ -228,12 +269,51 @@ func normalizeContainerInspectRawJSONInternal(raw []byte) ([]byte, bool, error) 
 	return normalized, true, nil
 }
 
+func normalizeNetworkListRawJSONInternal(raw []byte) ([]byte, bool, error) {
+	var payload []any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, false, err
+	}
+
+	changed := false
+	for _, item := range payload {
+		networkPayload, ok := asMapInternal(item)
+		if !ok {
+			continue
+		}
+		changed = normalizeNetworkObjectInternal(networkPayload) || changed
+	}
+
+	if !changed {
+		return raw, false, nil
+	}
+
+	normalized, err := json.Marshal(payload)
+	if err != nil {
+		return nil, false, err
+	}
+	return normalized, true, nil
+}
+
 func normalizeNetworkInspectRawJSONInternal(raw []byte) ([]byte, bool, error) {
 	payload := map[string]any{}
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		return nil, false, err
 	}
 
+	changed := normalizeNetworkObjectInternal(payload)
+	if !changed {
+		return raw, false, nil
+	}
+
+	normalized, err := json.Marshal(payload)
+	if err != nil {
+		return nil, false, err
+	}
+	return normalized, true, nil
+}
+
+func normalizeNetworkObjectInternal(payload map[string]any) bool {
 	changed := false
 	if ipam, ok := asMapInternal(payload["IPAM"]); ok {
 		if configs, ok := asSliceInternal(ipam["Config"]); ok {
@@ -260,16 +340,7 @@ func normalizeNetworkInspectRawJSONInternal(raw []byte) ([]byte, bool, error) {
 			changed = normalizePrefixStringFieldInternal(endpoint, "IPv6Address") || changed
 		}
 	}
-
-	if !changed {
-		return raw, false, nil
-	}
-
-	normalized, err := json.Marshal(payload)
-	if err != nil {
-		return nil, false, err
-	}
-	return normalized, true, nil
+	return changed
 }
 
 func normalizeAddressStringFieldInternal(obj map[string]any, key string) bool {
@@ -452,6 +523,20 @@ func asMapInternal(value any) (map[string]any, bool) {
 func asSliceInternal(value any) ([]any, bool) {
 	out, ok := value.([]any)
 	return out, ok
+}
+
+func buildNetworkListQueryInternal(options client.NetworkListOptions) (url.Values, error) {
+	query := url.Values{}
+	if len(options.Filters) == 0 {
+		return query, nil
+	}
+
+	filtersJSON, err := json.Marshal(options.Filters)
+	if err != nil {
+		return nil, err
+	}
+	query.Set("filters", string(filtersJSON))
+	return query, nil
 }
 
 func isInspectAddressParseErrorInternal(err error) bool {

--- a/backend/pkg/libarcane/inspect_compat_test.go
+++ b/backend/pkg/libarcane/inspect_compat_test.go
@@ -164,6 +164,41 @@ func TestNormalizeNetworkInspectRawJSONInternal_NormalizesContainerEndpoints(t *
 	assert.Equal(t, netip.MustParsePrefix("fdd0:0:0:c::10/64"), endpoint.IPv6Address)
 }
 
+func TestNormalizeNetworkListRawJSONInternal(t *testing.T) {
+	raw := []byte(`[
+		{
+			"Name":"test-net",
+			"Id":"net123",
+			"Created":"2026-03-11T00:00:00Z",
+			"Scope":"local",
+			"Driver":"bridge",
+			"IPAM":{
+				"Driver":"default",
+				"Config":[
+					{
+						"Subnet":"fdd0:0:0:c::/64",
+						"Gateway":"fdd0:0:0:c::1/64",
+						"AuxiliaryAddresses":{
+							"router":"fdd0:0:0:c::2/64"
+						}
+					}
+				]
+			}
+		}
+	]`)
+
+	normalized, changed, err := normalizeNetworkListRawJSONInternal(raw)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	var networks []networktypes.Summary
+	require.NoError(t, json.Unmarshal(normalized, &networks))
+	require.Len(t, networks, 1)
+	require.Len(t, networks[0].IPAM.Config, 1)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::1"), networks[0].IPAM.Config[0].Gateway)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::2"), networks[0].IPAM.Config[0].AuxAddress["router"])
+}
+
 func TestNormalizeAddressStringInternal_TrimsWhitespaceAroundValidAddress(t *testing.T) {
 	normalized, changed := normalizeAddressStringInternal(" 172.18.0.1 ")
 	assert.True(t, changed)
@@ -250,6 +285,82 @@ func TestNetworkInspectWithCompatibility(t *testing.T) {
 	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::1"), result.Network.IPAM.Config[0].Gateway)
 }
 
+func TestNetworkListWithCompatibility(t *testing.T) {
+	networkJSON := `[
+		{
+			"Name":"test-net",
+			"Id":"net123",
+			"Created":"2026-03-11T00:00:00Z",
+			"Scope":"local",
+			"Driver":"bridge",
+			"IPAM":{
+				"Driver":"default",
+				"Config":[
+					{
+						"Subnet":"fdd0:0:0:c::/64",
+						"Gateway":"fdd0:0:0:c::1/64",
+						"AuxiliaryAddresses":{
+							"router":"fdd0:0:0:c::2/64"
+						}
+					}
+				]
+			}
+		}
+	]`
+
+	callCount := 0
+	dockerClient := newTestDockerClient(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		assert.Equal(t, "/v1.41/networks", r.URL.Path)
+		assert.Equal(t, `{"name":{"test-net":true}}`, r.URL.Query().Get("filters"))
+		_, _ = w.Write([]byte(networkJSON))
+	})
+
+	result, err := NetworkListWithCompatibility(context.Background(), dockerClient, client.NetworkListOptions{
+		Filters: make(client.Filters).Add("name", "test-net"),
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	require.Len(t, result.Items[0].IPAM.Config, 1)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::1"), result.Items[0].IPAM.Config[0].Gateway)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::2"), result.Items[0].IPAM.Config[0].AuxAddress["router"])
+	assert.Equal(t, 2, callCount)
+}
+
+func TestNetworkListWithCompatibility_SuccessSkipsFallback(t *testing.T) {
+	networkJSON := `[
+		{
+			"Name":"test-net",
+			"Id":"net123",
+			"Created":"2026-03-11T00:00:00Z",
+			"Scope":"local",
+			"Driver":"bridge",
+			"IPAM":{
+				"Driver":"default",
+				"Config":[
+					{
+						"Subnet":"fdd0:0:0:c::/64",
+						"Gateway":"fdd0:0:0:c::1"
+					}
+				]
+			}
+		}
+	]`
+
+	callCount := 0
+	dockerClient := newTestDockerClient(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		assert.Equal(t, "/v1.41/networks", r.URL.Path)
+		_, _ = w.Write([]byte(networkJSON))
+	})
+
+	result, err := NetworkListWithCompatibility(context.Background(), dockerClient, client.NetworkListOptions{})
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::1"), result.Items[0].IPAM.Config[0].Gateway)
+	assert.Equal(t, 1, callCount)
+}
+
 func TestContainerInspectWithCompatibility_TLSRemote(t *testing.T) {
 	containerJSON := `{
 		"Id":"abc123",
@@ -305,6 +416,29 @@ func TestInspectCompatibilityLeavesInvalidValuesFailing(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), `ParseAddr("definitely-not-an-ip")`))
 }
 
+func TestNetworkListWithCompatibility_LeavesInvalidValuesFailing(t *testing.T) {
+	callCount := 0
+	dockerClient := newTestDockerClient(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		assert.Equal(t, "/v1.41/networks", r.URL.Path)
+		_, _ = w.Write([]byte(`[
+			{
+				"Name":"test-net",
+				"Id":"net123",
+				"Created":"2026-03-11T00:00:00Z",
+				"Scope":"local",
+				"Driver":"bridge",
+				"IPAM":{"Driver":"default","Config":[{"Subnet":"fdd0:0:0:c::/64","Gateway":"definitely-not-an-ip"}]}
+			}
+		]`))
+	})
+
+	_, err := NetworkListWithCompatibility(context.Background(), dockerClient, client.NetworkListOptions{})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), `ParseAddr("definitely-not-an-ip")`))
+	assert.Equal(t, 2, callCount)
+}
+
 func TestWrapDockerAPIClientForInspectCompatibility(t *testing.T) {
 	dockerClient := newTestDockerClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{
@@ -320,6 +454,31 @@ func TestWrapDockerAPIClientForInspectCompatibility(t *testing.T) {
 	result, err := wrapped.ContainerInspect(context.Background(), "test-container", client.ContainerInspectOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::1"), result.Container.NetworkSettings.Networks["bridge"].IPv6Gateway)
+}
+
+func TestWrapDockerAPIClientForInspectCompatibility_NetworkList(t *testing.T) {
+	callCount := 0
+	dockerClient := newTestDockerClient(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		assert.Equal(t, "/v1.41/networks", r.URL.Path)
+		_, _ = w.Write([]byte(`[
+			{
+				"Name":"test-net",
+				"Id":"net123",
+				"Created":"2026-03-11T00:00:00Z",
+				"Scope":"local",
+				"Driver":"bridge",
+				"IPAM":{"Driver":"default","Config":[{"Subnet":"fdd0:0:0:c::/64","Gateway":"fdd0:0:0:c::1/64"}]}
+			}
+		]`))
+	})
+
+	wrapped := WrapDockerAPIClientForInspectCompatibility(dockerClient)
+	result, err := wrapped.NetworkList(context.Background(), client.NetworkListOptions{})
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	assert.Equal(t, netip.MustParseAddr("fdd0:0:0:c::1"), result.Items[0].IPAM.Config[0].Gateway)
+	assert.Equal(t, 2, callCount)
 }
 
 func TestWrapDockerAPIClientForInspectCompatibility_ContainerCreateLegacyNetworks(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2007

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes IPv6 address-parsing failures that occurred when the Docker daemon returned IPAM gateway addresses in CIDR notation (e.g. `fdd0:0:0:c::1/64`) during a `NetworkList` call. Newer Moby typed structs expect plain `netip.Addr` values and reject such responses with a `ParseAddr` error.

The fix follows the existing `ContainerInspectWithCompatibility` / `NetworkInspectWithCompatibility` pattern already in `inspect_compat.go`:

- **`NetworkListWithCompatibility`** — tries the standard typed call first; on a `ParseAddr`/`ParsePrefix` error it falls back to a raw HTTP fetch, normalises the JSON (stripping CIDR suffixes from gateway/auxiliary-address fields), and manually unmarshals the repaired bytes.
- **`normalizeNetworkObjectInternal`** — the per-object normalisation logic extracted from `normalizeNetworkInspectRawJSONInternal` and shared by both the inspect and list paths, eliminating duplication.
- **`buildNetworkListQueryInternal`** — encodes `NetworkListOptions.Filters` into a `url.Values` query string using `json.Marshal`, producing the same `{"key":{"value":true}}` format the standard client library sends.
- Both call-sites in `docker_client_service.go` and `network_service.go` are updated to use the new wrapper.

Key observations:
- The fallback error-handling pattern (returning the original `err` from all intermediate failure points) is **consistent** with the two existing compat functions; however, if the fallback fetch or normalisation fails, the caller receives the original `ParseAddr` error instead of the more-specific downstream error, which can complicate debugging.
- Test coverage is thorough: success-skips-fallback, CIDR-gateway triggers fallback, invalid (non-normalizable) gateway propagates original error, and wrapper-delegation are all exercised.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge; the fix is narrow, well-tested, and follows the established compatibility pattern without touching any data-mutation paths.
- The implementation correctly mirrors the existing `ContainerInspectWithCompatibility` and `NetworkInspectWithCompatibility` patterns, the refactoring of `normalizeNetworkObjectInternal` is semantically equivalent to the previous code, and four new test cases cover the critical code paths. The only deduction is for the minor inconsistency where intermediate fallback errors are silently discarded (returning the original ParseAddr error), which could hamper debugging but does not affect correctness.
- No files require special attention; `backend/pkg/libarcane/inspect_compat.go` is the core change and its logic is consistent with the rest of the file.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/pkg/libarcane/inspect_compat.go | Adds `NetworkListWithCompatibility` and `normalizeNetworkListRawJSONInternal` following the established fallback pattern; extracts `normalizeNetworkObjectInternal` for reuse between inspect and list paths. Logic and error-handling are consistent with existing functions; one minor inconsistency with missing `Raw` field in the success return value. |
| backend/internal/services/docker_client_service.go | Swaps direct `dockerClient.NetworkList` call for `libarcane.NetworkListWithCompatibility`, wiring the fix into the stats/overview path. |
| backend/internal/services/network_service.go | Swaps direct `dockerClient.NetworkList` call for `libarcane.NetworkListWithCompatibility` in the paginated listing path; no other changes. |
| backend/pkg/libarcane/inspect_compat_test.go | Adds comprehensive table of test cases for `NetworkListWithCompatibility`: success-skips-fallback, CIDR-gateway triggers fallback, invalid gateway propagates original error, and wrapped client delegation. Coverage is on par with the existing inspect tests. |

</details>

</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fpkg%2Flibarcane%2Finspect_compat.go%3A155-158%0A**Silent%20discard%20of%20fallback%20errors**%0A%0AWhen%20%60normalizeErr%20!%3D%20nil%60%20or%20%60!changed%60%2C%20the%20function%20returns%20the%20original%20%60err%60%20from%20%60apiClient.NetworkList%60%20and%20silently%20discards%20both%20%60normalizeErr%60%20and%20any%20error%20from%20the%20preceding%20%60fetchDockerAPIJSONInternal%60%20step.%20In%20practice%20this%20means%20a%20caller%20who%20encounters%2C%20say%2C%20a%20transport%20failure%20in%20the%20fallback%20fetch%20will%20receive%20a%20%60ParseAddr%28%E2%80%A6%29%60%20error%20rather%20than%20the%20actual%20fetch%20error%2C%20which%20makes%20debugging%20harder.%0A%0AThis%20is%20the%20same%20pattern%20used%20by%20%60ContainerInspectWithCompatibility%60%20and%20%60NetworkInspectWithCompatibility%60%2C%20so%20it's%20consistent%20across%20the%20file.%20However%2C%20since%20all%20three%20functions%20share%20the%20same%20behaviour%20it%20may%20be%20worth%20wrapping%20the%20new%20error%20for%20context%20on%20top%20of%20the%20original%3A%0A%0A%60%60%60go%0Aif%20normalizeErr%20!%3D%20nil%20%7C%7C%20!changed%20%7B%0A%20%20%20%20%2F%2F%20Optionally%3A%20fmt.Errorf%28%22network%20list%20compatibility%20fallback%20failed%3A%20%25w%22%2C%20errors.Join%28normalizeErr%2C%20err%29%29%0A%20%20%20%20return%20client.NetworkListResult%7B%7D%2C%20err%0A%7D%0A%60%60%60%0A%0AThis%20is%20a%20non-critical%20style%20observation%2C%20not%20a%20blocking%20bug.%0A%0A**Rule%20Used%3A**%20%23%20Golang%20Pro%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/libarcane/inspect_compat.go
Line: 155-158

Comment:
**Silent discard of fallback errors**

When `normalizeErr != nil` or `!changed`, the function returns the original `err` from `apiClient.NetworkList` and silently discards both `normalizeErr` and any error from the preceding `fetchDockerAPIJSONInternal` step. In practice this means a caller who encounters, say, a transport failure in the fallback fetch will receive a `ParseAddr(…)` error rather than the actual fetch error, which makes debugging harder.

This is the same pattern used by `ContainerInspectWithCompatibility` and `NetworkInspectWithCompatibility`, so it's consistent across the file. However, since all three functions share the same behaviour it may be worth wrapping the new error for context on top of the original:

```go
if normalizeErr != nil || !changed {
    // Optionally: fmt.Errorf("network list compatibility fallback failed: %w", errors.Join(normalizeErr, err))
    return client.NetworkListResult{}, err
}
```

This is a non-critical style observation, not a blocking bug.

**Rule Used:** # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: ipv6 parsing fa..."](https://github.com/getarcaneapp/arcane/commit/c0b76c2880c7c9c8e050ea6d00119455d45ecc29)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->