### PR TITLE
fix: certain tty:true containers logs never stream correctly

### DIFF
--- a/backend/internal/api/ws_handler.go
+++ b/backend/internal/api/ws_handler.go
@@ -455,7 +455,14 @@ func (h *WebSocketHandler) startContainerLogHub(containerID, format string, batc
 	lines := make(chan string, 256)
 	go func(ctx context.Context) {
 		defer close(lines)
-		_ = h.containerService.StreamLogs(ctx, containerID, lines, follow, tail, since, timestamps)
+		if err := h.containerService.StreamLogs(ctx, containerID, lines, follow, tail, since, timestamps); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return
+			}
+
+			slog.Warn("container log stream failed", "containerID", containerID, "error", err)
+			broadcastContainerLogStreamErrorInternal(ls, err)
+		}
 	}(ctx)
 
 	if format == "json" {
@@ -487,6 +494,28 @@ func (h *WebSocketHandler) startContainerLogHub(containerID, format string, batc
 	}
 
 	return ls.hub
+}
+
+func broadcastContainerLogStreamErrorInternal(stream *wsLogStream, err error) {
+	if stream == nil || stream.hub == nil || err == nil {
+		return
+	}
+
+	message := "Failed to stream container logs: " + err.Error()
+	if stream.format == "json" {
+		msg := ws.LogMessage{
+			Seq:       stream.seq.Add(1),
+			Level:     "error",
+			Message:   message,
+			Timestamp: ws.NowRFC3339(),
+		}
+		if b, marshalErr := json.Marshal(msg); marshalErr == nil {
+			stream.hub.Broadcast(b)
+		}
+		return
+	}
+
+	stream.hub.Broadcast([]byte(message))
 }
 
 // ContainerStats streams container stats over WebSocket.

--- a/backend/internal/api/ws_handler_test.go
+++ b/backend/internal/api/ws_handler_test.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	ws "github.com/getarcaneapp/arcane/backend/pkg/libarcane/ws"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBroadcastContainerLogStreamErrorInternal_JSON(t *testing.T) {
+	hub := ws.NewHub(10)
+	ctx := t.Context()
+	go hub.Run(ctx)
+
+	clientConn, serverConn, cleanup := newTestWSPairInternal(t)
+	t.Cleanup(cleanup)
+
+	ws.ServeClient(ctx, hub, serverConn)
+
+	stream := &wsLogStream{
+		hub:    hub,
+		format: "json",
+	}
+
+	broadcastContainerLogStreamErrorInternal(stream, errors.New("boom"))
+
+	_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, payload, err := clientConn.ReadMessage()
+	require.NoError(t, err)
+
+	var message ws.LogMessage
+	require.NoError(t, json.Unmarshal(payload, &message))
+	require.Equal(t, "error", message.Level)
+	require.Equal(t, "Failed to stream container logs: boom", message.Message)
+	require.Empty(t, message.ContainerID)
+	require.NotEmpty(t, message.Timestamp)
+}
+
+func TestBroadcastContainerLogStreamErrorInternal_Text(t *testing.T) {
+	hub := ws.NewHub(10)
+	ctx := t.Context()
+	go hub.Run(ctx)
+
+	clientConn, serverConn, cleanup := newTestWSPairInternal(t)
+	t.Cleanup(cleanup)
+
+	ws.ServeClient(ctx, hub, serverConn)
+
+	stream := &wsLogStream{
+		hub:    hub,
+		format: "text",
+	}
+
+	broadcastContainerLogStreamErrorInternal(stream, errors.New("boom"))
+
+	_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, payload, err := clientConn.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, "Failed to stream container logs: boom", string(payload))
+}
+
+func newTestWSPairInternal(t *testing.T) (clientConn *websocket.Conn, serverConn *websocket.Conn, cleanup func()) {
+	t.Helper()
+	serverReady := make(chan *websocket.Conn, 1)
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		serverReady <- conn
+	}))
+
+	url := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	require.NoError(t, err)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+
+	serverConn = <-serverReady
+
+	return clientConn, serverConn, func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+		server.Close()
+	}
+}

