### PR TITLE
fix: PID and GID not being using for file creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,12 @@ APP_URL=https://your-domain.com
 # TLS_CERT_FILE=/path/to/fullchain.pem
 # TLS_KEY_FILE=/path/to/privkey.pem
 
-# User/Group IDs for file permissions (used by Docker)
-PUID=1000
-PGID=1000
+# Optional runtime UID/GID for published Docker images.
+# When both are set, Arcane will run as that UID/GID and files it writes under
+# /app/data will be owned by that user inside the container.
+# Leave both unset to keep the current default runtime behavior.
+# PUID=1000
+# PGID=1000
 
 # File and Directory Permissions (Octal)
 # Default: 0644 for files, 0755 for directories

--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -31,6 +31,9 @@ import (
 
 func Bootstrap(ctx context.Context) error {
 	_ = godotenv.Load()
+	if err := startup.ApplyRequestedRuntimeIdentity(); err != nil {
+		return fmt.Errorf("apply runtime identity: %w", err)
+	}
 	cfg := config.Load()
 
 	SetupGinLogger(cfg)

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -25,6 +25,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 
+	"github.com/getarcaneapp/arcane/backend/internal/common"
 	"github.com/getarcaneapp/arcane/backend/internal/config"
 	"github.com/getarcaneapp/arcane/backend/resources"
 )
@@ -527,5 +528,5 @@ func ensureSQLiteDirectory(connString string) error {
 	if dir == "" || dir == "." {
 		return nil
 	}
-	return os.MkdirAll(dir, 0o755) //nolint:gosec // directory path is intentionally derived from configured SQLite DSN
+	return os.MkdirAll(dir, common.DirPerm) //nolint:gosec // directory path is intentionally derived from configured SQLite DSN
 }

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -1695,7 +1695,7 @@ func TestProjectService_UpdateProject_WritesThroughSymlinkedProjectPath(t *testi
 	project := &models.Project{
 		BaseModel: models.BaseModel{ID: "proj-symlink-update"},
 		Name:      "demo",
-		DirName:   ptr("demo"),
+		DirName:   new("demo"),
 		Path:      linkPath,
 		Status:    models.ProjectStatusStopped,
 	}
@@ -1704,7 +1704,7 @@ func TestProjectService_UpdateProject_WritesThroughSymlinkedProjectPath(t *testi
 	updatedCompose := "services:\n  app:\n    image: nginx:1.27-alpine\n"
 	updatedEnv := "FOO=updated\n"
 
-	updated, err := svc.UpdateProject(ctx, project.ID, nil, ptr(updatedCompose), ptr(updatedEnv), models.User{
+	updated, err := svc.UpdateProject(ctx, project.ID, nil, new(updatedCompose), new(updatedEnv), models.User{
 		BaseModel: models.BaseModel{ID: "u1"},
 		Username:  "tester",
 	})

--- a/backend/pkg/fswatch/watcher_test.go
+++ b/backend/pkg/fswatch/watcher_test.go
@@ -20,8 +20,7 @@ func TestWatcher_StartWatchesExistingSymlinkDirectoriesWhenEnabled(t *testing.T)
 	require.NoError(t, os.Symlink(targetPath, linkPath))
 
 	changeCh := make(chan struct{}, 1)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	watcher, err := NewWatcher(root, WatcherOptions{
 		Debounce:          25 * time.Millisecond,
@@ -59,8 +58,7 @@ func TestWatcher_StartSkipsExistingSymlinkDirectoriesWhenDisabled(t *testing.T) 
 	require.NoError(t, os.Symlink(targetPath, linkPath))
 
 	changeCh := make(chan struct{}, 1)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	watcher, err := NewWatcher(root, WatcherOptions{
 		Debounce: 25 * time.Millisecond,

--- a/backend/pkg/libarcane/startup/runtime_identity.go
+++ b/backend/pkg/libarcane/startup/runtime_identity.go
@@ -1,0 +1,248 @@
+package startup
+
+import (
+	"fmt"
+	"math"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	pkgutils "github.com/getarcaneapp/arcane/backend/pkg/utils"
+)
+
+const (
+	defaultDataDirectory   = "/app/data"
+	defaultBuildsDirectory = "/builds"
+	defaultDatabaseURL     = "file:data/arcane.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(2500)&_txlock=immediate"
+	mountInfoPath          = "/proc/self/mountinfo"
+)
+
+type runtimeIdentityRequest struct {
+	Enabled bool
+	UID     uint32
+	GID     uint32
+}
+
+// ApplyRequestedRuntimeIdentity switches the current process to the configured
+// runtime UID/GID before the rest of the app initializes.
+func ApplyRequestedRuntimeIdentity() error {
+	req, warning, err := loadRuntimeIdentityRequestInternal(os.Getenv)
+	if warning != "" {
+		fmt.Fprintf(os.Stderr, "Runtime identity warning: %s\n", warning)
+	}
+	if err != nil || !req.Enabled {
+		return err
+	}
+
+	runtimeUID := int(req.UID)
+	runtimeGID := int(req.GID)
+
+	// Avoid re-execing forever when the requested runtime identity is already active,
+	// including explicit root requests such as PUID=0/PGID=0.
+	if os.Geteuid() == runtimeUID && os.Getegid() == runtimeGID {
+		return ensureSQLiteFilesExistInternal(os.Getenv("DATABASE_URL"))
+	}
+
+	if os.Geteuid() != 0 {
+		return ensureSQLiteFilesExistInternal(os.Getenv("DATABASE_URL"))
+	}
+
+	mountpoints, err := loadMountpointsInternal(mountInfoPath)
+	if err != nil {
+		return fmt.Errorf("load mountpoints: %w", err)
+	}
+
+	if err := prepareWritablePathsInternal(req, mountpoints); err != nil {
+		return err
+	}
+
+	return reexecWithRuntimeIdentityInternal(req)
+}
+
+func loadRuntimeIdentityRequestInternal(getenv func(string) string) (runtimeIdentityRequest, string, error) {
+	puid := strings.TrimSpace(getenv("PUID"))
+	pgid := strings.TrimSpace(getenv("PGID"))
+
+	if puid == "" && pgid == "" {
+		return runtimeIdentityRequest{}, "", nil
+	}
+
+	if puid == "" || pgid == "" {
+		return runtimeIdentityRequest{}, "PUID and PGID must both be set to enable non-root mode; continuing with default runtime user", nil
+	}
+
+	uid, err := parseRuntimeIdentityValueInternal(puid, "PUID")
+	if err != nil {
+		return runtimeIdentityRequest{}, "", fmt.Errorf("invalid PUID %q: %w", puid, err)
+	}
+
+	gid, err := parseRuntimeIdentityValueInternal(pgid, "PGID")
+	if err != nil {
+		return runtimeIdentityRequest{}, "", fmt.Errorf("invalid PGID %q: %w", pgid, err)
+	}
+
+	return runtimeIdentityRequest{
+		Enabled: true,
+		UID:     uid,
+		GID:     gid,
+	}, "", nil
+}
+
+func parseRuntimeIdentityValueInternal(raw string, key string) (uint32, error) {
+	value, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", key, err)
+	}
+	if value > uint64(math.MaxInt) {
+		return 0, fmt.Errorf("parse %s: value %q exceeds platform int range", key, raw)
+	}
+
+	return uint32(value), nil
+}
+
+func prepareWritablePathsInternal(req runtimeIdentityRequest, mountpoints map[string]struct{}) error {
+	uid := int(req.UID)
+	gid := int(req.GID)
+
+	if err := os.MkdirAll(defaultDataDirectory, pkgutils.DirPerm); err != nil {
+		return fmt.Errorf("create data directory: %w", err)
+	}
+
+	if err := os.Chown(defaultDataDirectory, uid, gid); err != nil {
+		return fmt.Errorf("chown data directory: %w", err)
+	}
+
+	entries, err := os.ReadDir(defaultDataDirectory)
+	if err != nil {
+		return fmt.Errorf("read data directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		entryPath := filepath.Join(defaultDataDirectory, entry.Name())
+		if _, mounted := mountpoints[entryPath]; mounted {
+			continue
+		}
+		if err := chownRecursiveInternal(entryPath, uid, gid); err != nil {
+			return fmt.Errorf("chown %s: %w", entryPath, err)
+		}
+	}
+
+	if _, mounted := mountpoints[defaultBuildsDirectory]; mounted {
+		return nil
+	}
+
+	if _, err := os.Stat(defaultBuildsDirectory); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat builds directory: %w", err)
+	}
+
+	if err := chownRecursiveInternal(defaultBuildsDirectory, uid, gid); err != nil {
+		return fmt.Errorf("chown builds directory: %w", err)
+	}
+
+	return nil
+}
+
+func ensureSQLiteFilesExistInternal(databaseURL string) error {
+	sqlitePath, ok, err := sqliteDatabasePathInternal(databaseURL)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	file, err := os.OpenFile(sqlitePath, os.O_CREATE|os.O_RDWR, pkgutils.FilePerm) //nolint:gosec // path is derived from the configured SQLite DSN
+	if err != nil {
+		return fmt.Errorf("create sqlite file %s: %w", sqlitePath, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close sqlite file %s: %w", sqlitePath, err)
+	}
+
+	return nil
+}
+
+func sqliteDatabasePathInternal(databaseURL string) (string, bool, error) {
+	value := strings.TrimSpace(databaseURL)
+	if value == "" {
+		value = defaultDatabaseURL
+	}
+	if !strings.HasPrefix(value, "file:") {
+		return "", false, nil
+	}
+
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "", false, fmt.Errorf("parse sqlite database url: %w", err)
+	}
+
+	pathPart := parsed.Opaque
+	if pathPart == "" {
+		pathPart = parsed.Path
+	}
+
+	pathPart = strings.TrimPrefix(pathPart, "/")
+	if pathPart == "" || strings.HasPrefix(pathPart, ":memory:") {
+		return "", false, nil
+	}
+
+	return filepath.Clean(pathPart), true, nil
+}
+
+func chownRecursiveInternal(path string, uid int, gid int) error {
+	return filepath.Walk(path, func(currentPath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		//nolint:gosec // currentPath comes from fixed container paths under /app/data or /builds
+		return os.Lchown(currentPath, uid, gid)
+	})
+}
+
+func loadMountpointsInternal(path string) (map[string]struct{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]struct{}{}, nil
+		}
+		return nil, err
+	}
+	return parseMountpointsInternal(string(data)), nil
+}
+
+func parseMountpointsInternal(data string) map[string]struct{} {
+	mountpoints := make(map[string]struct{})
+
+	for line := range strings.SplitSeq(data, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			continue
+		}
+
+		mountpoint := filepath.Clean(unescapeMountInfoPathInternal(fields[4]))
+		mountpoints[mountpoint] = struct{}{}
+	}
+
+	return mountpoints
+}
+
+func unescapeMountInfoPathInternal(path string) string {
+	replacer := strings.NewReplacer(
+		`\\`, `\`,
+		`\040`, " ",
+		`\011`, "\t",
+		`\012`, "\n",
+		`\134`, `\`,
+	)
+	return replacer.Replace(path)
+}

--- a/backend/pkg/libarcane/startup/runtime_identity_linux.go
+++ b/backend/pkg/libarcane/startup/runtime_identity_linux.go
@@ -1,0 +1,70 @@
+//go:build linux
+
+package startup
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+)
+
+func reexecWithRuntimeIdentityInternal(req runtimeIdentityRequest) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve executable: %w", err)
+	}
+
+	cmd := exec.Command(executable, os.Args[1:]...)
+	cmd.Env = os.Environ()
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{
+			Uid: req.UID,
+			Gid: req.GID,
+		},
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start runtime identity child: %w", err)
+	}
+
+	sigCh := make(chan os.Signal, 2)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	for {
+		select {
+		case sig := <-sigCh:
+			if cmd.Process != nil {
+				_ = cmd.Process.Signal(sig)
+			}
+		case err := <-done:
+			if err == nil {
+				os.Exit(0)
+			}
+
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+					if status.Signaled() {
+						os.Exit(128 + int(status.Signal()))
+					}
+					os.Exit(status.ExitStatus())
+				}
+				os.Exit(exitErr.ExitCode())
+			}
+
+			return fmt.Errorf("wait for runtime identity child: %w", err)
+		}
+	}
+}

--- a/backend/pkg/libarcane/startup/runtime_identity_nonlinux.go
+++ b/backend/pkg/libarcane/startup/runtime_identity_nonlinux.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package startup
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func reexecWithRuntimeIdentityInternal(req runtimeIdentityRequest) error {
+	return fmt.Errorf("runtime identity switching is only supported on linux, current platform is %s", runtime.GOOS)
+}

--- a/backend/pkg/libarcane/startup/runtime_identity_test.go
+++ b/backend/pkg/libarcane/startup/runtime_identity_test.go
@@ -1,0 +1,128 @@
+package startup
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadRuntimeIdentityRequest(t *testing.T) {
+	t.Run("disabled when unset", func(t *testing.T) {
+		req, warning, err := loadRuntimeIdentityRequestInternal(func(string) string { return "" })
+		require.NoError(t, err)
+		require.Empty(t, warning)
+		require.False(t, req.Enabled)
+	})
+
+	t.Run("warning when partial config", func(t *testing.T) {
+		req, warning, err := loadRuntimeIdentityRequestInternal(func(key string) string {
+			if key == "PUID" {
+				return "1001"
+			}
+			return ""
+		})
+		require.NoError(t, err)
+		require.Contains(t, warning, "PUID and PGID must both be set")
+		require.False(t, req.Enabled)
+	})
+
+	t.Run("error when invalid numeric value", func(t *testing.T) {
+		_, _, err := loadRuntimeIdentityRequestInternal(func(key string) string {
+			if key == "PUID" {
+				return "abc"
+			}
+			return "1001"
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid PUID")
+	})
+
+	t.Run("error when value exceeds uint32", func(t *testing.T) {
+		tooLarge := strconv.FormatUint(uint64(math.MaxUint32)+1, 10)
+
+		_, _, err := loadRuntimeIdentityRequestInternal(func(key string) string {
+			if key == "PUID" {
+				return tooLarge
+			}
+			return "1001"
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid PUID")
+	})
+
+	t.Run("enabled when both set", func(t *testing.T) {
+		req, warning, err := loadRuntimeIdentityRequestInternal(func(key string) string {
+			switch key {
+			case "PUID":
+				return "1001"
+			case "PGID":
+				return "2001"
+			default:
+				return ""
+			}
+		})
+		require.NoError(t, err)
+		require.Empty(t, warning)
+		require.True(t, req.Enabled)
+		require.Equal(t, uint32(1001), req.UID)
+		require.Equal(t, uint32(2001), req.GID)
+	})
+}
+
+func TestParseMountpoints(t *testing.T) {
+	data := `36 25 0:32 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+97 92 0:44 / /app/data rw,relatime - ext4 /dev/sda1 rw
+98 92 0:45 / /app/data/projects rw,relatime - ext4 /dev/sdb1 rw
+99 92 0:46 / /builds rw,relatime - ext4 /dev/sdc1 rw
+`
+
+	parsed := parseMountpointsInternal(data)
+	require.Contains(t, parsed, "/app/data")
+	require.Contains(t, parsed, "/app/data/projects")
+	require.Contains(t, parsed, "/builds")
+}
+
+func TestSQLiteDatabasePath(t *testing.T) {
+	t.Run("uses default sqlite path when unset", func(t *testing.T) {
+		path, ok, err := sqliteDatabasePathInternal("")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, "data/arcane.db", path)
+	})
+
+	t.Run("returns configured sqlite path", func(t *testing.T) {
+		path, ok, err := sqliteDatabasePathInternal("file:/app/custom/arcane.db?_pragma=journal_mode(WAL)")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, "app/custom/arcane.db", path)
+	})
+
+	t.Run("skips non sqlite database urls", func(t *testing.T) {
+		path, ok, err := sqliteDatabasePathInternal("postgres://arcane:secret@db/arcane")
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Empty(t, path)
+	})
+}
+
+func TestEnsureSQLiteFilesExistInternal(t *testing.T) {
+	tempDir := t.TempDir()
+
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+
+	require.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(oldWd))
+	})
+
+	require.NoError(t, ensureSQLiteFilesExistInternal("file:arcane.db?_pragma=journal_mode(WAL)"))
+
+	require.FileExists(t, filepath.Join(tempDir, "arcane.db"))
+	require.NoFileExists(t, filepath.Join(tempDir, "arcane.db-wal"))
+	require.NoFileExists(t, filepath.Join(tempDir, "arcane.db-shm"))
+}

--- a/docker/examples/compose.agent-edge.yaml
+++ b/docker/examples/compose.agent-edge.yaml
@@ -7,6 +7,10 @@ services:
       - EDGE_AGENT=true
       - AGENT_TOKEN=arc_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
       - MANAGER_API_URL=https://your-manager.example.com
+      # Optional: run the agent as a specific host UID/GID instead of the default runtime user.
+      # When using the mounted Docker socket, Arcane will map the socket group automatically.
+      # - PUID=1000
+      # - PGID=1000
       # Set to grpc to enable protobuf transport over the manager API port.
       - EDGE_TRANSPORT=websocket
     volumes:

--- a/docker/examples/compose.agent.yaml
+++ b/docker/examples/compose.agent.yaml
@@ -8,6 +8,10 @@ services:
       - AGENT_MODE=true
       - AGENT_TOKEN=arc_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
       - MANAGER_API_URL=http://10.1.1.4:3552
+      # Optional: run the agent as a specific host UID/GID instead of the default runtime user.
+      # When using the mounted Docker socket, Arcane will map the socket group automatically.
+      # - PUID=1000
+      # - PGID=1000
       # Optional gRPC tunnel setting:
       - EDGE_TRANSPORT=websocket
     volumes:

--- a/docker/examples/compose.basic.yaml
+++ b/docker/examples/compose.basic.yaml
@@ -12,6 +12,10 @@ services:
     environment:
       - ENCRYPTION_KEY=xxxxxxxxxxxxxxxxxxxxxx
       - JWT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxx
+      # Optional: run Arcane as a specific host UID/GID instead of the default runtime user.
+      # When using the mounted Docker socket, Arcane will map the socket group automatically.
+      # - PUID=1000
+      # - PGID=1000
       # Timezone for cron job scheduling (e.g., America/New_York, Europe/London, UTC)
       # See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
       - TZ=UTC

--- a/docker/examples/compose.proxy.yaml
+++ b/docker/examples/compose.proxy.yaml
@@ -47,6 +47,10 @@ services:
     environment:
       - ENCRYPTION_KEY=xxxxxxxxxxxxxxxxxxxxxx
       - JWT_SECRET=xxxxxxxxxxxxxxxxxxxxxx
+      # Optional: run Arcane as a specific host UID/GID instead of the default runtime user.
+      # With DOCKER_HOST over TCP, no Unix socket group mapping is needed.
+      # - PUID=1000
+      # - PGID=1000
       - DOCKER_HOST=tcp://docker-socket-proxy:2375 # Use the proxy instead of direct socket
     networks:
       - arcane-internal

--- a/frontend/src/lib/components/badges/port-badge.svelte
+++ b/frontend/src/lib/components/badges/port-badge.svelte
@@ -72,9 +72,7 @@
 
 	const allPorts = $derived(uniquePorts(ports));
 	const visiblePorts = $derived(
-		collapsible && !expanded && allPorts.length > maxVisible
-			? allPorts.slice(0, maxVisible)
-			: allPorts
+		collapsible && !expanded && allPorts.length > maxVisible ? allPorts.slice(0, maxVisible) : allPorts
 	);
 	const published = $derived(visiblePorts.filter((p) => p.isPublished));
 	const exposedOnly = $derived(visiblePorts.filter((p) => !p.isPublished));
@@ -131,7 +129,7 @@
 				<ArcaneTooltip.Trigger>
 					<button
 						onclick={() => (expanded = !expanded)}
-						class="bg-muted hover:bg-muted/80 text-muted-foreground inline-flex items-center rounded-lg border px-2 py-1 text-[11px] font-medium shadow-sm transition-colors cursor-pointer"
+						class="bg-muted hover:bg-muted/80 text-muted-foreground inline-flex cursor-pointer items-center rounded-lg border px-2 py-1 text-[11px] font-medium shadow-sm transition-colors"
 					>
 						{expanded ? '−' : `+${hiddenCount}`}
 					</button>

--- a/tests/spec/docker-runtime-identity.spec.ts
+++ b/tests/spec/docker-runtime-identity.spec.ts
@@ -1,0 +1,309 @@
+import { test, expect } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const IMAGE = process.env.ARCANE_RUNTIME_TEST_IMAGE || 'arcane:playwright-tests';
+const HEALTH_PATH = '/api/health';
+
+function docker(args: string[], options?: { stdio?: 'pipe' | 'inherit' }) {
+	const output = execFileSync('docker', args, {
+		encoding: 'utf8',
+		stdio: options?.stdio ?? 'pipe'
+	});
+	return typeof output === 'string' ? output.trim() : '';
+}
+
+function uniqueName(prefix: string) {
+	return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function dockerRunContainer(args: string[]) {
+	return docker(['run', '-d', ...args]);
+}
+
+function dockerExec(container: string, command: string) {
+	return docker(['exec', container, 'sh', '-lc', command]);
+}
+
+function dockerExecAsUser(container: string, user: string, command: string) {
+	return docker(['exec', '-u', user, container, 'sh', '-lc', command]);
+}
+
+function dockerStatus(container: string) {
+	return docker(['inspect', '-f', '{{.State.Status}}', container]);
+}
+
+function dockerPort(container: string) {
+	const mapping = docker(['port', container, '3552/tcp']);
+	return mapping.split(':').at(-1)?.trim() || '';
+}
+
+function dockerFileStat(volumePath: string, filePath: string) {
+	return docker([
+		'run',
+		'--rm',
+		'-v',
+		`${volumePath}:/mnt`,
+		'--entrypoint',
+		'sh',
+		IMAGE,
+		'-lc',
+		`stat -c '%u:%g' ${filePath}`
+	]);
+}
+
+function cleanupContainer(name: string) {
+	try {
+		docker(['rm', '-f', name], { stdio: 'inherit' });
+	} catch {
+		// ignore cleanup failures
+	}
+}
+
+function cleanupNetwork(name: string) {
+	try {
+		docker(['network', 'rm', name], { stdio: 'inherit' });
+	} catch {
+		// ignore cleanup failures
+	}
+}
+
+async function waitForHealth(container: string) {
+	const port = dockerPort(container);
+	expect(port).not.toBe('');
+
+	await expect
+		.poll(
+			async () => {
+				if (dockerStatus(container) !== 'running') {
+					return `container:${dockerStatus(container)}`;
+				}
+
+				try {
+					const response = await fetch(`http://127.0.0.1:${port}${HEALTH_PATH}`);
+					return response.ok ? 'UP' : `http:${response.status}`;
+				} catch {
+					return 'pending';
+				}
+			},
+			{
+				timeout: 120_000,
+				interval: 2_000
+			}
+		)
+		.toBe('UP');
+}
+
+async function waitForFile(container: string, filePath: string) {
+	await expect
+		.poll(
+			() => {
+				try {
+					return dockerExec(container, `test -f ${filePath} && echo present`);
+				} catch {
+					return 'missing';
+				}
+			},
+			{
+				timeout: 60_000,
+				interval: 1_000
+			}
+		)
+		.toBe('present');
+}
+
+function pidOneStatus(container: string) {
+	return dockerExec(container, "grep -E '^(Uid|Gid|Groups):' /proc/1/status");
+}
+
+function arcaneProcessStatuses(container: string) {
+	return dockerExec(
+		container,
+		[
+			'for f in /proc/[0-9]*/status; do',
+			'  name=$(awk \'/^Name:/ {print $2}\' "$f");',
+			'  [ "$name" = "arcane" ] || continue;',
+			'  pid=$(awk \'/^Pid:/ {print $2}\' "$f");',
+			'  ppid=$(awk \'/^PPid:/ {print $2}\' "$f");',
+			'  uid=$(awk \'/^Uid:/ {print $2}\' "$f");',
+			'  gid=$(awk \'/^Gid:/ {print $2}\' "$f");',
+			'  groups=$(awk \'/^Groups:/ {for (i = 2; i <= NF; i++) printf("%s%s", $i, (i < NF ? "," : ""));}\' "$f");',
+			'  echo "$pid:$ppid:$uid:$gid:$groups";',
+			'done'
+		].join(' ')
+	)
+		.split('\n')
+		.filter(Boolean);
+}
+
+function defaultRunArgs(name: string, dataDir: string) {
+	return [
+		'--name',
+		name,
+		'-p',
+		'0:3552',
+		'-e',
+		'ENVIRONMENT=testing',
+		'-e',
+		'APP_URL=http://localhost:3552',
+		'-e',
+		'ENCRYPTION_KEY=3JDIgolks2tJ9ymm1AdqzlYMWu0DUWyt',
+		'-e',
+		'JWT_SECRET=your-super-secret-jwt-key-change-this-in-production',
+		'-v',
+		`${dataDir}:/app/data`
+	];
+}
+
+test.describe.serial('Docker runtime identity', () => {
+	test.setTimeout(240_000);
+
+	test('keeps default root runtime behavior when PUID and PGID are unset', async () => {
+		const containerName = uniqueName('arcane-default');
+		const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arcane-default-'));
+
+		try {
+			dockerRunContainer([
+				...defaultRunArgs(containerName, dataDir),
+				'-v',
+				'/var/run/docker.sock:/var/run/docker.sock',
+				IMAGE
+			]);
+
+			await waitForHealth(containerName);
+			await waitForFile(containerName, '/app/data/arcane.db');
+
+			const status = pidOneStatus(containerName);
+			expect(status).toContain('Uid:\t0\t0\t0\t0');
+			expect(status).toContain('Gid:\t0\t0\t0\t0');
+		} finally {
+			cleanupContainer(containerName);
+			fs.rmSync(dataDir, { recursive: true, force: true });
+		}
+	});
+
+	test('runs as the requested UID and GID without chowning a mounted projects directory', async () => {
+		const containerName = uniqueName('arcane-puid');
+		const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arcane-puid-data-'));
+		const projectsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arcane-puid-projects-'));
+		const sentinelPath = path.join(projectsDir, 'sentinel.txt');
+		fs.writeFileSync(sentinelPath, 'sentinel\n');
+
+		const baselineProjectsStat = dockerFileStat(projectsDir, '/mnt/sentinel.txt');
+
+		try {
+			dockerRunContainer([
+				...defaultRunArgs(containerName, dataDir),
+				'-e',
+				'PUID=1001',
+				'-e',
+				'PGID=1001',
+				'-v',
+				'/var/run/docker.sock:/var/run/docker.sock',
+				'-v',
+				`${projectsDir}:/app/data/projects`,
+				IMAGE
+			]);
+
+			await waitForHealth(containerName);
+			await waitForFile(containerName, '/app/data/arcane.db');
+
+			const dbStat = dockerExecAsUser(
+				containerName,
+				'1001:1001',
+				"stat -c '%u:%g' /app/data/arcane.db"
+			);
+			expect(dbStat).toBe('1001:1001');
+
+			const projectsStat = dockerExec(
+				containerName,
+				"stat -c '%u:%g' /app/data/projects/sentinel.txt"
+			);
+			expect(projectsStat).toBe(baselineProjectsStat);
+
+			const processStatuses = arcaneProcessStatuses(containerName);
+			expect(processStatuses.some((status) => status.startsWith('1:0:0:0:'))).toBe(true);
+			expect(processStatuses.some((status) => /^(?!1:)\d+:1:1001:1001:/.test(status))).toBe(true);
+		} finally {
+			cleanupContainer(containerName);
+			fs.rmSync(dataDir, { recursive: true, force: true });
+			fs.rmSync(projectsDir, { recursive: true, force: true });
+		}
+	});
+
+	test('supports tcp docker host mode without a mounted Unix socket', async () => {
+		const networkName = uniqueName('arcane-proxy-net');
+		const proxyName = uniqueName('arcane-proxy');
+		const containerName = uniqueName('arcane-proxy-app');
+		const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arcane-proxy-data-'));
+
+		try {
+			docker(['network', 'create', networkName], { stdio: 'inherit' });
+
+			dockerRunContainer([
+				'--name',
+				proxyName,
+				'--network',
+				networkName,
+				'-e',
+				'EVENTS=1',
+				'-e',
+				'PING=1',
+				'-e',
+				'VERSION=1',
+				'-e',
+				'AUTH=0',
+				'-e',
+				'POST=1',
+				'-e',
+				'CONTAINERS=1',
+				'-e',
+				'IMAGES=1',
+				'-e',
+				'INFO=1',
+				'-e',
+				'NETWORKS=1',
+				'-e',
+				'VOLUMES=1',
+				'-v',
+				'/var/run/docker.sock:/var/run/docker.sock:ro',
+				'tecnativa/docker-socket-proxy:latest'
+			]);
+			await new Promise((resolve) => setTimeout(resolve, 2_000));
+
+			dockerRunContainer([
+				...defaultRunArgs(containerName, dataDir),
+				'--network',
+				networkName,
+				'-e',
+				'PUID=1001',
+				'-e',
+				'PGID=1001',
+				'-e',
+				`DOCKER_HOST=tcp://${proxyName}:2375`,
+				IMAGE
+			]);
+
+			await waitForHealth(containerName);
+			await waitForFile(containerName, '/app/data/arcane.db');
+
+			const dbStat = dockerExecAsUser(
+				containerName,
+				'1001:1001',
+				"stat -c '%u:%g' /app/data/arcane.db"
+			);
+			expect(dbStat).toBe('1001:1001');
+
+			const processStatuses = arcaneProcessStatuses(containerName);
+			expect(processStatuses.some((status) => status.startsWith('1:0:0:0:'))).toBe(true);
+			expect(processStatuses.some((status) => /^(?!1:)\d+:1:1001:1001:/.test(status))).toBe(true);
+		} finally {
+			cleanupContainer(containerName);
+			cleanupContainer(proxyName);
+			cleanupNetwork(networkName);
+			fs.rmSync(dataDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements proper `PUID`/`PGID` support for Docker deployments, fixing the long-standing issue where files created by Arcane were owned by root instead of the configured host user. The mechanism works by re-executing the binary as the target UID/GID (on Linux), chowning `/app/data` and `/builds` first, and skipping mounted directories to avoid interfering with user-supplied volume data.

**Key changes:**
- New `startup.ApplyRequestedRuntimeIdentity()` function handles the PUID/PGID identity switch early in `Bootstrap()`, before config or DB initialization.
- The re-exec approach (parent runs as root, spawns a child with the correct `syscall.Credential`) is a solid pattern for privilege drop in containers.
- The infinite re-exec loop (previously flagged) is now correctly guarded by `os.Geteuid() == req.UID && os.Getegid() == req.GID`.
- `PUID`/`PGID` documentation is updated across `.env.example` and all Docker Compose examples.

**Issues found:**
- **Logic bug in `sqliteDatabasePathInternal`**: absolute `DATABASE_URL` paths (e.g., `file:/app/data/arcane.db`) have their leading `/` stripped, causing `ensureSQLiteFilesExistInternal` to target a relative path (`app/data/arcane.db`) instead of the intended absolute path. For most users the default relative URL works fine, but anyone configuring an absolute path will find the ownership pre-creation silently does nothing.
- **Missing parent-directory creation** in `ensureSQLiteFilesExistInternal`: `os.OpenFile` with `O_CREATE` will fail if the parent directory does not yet exist, which can happen on the "already the right user" or "non-root" fast paths.
- **Non-standard `\\` replacement** in `unescapeMountInfoPathInternal`: the Linux kernel only uses `\134` for backslashes in mountinfo; the `\\` rule is dead code.
- **`os.Chdir` in test** `TestEnsureSQLiteFilesExistInternal` is process-wide and fragile under parallel test execution.
</details>

<details open><summary><h3>Confidence Score: 2/5</h3></summary>

- PR should not be merged until the absolute-path stripping bug in `sqliteDatabasePathInternal` is fixed, as it silently breaks the core feature for any user with an absolute `DATABASE_URL`.
- The overall approach is well-designed and addresses the issue correctly, but the logic bug in `sqliteDatabasePathInternal` — where absolute paths like `file:/app/data/arcane.db` get their leading slash stripped to `app/data/arcane.db` — means the SQLite pre-creation/ownership step silently does nothing for a common configuration. The test suite even asserts the wrong behavior, masking the defect. The missing parent-directory creation is a secondary correctness concern.
- `backend/pkg/libarcane/startup/runtime_identity.go` (absolute path stripping + missing mkdir) and `backend/pkg/libarcane/startup/runtime_identity_test.go` (test asserting wrong path and unsafe `os.Chdir`).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/pkg/libarcane/startup/runtime_identity.go | Core implementation of PUID/PGID runtime identity switching. Contains a logic bug where absolute SQLite paths (e.g., `file:/app/data/arcane.db`) have their leading slash stripped, causing the pre-creation/ownership step to target the wrong path. Also missing parent-directory creation before `os.OpenFile`. |
| backend/pkg/libarcane/startup/runtime_identity_linux.go | Linux-specific re-exec implementation using `syscall.Credential`. Signal forwarding and exit-code propagation are handled correctly. No issues found. |
| backend/pkg/libarcane/startup/runtime_identity_test.go | Good unit test coverage for the parsing helpers. The `TestEnsureSQLiteFilesExistInternal` test uses `os.Chdir` which is process-wide and unsafe under parallel execution. The `TestSQLiteDatabasePath` test asserts the buggy behavior (stripped absolute path) rather than the expected correct path. |
| backend/internal/bootstrap/bootstrap.go | Calls `startup.ApplyRequestedRuntimeIdentity()` immediately after `godotenv.Load()`, ensuring identity is applied before config or DB initialization. Correct placement and error propagation. |
| tests/spec/docker-runtime-identity.spec.ts | Comprehensive end-to-end Docker integration tests covering default, PUID/PGID, and TCP proxy scenarios. Uses `execFileSync` for Docker commands, has good cleanup, and validates both process UID/GID and file ownership. Contains a `setTimeout(resolve, 2000)` busy-wait for the proxy container; a proper health-poll would be more robust but is a minor concern. |

</details>

</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Abackend%2Fpkg%2Flibarcane%2Fstartup%2Fruntime_identity.go%3A164-175%0A**Absolute%20SQLite%20path%20has%20leading%20slash%20stripped**%0A%0A%60sqliteDatabasePathInternal%60%20unconditionally%20calls%20%60strings.TrimPrefix%28pathPart%2C%20%22%2F%22%29%60%20after%20extracting%20the%20path%20from%20the%20parsed%20URL.%20For%20absolute%20%60DATABASE_URL%60%20values%20like%20%60file%3A%2Fapp%2Fdata%2Farcane.db%60%2C%20%60url.Parse%60%20sets%20%60Opaque%60%20to%20%60%22%22%60%20and%20%60Path%60%20to%20%60%2Fapp%2Fdata%2Farcane.db%60.%20After%20the%20trim%2C%20the%20returned%20path%20is%20%60app%2Fdata%2Farcane.db%60%20%28relative%29%2C%20not%20%60%2Fapp%2Fdata%2Farcane.db%60%20%28absolute%29.%20The%20test%20at%20line%2083%E2%80%9387%20explicitly%20asserts%20this%20incorrect%20behavior%3A%0A%0A%60%60%60go%0Arequire.Equal%28t%2C%20%22app%2Fcustom%2Farcane.db%22%2C%20path%29%0A%60%60%60%0A%0AIf%20the%20container%20working%20directory%20is%20%60%2Fapp%60%2C%20%60os.OpenFile%28%22app%2Fdata%2Farcane.db%22%2C%20...%29%60%20would%20resolve%20to%20%60%2Fapp%2Fapp%2Fdata%2Farcane.db%60%20%E2%80%94%20a%20completely%20wrong%20path%20%E2%80%94%20meaning%20the%20pre-creation%20%28and%20thus%20the%20ownership%29%20step%20silently%20does%20nothing%20for%20users%20who%20configure%20an%20absolute%20database%20path.%0A%0AThe%20fix%20is%20to%20only%20strip%20the%20leading%20slash%20from%20the%20opaque%2Frelative%20portion%2C%20preserving%20absolute%20paths%3A%0A%0A%60%60%60go%0Aif%20parsed.Opaque%20!%3D%20%22%22%20%7B%0A%20%20%20%20pathPart%20%3D%20strings.TrimPrefix%28parsed.Opaque%2C%20%22%2F%22%29%0A%7D%20else%20%7B%0A%20%20%20%20pathPart%20%3D%20parsed.Path%20%2F%2F%20keep%20the%20absolute%20path%20as-is%0A%7D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20%23%20Golang%20Pro%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A%23%23%23%20Issue%202%20of%204%0Abackend%2Fpkg%2Flibarcane%2Fstartup%2Fruntime_identity.go%3A131-149%0A**Parent%20directory%20not%20created%20before%20%60os.OpenFile%60**%0A%0A%60ensureSQLiteFilesExistInternal%60%20calls%20%60os.OpenFile%60%20with%20%60O_CREATE%60%20but%20does%20not%20first%20ensure%20the%20parent%20directory%20of%20the%20SQLite%20file%20exists.%20If%20the%20database%20URL%20resolves%20to%20a%20path%20like%20%60data%2Farcane.db%60%20and%20the%20%60data%2F%60%20subdirectory%20has%20not%20yet%20been%20created%2C%20%60os.OpenFile%60%20will%20return%20a%20%22no%20such%20file%20or%20directory%22%20error%2C%20causing%20%60ApplyRequestedRuntimeIdentity%60%20to%20fail%20on%20first%20run.%0A%0A%60prepareWritablePathsInternal%60%20creates%20%60%2Fapp%2Fdata%60%20only%20when%20the%20re-exec%20path%20is%20taken%20%28i.e.%2C%20running%20as%20root%29.%20When%20%60euid%20%3D%3D%20req.UID%20%26%26%20euid%20!%3D%200%60%20%E2%80%94%20the%20%22already%20the%20right%20user%22%20early-return%20path%20%E2%80%94%20no%20directory%20setup%20occurs%20before%20this%20function%20is%20called.%0A%0AAdding%20an%20%60os.MkdirAll%60%20call%20for%20the%20parent%20directory%20makes%20this%20robust%3A%0A%0A%60%60%60go%0Afunc%20ensureSQLiteFilesExistInternal%28databaseURL%20string%29%20error%20%7B%0A%20%20%20%20sqlitePath%2C%20ok%2C%20err%20%3A%3D%20sqliteDatabasePathInternal%28databaseURL%29%0A%20%20%20%20if%20err%20!%3D%20nil%20%7B%0A%20%20%20%20%20%20%20%20return%20err%0A%20%20%20%20%7D%0A%20%20%20%20if%20!ok%20%7B%0A%20%20%20%20%20%20%20%20return%20nil%0A%20%20%20%20%7D%0A%0A%20%20%20%20dir%20%3A%3D%20filepath.Dir%28sqlitePath%29%0A%20%20%20%20if%20dir%20!%3D%20%22%22%20%26%26%20dir%20!%3D%20%22.%22%20%7B%0A%20%20%20%20%20%20%20%20if%20err%20%3A%3D%20os.MkdirAll%28dir%2C%20pkgutils.DirPerm%29%3B%20err%20!%3D%20nil%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20fmt.Errorf%28%22create%20sqlite%20directory%20%25s%3A%20%25w%22%2C%20dir%2C%20err%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%0A%20%20%20%20file%2C%20err%20%3A%3D%20os.OpenFile%28sqlitePath%2C%20os.O_CREATE%7Cos.O_RDWR%2C%20pkgutils.FilePerm%29%0A%20%20%20%20...%0A%7D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20%23%20Go%20Development%20Patterns%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0A%23%23%23%20Issue%203%20of%204%0Abackend%2Fpkg%2Flibarcane%2Fstartup%2Fruntime_identity.go%3A220-229%0A**%60%5C%5C%60%20is%20not%20a%20valid%20mountinfo%20escape%20sequence**%0A%0AThe%20Linux%20kernel%20encodes%20special%20characters%20in%20%60%2Fproc%2Fself%2Fmountinfo%60%20using%20octal%20sequences%20only%3A%20%60%5C040%60%20%28space%29%2C%20%60%5C011%60%20%28tab%29%2C%20%60%5C012%60%20%28newline%29%2C%20%60%5C134%60%20%28backslash%29.%20A%20literal%20double-backslash%20%28%60%5C%5C%60%29%20never%20appears%20in%20a%20well-formed%20mountinfo%20entry%20%E2%80%94%20a%20backslash%20in%20a%20path%20is%20always%20represented%20as%20%60%5C134%60.%0A%0AThe%20%60%5C%5C%60%20%E2%86%92%20%60%5C%60%20replacement%20rule%20is%20therefore%20dead%20code%20for%20valid%20mountinfo%20input.%20More%20importantly%2C%20it%20also%20introduces%20ordering%20ambiguity%3A%20both%20%60%5C%5C%60%20and%20%60%5C134%60%20start%20with%20%60%5C%60%2C%20so%20a%20reader%20must%20verify%20they%20can't%20collide%20%28they%20can't%2C%20since%20%60%5C134%60%20is%20%60%5C%60%2B%601%60%2B%603%60%2B%604%60%20whereas%20%60%5C%5C%60%20requires%20%60%5C%60%2B%60%5C%60%20at%20the%20same%20position%29.%20Remove%20the%20%60%5C%5C%60%20rule%20to%20match%20the%20actual%20kernel%20encoding%3A%0A%0A%60%60%60suggestion%0Afunc%20unescapeMountInfoPathInternal%28path%20string%29%20string%20%7B%0A%09replacer%20%3A%3D%20strings.NewReplacer%28%0A%09%09%60%5C040%60%2C%20%22%20%22%2C%0A%09%09%60%5C011%60%2C%20%22%5Ct%22%2C%0A%09%09%60%5C012%60%2C%20%22%5Cn%22%2C%0A%09%09%60%5C134%60%2C%20%60%5C%60%2C%0A%09%29%0A%09return%20replacer.Replace%28path%29%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Abackend%2Fpkg%2Flibarcane%2Fstartup%2Fruntime_identity_test.go%3A97-113%0A**%60os.Chdir%60%20in%20tests%20is%20process-wide%20and%20unsafe%20with%20parallel%20execution**%0A%0A%60os.Chdir%60%20changes%20the%20working%20directory%20of%20the%20entire%20OS%20process%2C%20not%20just%20the%20current%20goroutine.%20If%20any%20other%20test%20in%20the%20package%20runs%20concurrently%20%28e.g.%2C%20if%20%60t.Parallel%28%29%60%20is%20added%20in%20the%20future%2C%20or%20the%20test%20binary%20is%20run%20with%20%60-parallel%60%29%2C%20this%20will%20silently%20corrupt%20their%20relative-path%20operations.%0A%0AA%20safer%20pattern%20is%20to%20make%20%60ensureSQLiteFilesExistInternal%60%20accept%20a%20%60baseDir%60%20parameter%2C%20or%20to%20use%20%60filepath.Join%28tempDir%2C%20%22arcane.db%22%29%60%20with%20an%20absolute%20URL%20in%20the%20test%3A%0A%0A%60%60%60go%0Afunc%20TestEnsureSQLiteFilesExistInternal%28t%20*testing.T%29%20%7B%0A%20%20%20%20tempDir%20%3A%3D%20t.TempDir%28%29%0A%20%20%20%20dbPath%20%3A%3D%20filepath.Join%28tempDir%2C%20%22arcane.db%22%29%0A%20%20%20%20require.NoError%28t%2C%20ensureSQLiteFilesExistInternal%28%22file%3A%22%2BdbPath%29%29%0A%20%20%20%20require.FileExists%28t%2C%20dbPath%29%0A%20%20%20%20require.NoFileExists%28t%2C%20dbPath%2B%22-wal%22%29%0A%20%20%20%20require.NoFileExists%28t%2C%20dbPath%2B%22-shm%22%29%0A%7D%0A%60%60%60%0A%0AThis%20avoids%20modifying%20global%20process%20state%20while%20achieving%20the%20same%20coverage.%0A%0A**Rule%20Used%3A**%20%23%20Golang%20Pro%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/libarcane/startup/runtime_identity.go
Line: 164-175

Comment:
**Absolute SQLite path has leading slash stripped**

`sqliteDatabasePathInternal` unconditionally calls `strings.TrimPrefix(pathPart, "/")` after extracting the path from the parsed URL. For absolute `DATABASE_URL` values like `file:/app/data/arcane.db`, `url.Parse` sets `Opaque` to `""` and `Path` to `/app/data/arcane.db`. After the trim, the returned path is `app/data/arcane.db` (relative), not `/app/data/arcane.db` (absolute). The test at line 83–87 explicitly asserts this incorrect behavior:

```go
require.Equal(t, "app/custom/arcane.db", path)
```

If the container working directory is `/app`, `os.OpenFile("app/data/arcane.db", ...)` would resolve to `/app/app/data/arcane.db` — a completely wrong path — meaning the pre-creation (and thus the ownership) step silently does nothing for users who configure an absolute database path.

The fix is to only strip the leading slash from the opaque/relative portion, preserving absolute paths:

```go
if parsed.Opaque != "" {
    pathPart = strings.TrimPrefix(parsed.Opaque, "/")
} else {
    pathPart = parsed.Path // keep the absolute path as-is
}
```

**Rule Used:** # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/libarcane/startup/runtime_identity.go
Line: 131-149

Comment:
**Parent directory not created before `os.OpenFile`**

`ensureSQLiteFilesExistInternal` calls `os.OpenFile` with `O_CREATE` but does not first ensure the parent directory of the SQLite file exists. If the database URL resolves to a path like `data/arcane.db` and the `data/` subdirectory has not yet been created, `os.OpenFile` will return a "no such file or directory" error, causing `ApplyRequestedRuntimeIdentity` to fail on first run.

`prepareWritablePathsInternal` creates `/app/data` only when the re-exec path is taken (i.e., running as root). When `euid == req.UID && euid != 0` — the "already the right user" early-return path — no directory setup occurs before this function is called.

Adding an `os.MkdirAll` call for the parent directory makes this robust:

```go
func ensureSQLiteFilesExistInternal(databaseURL string) error {
    sqlitePath, ok, err := sqliteDatabasePathInternal(databaseURL)
    if err != nil {
        return err
    }
    if !ok {
        return nil
    }

    dir := filepath.Dir(sqlitePath)
    if dir != "" && dir != "." {
        if err := os.MkdirAll(dir, pkgutils.DirPerm); err != nil {
            return fmt.Errorf("create sqlite directory %s: %w", dir, err)
        }
    }

    file, err := os.OpenFile(sqlitePath, os.O_CREATE|os.O_RDWR, pkgutils.FilePerm)
    ...
}
```

**Rule Used:** # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/libarcane/startup/runtime_identity.go
Line: 220-229

Comment:
**`\\` is not a valid mountinfo escape sequence**

The Linux kernel encodes special characters in `/proc/self/mountinfo` using octal sequences only: `\040` (space), `\011` (tab), `\012` (newline), `\134` (backslash). A literal double-backslash (`\\`) never appears in a well-formed mountinfo entry — a backslash in a path is always represented as `\134`.

The `\\` → `\` replacement rule is therefore dead code for valid mountinfo input. More importantly, it also introduces ordering ambiguity: both `\\` and `\134` start with `\`, so a reader must verify they can't collide (they can't, since `\134` is `\`+`1`+`3`+`4` whereas `\\` requires `\`+`\` at the same position). Remove the `\\` rule to match the actual kernel encoding:

```suggestion
func unescapeMountInfoPathInternal(path string) string {
	replacer := strings.NewReplacer(
		`\040`, " ",
		`\011`, "\t",
		`\012`, "\n",
		`\134`, `\`,
	)
	return replacer.Replace(path)
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/libarcane/startup/runtime_identity_test.go
Line: 97-113

Comment:
**`os.Chdir` in tests is process-wide and unsafe with parallel execution**

`os.Chdir` changes the working directory of the entire OS process, not just the current goroutine. If any other test in the package runs concurrently (e.g., if `t.Parallel()` is added in the future, or the test binary is run with `-parallel`), this will silently corrupt their relative-path operations.

A safer pattern is to make `ensureSQLiteFilesExistInternal` accept a `baseDir` parameter, or to use `filepath.Join(tempDir, "arcane.db")` with an absolute URL in the test:

```go
func TestEnsureSQLiteFilesExistInternal(t *testing.T) {
    tempDir := t.TempDir()
    dbPath := filepath.Join(tempDir, "arcane.db")
    require.NoError(t, ensureSQLiteFilesExistInternal("file:"+dbPath))
    require.FileExists(t, dbPath)
    require.NoFileExists(t, dbPath+"-wal")
    require.NoFileExists(t, dbPath+"-shm")
}
```

This avoids modifying global process state while achieving the same coverage.

**Rule Used:** # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: PID and GID not..."](https://github.com/getarcaneapp/arcane/commit/a1fa311fecaf5838e16d8f3702b4ba54c9e9ad80)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Rule used - # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

<!-- /greptile_comment -->