--- a/backend/internal/services/container_service.go
+++ b/backend/internal/services/container_service.go
@@ -609,6 +609,11 @@ func (s *ContainerService) StreamLogs(ctx context.Context, containerID string, l
 		return fmt.Errorf("failed to connect to Docker: %w", err)
 	}
 
+	containerInspect, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, containerID, client.ContainerInspectOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to inspect container for logs: %w", err)
+	}
+
 	options := client.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
@@ -624,114 +629,147 @@ func (s *ContainerService) StreamLogs(ctx context.Context, containerID string, l
 	}
 	defer func() { _ = logs.Close() }()
 
+	isTTY := containerInspect.Container.Config != nil && containerInspect.Container.Config.Tty
+	return s.streamContainerLogsInternal(ctx, logs, logsChan, follow, isTTY)
+}
+
+func (s *ContainerService) streamContainerLogsInternal(ctx context.Context, logs io.ReadCloser, logsChan chan<- string, follow bool, isTTY bool) error {
+	if isTTY {
+		return s.streamRawLogsInternal(ctx, logs, logsChan)
+	}
 	if follow {
 		return s.streamMultiplexedLogs(ctx, logs, logsChan)
 	}
-
-	return s.readAllLogs(logs, logsChan)
+	return s.readAllLogs(ctx, logs, logsChan)
 }
 
-func (s *ContainerService) streamMultiplexedLogs(ctx context.Context, logs io.ReadCloser, logsChan chan<- string) error {
+func (s *ContainerService) streamRawLogsInternal(ctx context.Context, logs io.Reader, logsChan chan<- string) error {
+	return s.readLogsFromReader(ctx, logs, logsChan, "")
+}
+
+func (s *ContainerService) streamMultiplexedLogs(ctx context.Context, logs io.Reader, logsChan chan<- string) error {
 	// Use stdcopy to demultiplex Docker's stream format
 	// Docker multiplexes stdout and stderr in a special format
 	stdoutReader, stdoutWriter := io.Pipe()
 	stderrReader, stderrWriter := io.Pipe()
+	errCh := make(chan error, 3)
 
 	// Start demultiplexing in a goroutine
 	go func() {
-		defer func() { _ = stdoutWriter.Close() }()
-		defer func() { _ = stderrWriter.Close() }()
 		_, err := stdcopy.StdCopy(stdoutWriter, stderrWriter, logs)
 		if err != nil && !errors.Is(err, io.EOF) {
-			fmt.Printf("Error demultiplexing logs: %v\n", err)
+			_ = stdoutWriter.CloseWithError(err)
+			_ = stderrWriter.CloseWithError(err)
+			errCh <- fmt.Errorf("failed to demultiplex logs: %w", err)
+			return
 		}
+		_ = stdoutWriter.Close()
+		_ = stderrWriter.Close()
+		errCh <- nil
 	}()
 
 	// Read from both stdout and stderr concurrently
-	done := make(chan error, 2)
-
-	// Read stdout
 	go func() {
-		done <- s.readLogsFromReader(ctx, stdoutReader, logsChan, "stdout")
+		defer func() { _ = stdoutReader.Close() }()
+		errCh <- s.readLogsFromReader(ctx, stdoutReader, logsChan, "")
 	}()
 
-	// Read stderr
 	go func() {
-		done <- s.readLogsFromReader(ctx, stderrReader, logsChan, "stderr")
+		defer func() { _ = stderrReader.Close() }()
+		errCh <- s.readLogsFromReader(ctx, stderrReader, logsChan, "[STDERR] ")
 	}()
 
-	// Wait for context cancellation or error
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case err := <-done:
-		if err != nil && !errors.Is(err, io.EOF) {
-			return err
-		}
-		// Wait for the other goroutine or context cancellation
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-done:
-			return nil
+	var firstErr error
+	for range 3 {
+		err := <-errCh
+		switch {
+		case err == nil:
+		case errors.Is(err, io.EOF):
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		default:
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	return firstErr
 }
 
 // readLogsFromReader reads logs line by line from a reader
-func (s *ContainerService) readLogsFromReader(ctx context.Context, reader io.Reader, logsChan chan<- string, source string) error {
-	scanner := bufio.NewScanner(reader)
+func (s *ContainerService) readLogsFromReader(ctx context.Context, reader io.Reader, logsChan chan<- string, prefix string) error {
+	bufferedReader := bufio.NewReader(reader)
 
-	for scanner.Scan() {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			line := scanner.Text()
-			if line != "" {
-				// Add source prefix for stderr logs
-				if source == "stderr" {
-					line = "[STDERR] " + line
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		line, err := bufferedReader.ReadString('\n')
+		if len(line) > 0 {
+			trimmed := strings.TrimRight(line, "\r\n")
+			if trimmed != "" {
+				if prefix != "" {
+					trimmed = prefix + trimmed
 				}
 
 				select {
-				case logsChan <- line:
+				case logsChan <- trimmed:
 				case <-ctx.Done():
 					return ctx.Err()
 				}
 			}
 		}
-	}
 
-	return scanner.Err()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
 }
 
-func (s *ContainerService) readAllLogs(logs io.ReadCloser, logsChan chan<- string) error {
+func (s *ContainerService) readAllLogs(ctx context.Context, logs io.ReadCloser, logsChan chan<- string) error {
 	stdoutBuf := &strings.Builder{}
 	stderrBuf := &strings.Builder{}
+	stdCopyDone := make(chan struct{})
+	defer close(stdCopyDone)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = logs.Close()
+		case <-stdCopyDone:
+		}
+	}()
 
 	_, err := stdcopy.StdCopy(stdoutBuf, stderrBuf, logs)
 	if err != nil && !errors.Is(err, io.EOF) {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return fmt.Errorf("failed to demultiplex logs: %w", err)
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
 	}
 
 	// Send stdout lines
 	if stdoutBuf.Len() > 0 {
-		lines := strings.SplitSeq(strings.TrimRight(stdoutBuf.String(), "\n"), "\n")
-		for line := range lines {
-			if line != "" {
-				logsChan <- line
-			}
+		if err := s.readLogsFromReader(ctx, strings.NewReader(stdoutBuf.String()), logsChan, ""); err != nil {
+			return err
 		}
 	}
 
 	// Send stderr lines with prefix
 	if stderrBuf.Len() > 0 {
-		lines := strings.SplitSeq(strings.TrimRight(stderrBuf.String(), "\n"), "\n")
-		for line := range lines {
-			if line != "" {
-				logsChan <- "[STDERR] " + line
-			}
+		if err := s.readLogsFromReader(ctx, strings.NewReader(stderrBuf.String()), logsChan, "[STDERR] "); err != nil {
+			return err
 		}
 	}
 

--- a/backend/internal/services/container_service_test.go
+++ b/backend/internal/services/container_service_test.go
@@ -1,8 +1,14 @@
 package services
 
 import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
 	"net/netip"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
 	containertypes "github.com/getarcaneapp/arcane/types/container"
@@ -95,6 +101,150 @@ func TestBuildCleanNetworkingConfigInternalPreservesEndpointSettings(t *testing.
 	require.Nil(t, out.EndpointsConfig["bridge"].IPAMConfig)
 }
 
+func TestStreamContainerLogs_NonTTYFollowDemultiplexesStdoutAndStderr(t *testing.T) {
+	var stream bytes.Buffer
+	writeDockerLogFrameInternal(t, &stream, 1, "stdout line\n")
+	writeDockerLogFrameInternal(t, &stream, 2, "stderr line\n")
+
+	service := &ContainerService{}
+	logsChan := make(chan string, 4)
+
+	err := service.streamContainerLogsInternal(t.Context(), io.NopCloser(bytes.NewReader(stream.Bytes())), logsChan, true, false)
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, []string{"stdout line", "[STDERR] stderr line"}, drainLogLinesInternal(logsChan))
+}
+
+func TestStreamContainerLogs_TTYFollowStreamsRawOutput(t *testing.T) {
+	service := &ContainerService{}
+	logsChan := make(chan string, 4)
+
+	err := service.streamContainerLogsInternal(t.Context(), io.NopCloser(strings.NewReader("first line\nsecond line")), logsChan, true, true)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"first line", "second line"}, drainLogLinesInternal(logsChan))
+}
+
+func TestStreamContainerLogs_NonTTYSnapshotDemultiplexesStdoutAndStderr(t *testing.T) {
+	var stream bytes.Buffer
+	writeDockerLogFrameInternal(t, &stream, 1, "stdout snapshot\n")
+	writeDockerLogFrameInternal(t, &stream, 2, "stderr snapshot\n")
+
+	service := &ContainerService{}
+	logsChan := make(chan string, 4)
+
+	err := service.streamContainerLogsInternal(t.Context(), io.NopCloser(bytes.NewReader(stream.Bytes())), logsChan, false, false)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"stdout snapshot", "[STDERR] stderr snapshot"}, drainLogLinesInternal(logsChan))
+}
+
+func TestStreamContainerLogs_TTYSnapshotStreamsRawOutput(t *testing.T) {
+	service := &ContainerService{}
+	logsChan := make(chan string, 4)
+
+	err := service.streamContainerLogsInternal(t.Context(), io.NopCloser(strings.NewReader("snapshot line\ntrailing line")), logsChan, false, true)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"snapshot line", "trailing line"}, drainLogLinesInternal(logsChan))
+}
+
+func TestReadLogsFromReader_HandlesLongLinesAndPartialEOF(t *testing.T) {
+	longLine := strings.Repeat("a", 70*1024)
+	service := &ContainerService{}
+	logsChan := make(chan string, 4)
+
+	err := service.readLogsFromReader(t.Context(), strings.NewReader(longLine+"\npartial tail"), logsChan, "")
+	require.NoError(t, err)
+
+	require.Equal(t, []string{longLine, "partial tail"}, drainLogLinesInternal(logsChan))
+}
+
+func TestStreamContainerLogs_TTYPythonLikeFollowDoesNotReturnEmptyLogs(t *testing.T) {
+	service := &ContainerService{}
+	logsChan := make(chan string, 4)
+
+	err := service.streamContainerLogsInternal(
+		t.Context(),
+		io.NopCloser(strings.NewReader("2026-03-22 10:15:00 - INFO - Starting miner\n2026-03-22 10:15:01 - INFO - Connected")),
+		logsChan,
+		true,
+		true,
+	)
+	require.NoError(t, err)
+
+	lines := drainLogLinesInternal(logsChan)
+	require.NotEmpty(t, lines)
+	require.Equal(t, []string{
+		"2026-03-22 10:15:00 - INFO - Starting miner",
+		"2026-03-22 10:15:01 - INFO - Connected",
+	}, lines)
+}
+
+func TestStreamMultiplexedLogs_ContextCancelDoesNotDeadlock(t *testing.T) {
+	var stream bytes.Buffer
+	writeDockerLogFrameInternal(t, &stream, 1, "line 1\n")
+	writeDockerLogFrameInternal(t, &stream, 1, "line 2\n")
+	writeDockerLogFrameInternal(t, &stream, 1, "line 3\n")
+
+	service := &ContainerService{}
+	logsChan := make(chan string, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- service.streamMultiplexedLogs(ctx, io.NopCloser(bytes.NewReader(stream.Bytes())), logsChan)
+	}()
+
+	require.Eventually(t, func() bool {
+		return len(logsChan) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("streamMultiplexedLogs did not exit after cancellation")
+	}
+}
+
+func TestReadAllLogs_ContextCancelClosesReader(t *testing.T) {
+	service := &ContainerService{}
+	logsChan := make(chan string, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reader := &blockingReadCloser{readStarted: make(chan struct{}), closeCalled: make(chan struct{})}
+	done := make(chan error, 1)
+	go func() {
+		done <- service.readAllLogs(ctx, reader, logsChan)
+	}()
+
+	select {
+	case <-reader.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("readAllLogs did not start reading")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("readAllLogs did not exit after cancellation")
+	}
+
+	select {
+	case <-reader.closeCalled:
+	case <-time.After(time.Second):
+		t.Fatal("readAllLogs did not close the reader on cancellation")
+	}
+}
+
 func newGroupedContainerSummary(name string, project string) containertypes.Summary {
 	labels := map[string]string{}
 	if project != "" {
@@ -107,4 +257,53 @@ func newGroupedContainerSummary(name string, project string) containertypes.Summ
 		Labels: labels,
 		State:  "running",
 	}
+}
+
+func drainLogLinesInternal(logsChan chan string) []string {
+	close(logsChan)
+
+	lines := make([]string, 0, len(logsChan))
+	for line := range logsChan {
+		lines = append(lines, line)
+	}
+
+	return lines
+}
+
+func writeDockerLogFrameInternal(t *testing.T, buffer *bytes.Buffer, streamType byte, payload string) {
+	t.Helper()
+
+	header := make([]byte, 8)
+	header[0] = streamType
+	binary.BigEndian.PutUint32(header[4:], uint32(len(payload)))
+
+	_, err := buffer.Write(header)
+	require.NoError(t, err)
+	_, err = buffer.WriteString(payload)
+	require.NoError(t, err)
+}
+
+type blockingReadCloser struct {
+	readStarted chan struct{}
+	closeCalled chan struct{}
+}
+
+func (r *blockingReadCloser) Read(_ []byte) (int, error) {
+	select {
+	case <-r.readStarted:
+	default:
+		close(r.readStarted)
+	}
+
+	<-r.closeCalled
+	return 0, io.EOF
+}
+
+func (r *blockingReadCloser) Close() error {
+	select {
+	case <-r.closeCalled:
+	default:
+		close(r.closeCalled)
+	}
+	return nil
 }

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -1695,7 +1695,7 @@ func TestProjectService_UpdateProject_WritesThroughSymlinkedProjectPath(t *testi
 	project := &models.Project{
 		BaseModel: models.BaseModel{ID: "proj-symlink-update"},
 		Name:      "demo",
-		DirName:   ptr("demo"),
+		DirName:   new("demo"),
 		Path:      linkPath,
 		Status:    models.ProjectStatusStopped,
 	}
@@ -1704,7 +1704,7 @@ func TestProjectService_UpdateProject_WritesThroughSymlinkedProjectPath(t *testi
 	updatedCompose := "services:\n  app:\n    image: nginx:1.27-alpine\n"
 	updatedEnv := "FOO=updated\n"
 
-	updated, err := svc.UpdateProject(ctx, project.ID, nil, ptr(updatedCompose), ptr(updatedEnv), models.User{
+	updated, err := svc.UpdateProject(ctx, project.ID, nil, new(updatedCompose), new(updatedEnv), models.User{
 		BaseModel: models.BaseModel{ID: "u1"},
 		Username:  "tester",
 	})

--- a/backend/pkg/fswatch/watcher_test.go
+++ b/backend/pkg/fswatch/watcher_test.go
@@ -20,8 +20,7 @@ func TestWatcher_StartWatchesExistingSymlinkDirectoriesWhenEnabled(t *testing.T)
 	require.NoError(t, os.Symlink(targetPath, linkPath))
 
 	changeCh := make(chan struct{}, 1)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	watcher, err := NewWatcher(root, WatcherOptions{
 		Debounce:          25 * time.Millisecond,
@@ -59,8 +58,7 @@ func TestWatcher_StartSkipsExistingSymlinkDirectoriesWhenDisabled(t *testing.T) 
 	require.NoError(t, os.Symlink(targetPath, linkPath))
 
 	changeCh := make(chan struct{}, 1)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	watcher, err := NewWatcher(root, WatcherOptions{
 		Debounce: 25 * time.Millisecond,


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:https://github.com/getarcaneapp/arcane/issues/1663

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a long-standing issue where containers configured with `tty: true` produced empty or garbled log streams. The root cause is that Docker's `ContainerLogs` API returns raw bytes for TTY containers (no header framing), but the existing code always routed logs through `stdcopy.StdCopy`, which expects Docker's multiplexed stream format. A container inspect call is added in `StreamLogs` to detect the TTY flag, and a new dispatch layer (`streamContainerLogs`) routes TTY containers directly to a plain `readLogsFromReader` path while preserving the multiplexed path for normal containers.

**Key changes:**
- `StreamLogs` now inspects the container config to detect `tty: true` before opening the log stream.
- New `streamContainerLogs` dispatcher: TTY → `streamRawLogs`, non-TTY + follow → `streamMultiplexedLogs`, non-TTY + snapshot → `readAllLogs`.
- `readLogsFromReader` switched from `bufio.Scanner` (64 KB line limit) to `bufio.NewReader.ReadString`, removing the hard cap on line length and correctly handling partial last lines without a trailing newline.
- `streamMultiplexedLogs` refactored to use a single `errCh` of capacity 3 and unconditionally drain all goroutines before returning, eliminating the previous `select`-based early-exit that could leave goroutines running after the function returned.
- `ws_handler.go` goroutine now handles `StreamLogs` errors: context-cancellation errors are silently discarded; real errors are logged and broadcast to connected WebSocket clients via the new `broadcastContainerLogStreamErrorInternal`.
- Three `ptr(...)` call sites in tests migrated to `new(...)` per the project's Go 1.26 `//go:fix inline` convention.
- Two `fswatch` tests simplified to use `t.Context()`.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge once the previously flagged naming-convention and pipe-reader goroutine concerns are considered; the core TTY fix is correct and well-tested.
- The primary bug is correctly identified and fixed. The new dispatch logic is straightforward, tests cover all four TTY × follow combinations plus a long-line regression case. The two open concerns from the previous review cycle (unexported method naming, theoretical pipe-reader deadlock in `streamMultiplexedLogs`) are pre-existing or low-risk in production. Two new P2 style notes are left in this review but neither blocks merging.
- backend/internal/services/container_service.go — the `stdcopy.StdCopy` call in `readAllLogs` is not context-interruptible; and the previous review's goroutine lifecycle concern in `streamMultiplexedLogs` remains open.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/container_service.go | Core fix: adds `ContainerInspect` to detect TTY containers and routes them through `streamRawLogs` (plain line reader) instead of the multiplexed `stdcopy` path. Also refactors `readLogsFromReader` to use `bufio.NewReader.ReadString` (no 64 KB line limit) and propagates context into `readAllLogs`. Logic is correct; minor: `readAllLogs` still holds the Docker connection during `stdcopy.StdCopy` across context cancellation. |
| backend/internal/api/ws_handler.go | Adds proper error handling for `StreamLogs` failures: context-cancellation errors are silently swallowed, real errors are logged and broadcast to connected clients via the new `broadcastContainerLogStreamErrorInternal`. Minor inconsistency: error broadcast sets `ContainerID` on `ws.LogMessage` but the normal forwarding path does not. |
| backend/internal/api/ws_handler_test.go | New test file covering `broadcastContainerLogStreamErrorInternal` for both JSON and text formats. Uses an in-process WebSocket pair helper. Hub's unbuffered `register` channel guarantees the client is fully registered before broadcast fires, so no race condition. |
| backend/internal/services/container_service_test.go | Adds thorough table-style tests for TTY vs non-TTY × follow vs snapshot routing, long-line handling, and the Python-logger regression case. Helper functions `drainLogLinesInternal` and `writeDockerLogFrameInternal` are clean and self-contained. |
| backend/internal/services/project_service_test.go | Migrates three `ptr(...)` call sites to `new(...)` inline form per the project's Go 1.26 style convention (`//go:fix inline`). No logic changes. |
| backend/pkg/fswatch/watcher_test.go | Simplifies two tests by replacing manual `context.WithCancel` + `defer cancel()` pairs with `t.Context()`. Pure cleanup, no logic changes. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/internal/services/container_service.go`, line 735-742 ([link](https://github.com/getarcaneapp/arcane/blob/de337e74248132bfa71e97d4e0da722c386c7ed5/backend/internal/services/container_service.go#L735-L742)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`stdcopy.StdCopy` call in `readAllLogs` is not context-aware**

   The `stdcopy.StdCopy(stdoutBuf, stderrBuf, logs)` call on line 739 cannot be interrupted by context cancellation. For the non-follow snapshot path this is generally fine (Docker closes the stream after delivering historical logs), but if the underlying reader stalls — e.g. a very slow container with a large log backlog — the goroutine will block here even after the WebSocket client has disconnected, holding the Docker connection open until the read completes.

   Consider wrapping `logs` in a context-aware reader, or at minimum documenting this limitation with a comment.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/container_service.go
   Line: 735-742

   Comment:
   **`stdcopy.StdCopy` call in `readAllLogs` is not context-aware**

   The `stdcopy.StdCopy(stdoutBuf, stderrBuf, logs)` call on line 739 cannot be interrupted by context cancellation. For the non-follow snapshot path this is generally fine (Docker closes the stream after delivering historical logs), but if the underlying reader stalls — e.g. a very slow container with a large log backlog — the goroutine will block here even after the WebSocket client has disconnected, holding the Docker connection open until the read completes.

   Consider wrapping `logs` in a context-aware reader, or at minimum documenting this limitation with a comment.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fcontainer_service.go%0ALine%3A%20735-742%0A%0AComment%3A%0A**%60stdcopy.StdCopy%60%20call%20in%20%60readAllLogs%60%20is%20not%20context-aware**%0A%0AThe%20%60stdcopy.StdCopy%28stdoutBuf%2C%20stderrBuf%2C%20logs%29%60%20call%20on%20line%20739%20cannot%20be%20interrupted%20by%20context%20cancellation.%20For%20the%20non-follow%20snapshot%20path%20this%20is%20generally%20fine%20%28Docker%20closes%20the%20stream%20after%20delivering%20historical%20logs%29%2C%20but%20if%20the%20underlying%20reader%20stalls%20%E2%80%94%20e.g.%20a%20very%20slow%20container%20with%20a%20large%20log%20backlog%20%E2%80%94%20the%20goroutine%20will%20block%20here%20even%20after%20the%20WebSocket%20client%20has%20disconnected%2C%20holding%20the%20Docker%20connection%20open%20until%20the%20read%20completes.%0A%0AConsider%20wrapping%20%60logs%60%20in%20a%20context-aware%20reader%2C%20or%20at%20minimum%20documenting%20this%20limitation%20with%20a%20comment.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Finternal%2Fapi%2Fws_handler.go%3A506-514%0A**%60ContainerID%60%20field%20set%20only%20in%20error%20messages%2C%20absent%20in%20normal%20log%20messages**%0A%0AThe%20error%20broadcast%20populates%20%60ws.LogMessage.ContainerID%60%20but%20the%20normal%20log-forwarding%20path%20%28line%20479%29%20does%20not%3A%0A%0A%60%60%60go%0Amsgs%20%3C-%20ws.LogMessage%7B%0A%20%20%20%20Seq%3A%20%20%20%20%20%20%20seq%2C%0A%20%20%20%20Level%3A%20%20%20%20%20level%2C%0A%20%20%20%20Message%3A%20%20%20msg%2C%0A%20%20%20%20Timestamp%3A%20timestamp%2C%0A%20%20%20%20%2F%2F%20ContainerID%20never%20set%0A%7D%0A%60%60%60%0A%0AThis%20makes%20the%20field%20unreliable%20for%20clients%20that%20might%20key%20off%20it.%20If%20%60ContainerID%60%20is%20meaningful%20here%2C%20it%20should%20be%20threaded%20through%20the%20normal%20pipeline%20too%20%28the%20%60wsLogStream%60%20already%20stores%20%60containerID%60%20locally%29.%20If%20it's%20not%20needed%20in%20normal%20messages%2C%20removing%20it%20from%20the%20error%20message%20avoids%20the%20asymmetry.%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Finternal%2Fservices%2Fcontainer_service.go%3A735-742%0A**%60stdcopy.StdCopy%60%20call%20in%20%60readAllLogs%60%20is%20not%20context-aware**%0A%0AThe%20%60stdcopy.StdCopy%28stdoutBuf%2C%20stderrBuf%2C%20logs%29%60%20call%20on%20line%20739%20cannot%20be%20interrupted%20by%20context%20cancellation.%20For%20the%20non-follow%20snapshot%20path%20this%20is%20generally%20fine%20%28Docker%20closes%20the%20stream%20after%20delivering%20historical%20logs%29%2C%20but%20if%20the%20underlying%20reader%20stalls%20%E2%80%94%20e.g.%20a%20very%20slow%20container%20with%20a%20large%20log%20backlog%20%E2%80%94%20the%20goroutine%20will%20block%20here%20even%20after%20the%20WebSocket%20client%20has%20disconnected%2C%20holding%20the%20Docker%20connection%20open%20until%20the%20read%20completes.%0A%0AConsider%20wrapping%20%60logs%60%20in%20a%20context-aware%20reader%2C%20or%20at%20minimum%20documenting%20this%20limitation%20with%20a%20comment.%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/api/ws_handler.go
Line: 506-514

Comment:
**`ContainerID` field set only in error messages, absent in normal log messages**

The error broadcast populates `ws.LogMessage.ContainerID` but the normal log-forwarding path (line 479) does not:

```go
msgs <- ws.LogMessage{
    Seq:       seq,
    Level:     level,
    Message:   msg,
    Timestamp: timestamp,
    // ContainerID never set
}
```

This makes the field unreliable for clients that might key off it. If `ContainerID` is meaningful here, it should be threaded through the normal pipeline too (the `wsLogStream` already stores `containerID` locally). If it's not needed in normal messages, removing it from the error message avoids the asymmetry.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/services/container_service.go
Line: 735-742

Comment:
**`stdcopy.StdCopy` call in `readAllLogs` is not context-aware**

The `stdcopy.StdCopy(stdoutBuf, stderrBuf, logs)` call on line 739 cannot be interrupted by context cancellation. For the non-follow snapshot path this is generally fine (Docker closes the stream after delivering historical logs), but if the underlying reader stalls — e.g. a very slow container with a large log backlog — the goroutine will block here even after the WebSocket client has disconnected, holding the Docker connection open until the read completes.

Consider wrapping `logs` in a context-aware reader, or at minimum documenting this limitation with a comment.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: certain tty:true containers logs ne..."](https://github.com/getarcaneapp/arcane/commit/de337e74248132bfa71e97d4e0da722c386c7ed5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25982234)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->