### PR TITLE
fix: dont schedule disabled jobs

### DIFF
--- a/backend/internal/services/job_service_test.go
+++ b/backend/internal/services/job_service_test.go
@@ -41,6 +41,23 @@ func TestJobService_ListJobs_AnalyticsHeartbeatIsManagedInternally(t *testing.T)
 	require.False(t, analyticsJob.IsContinuous)
 }
 
+func TestJobService_ListJobs_IncludesDisabledAutoHealJob(t *testing.T) {
+	ctx := context.Background()
+	db := setupSettingsTestDB(t)
+
+	settingsSvc, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+	require.NoError(t, settingsSvc.SetBoolSetting(ctx, "autoHealEnabled", false))
+
+	jobSvc := NewJobService(db, settingsSvc, &config.Config{})
+	jobs, err := jobSvc.ListJobs(ctx)
+	require.NoError(t, err)
+
+	autoHealJob := findJobStatusByIDInternal(t, jobs.Jobs, "auto-heal")
+	require.False(t, autoHealJob.Enabled)
+	require.Equal(t, "autoHealInterval", autoHealJob.SettingsKey)
+}
+
 func findJobStatusByIDInternal(t *testing.T, jobs []jobschedule.JobStatus, id string) jobschedule.JobStatus {
 	t.Helper()
 

--- a/backend/pkg/scheduler/auto_heal_job.go
+++ b/backend/pkg/scheduler/auto_heal_job.go
@@ -58,6 +58,10 @@ func (j *AutoHealJob) Name() string {
 	return AutoHealJobName
 }
 
+func (j *AutoHealJob) ShouldSchedule(ctx context.Context) bool {
+	return j.settingsService.GetBoolSetting(ctx, "autoHealEnabled", false)
+}
+
 func (j *AutoHealJob) Schedule(ctx context.Context) string {
 	schedule := j.settingsService.GetStringSetting(ctx, "autoHealInterval", "*/30 * * * * *")
 	if schedule == "" {

--- a/backend/pkg/scheduler/auto_heal_job_test.go
+++ b/backend/pkg/scheduler/auto_heal_job_test.go
@@ -106,6 +106,17 @@ func TestAutoHeal_Schedule_Default(t *testing.T) {
 	require.Equal(t, "auto-heal", job.Name())
 }
 
+func TestAutoHeal_ShouldSchedule(t *testing.T) {
+	ctx := context.Background()
+	_, settingsSvc, _ := setupAnalyticsStateServicesInternal(t)
+	job := NewAutoHealJob(nil, settingsSvc, nil, nil)
+
+	require.False(t, job.ShouldSchedule(ctx))
+
+	require.NoError(t, settingsSvc.SetBoolSetting(ctx, "autoHealEnabled", true))
+	require.True(t, job.ShouldSchedule(ctx))
+}
+
 func TestAutoHeal_ResetRestartTracking(t *testing.T) {
 	job := newTestAutoHealJob()
 

--- a/backend/pkg/scheduler/auto_update_job.go
+++ b/backend/pkg/scheduler/auto_update_job.go
@@ -25,6 +25,12 @@ func (j *AutoUpdateJob) Name() string {
 	return "auto-update"
 }
 
+func (j *AutoUpdateJob) ShouldSchedule(ctx context.Context) bool {
+	enabled := j.settingsService.GetBoolSetting(ctx, "autoUpdate", false)
+	pollingEnabled := j.settingsService.GetBoolSetting(ctx, "pollingEnabled", true)
+	return enabled && pollingEnabled
+}
+
 func (j *AutoUpdateJob) Schedule(ctx context.Context) string {
 	s := j.settingsService.GetStringSetting(ctx, "autoUpdateInterval", "0 0 0 * * *")
 	if s == "" {

--- a/backend/pkg/scheduler/auto_update_job_test.go
+++ b/backend/pkg/scheduler/auto_update_job_test.go
@@ -1,0 +1,25 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutoUpdateJob_ShouldSchedule_RequiresAutoUpdateAndPolling(t *testing.T) {
+	ctx := context.Background()
+	_, settingsSvc, _ := setupAnalyticsStateServicesInternal(t)
+	job := NewAutoUpdateJob(nil, settingsSvc)
+
+	require.False(t, job.ShouldSchedule(ctx))
+
+	require.NoError(t, settingsSvc.SetBoolSetting(ctx, "autoUpdate", true))
+	require.True(t, job.ShouldSchedule(ctx))
+
+	require.NoError(t, settingsSvc.SetBoolSetting(ctx, "pollingEnabled", false))
+	require.False(t, job.ShouldSchedule(ctx))
+
+	require.NoError(t, settingsSvc.SetBoolSetting(ctx, "autoUpdate", false))
+	require.False(t, job.ShouldSchedule(ctx))
+}

--- a/backend/pkg/scheduler/gitops_sync_job.go
+++ b/backend/pkg/scheduler/gitops_sync_job.go
@@ -26,6 +26,10 @@ func (j *GitOpsSyncJob) Name() string {
 	return "gitops-sync"
 }
 
+func (j *GitOpsSyncJob) ShouldSchedule(ctx context.Context) bool {
+	return j.settingsService.GetBoolSetting(ctx, "gitopsSyncEnabled", true)
+}
+
 func (j *GitOpsSyncJob) Schedule(ctx context.Context) string {
 	schedule := j.settingsService.GetStringSetting(ctx, "gitopsSyncInterval", "0 */1 * * * *")
 	if schedule == "" {

--- a/backend/pkg/scheduler/image_polling_job.go
+++ b/backend/pkg/scheduler/image_polling_job.go
@@ -27,6 +27,10 @@ func (j *ImagePollingJob) Name() string {
 	return "image-polling"
 }
 
+func (j *ImagePollingJob) ShouldSchedule(ctx context.Context) bool {
+	return j.settingsService.GetBoolSetting(ctx, "pollingEnabled", true)
+}
+
 func (j *ImagePollingJob) Schedule(ctx context.Context) string {
 	s := j.settingsService.GetStringSetting(ctx, "pollingInterval", "0 0 * * * *")
 	if s == "" {

--- a/backend/pkg/scheduler/scheduled_prune_job.go
+++ b/backend/pkg/scheduler/scheduled_prune_job.go
@@ -31,6 +31,10 @@ func (j *ScheduledPruneJob) Name() string {
 	return ScheduledPruneJobName
 }
 
+func (j *ScheduledPruneJob) ShouldSchedule(ctx context.Context) bool {
+	return j.settingsService.GetBoolSetting(ctx, "scheduledPruneEnabled", false)
+}
+
 func (j *ScheduledPruneJob) Schedule(ctx context.Context) string {
 	schedule := j.settingsService.GetStringSetting(ctx, "scheduledPruneInterval", "0 0 0 * * *")
 	if schedule == "" {

--- a/backend/pkg/scheduler/scheduler.go
+++ b/backend/pkg/scheduler/scheduler.go
@@ -48,44 +48,24 @@ func (js *JobScheduler) GetJob(jobID string) (schedulertypes.Job, bool) {
 
 func (js *JobScheduler) StartScheduler() {
 	for _, job := range js.jobs {
-		currentJob := job
-		schedule := currentJob.Schedule(js.context)
-
-		slog.InfoContext(js.context, "Starting Job", "name", currentJob.Name(), "schedule", schedule)
-
-		entryID, err := js.cron.AddFunc(schedule, func() {
-			slog.InfoContext(js.context, "Job starting", "name", currentJob.Name(), "schedule", schedule)
-			currentJob.Run(js.context)
-			slog.InfoContext(js.context, "Job finished", "name", currentJob.Name())
-		})
-		if err != nil {
-			slog.ErrorContext(js.context, "Failed to schedule job", "name", currentJob.Name(), "schedule", schedule, "error", err)
-			continue
+		if err := js.scheduleJobInternal(js.context, job); err != nil {
+			slog.ErrorContext(js.context, "Failed to schedule job", "name", job.Name(), "error", err)
 		}
-
-		js.entryIDs[currentJob.Name()] = entryID
 	}
 	js.cron.Start()
 }
 
 func (js *JobScheduler) RescheduleJob(ctx context.Context, job schedulertypes.Job) error {
-	schedule := job.Schedule(ctx)
-
 	if entryID, ok := js.entryIDs[job.Name()]; ok {
 		js.cron.Remove(entryID)
+		delete(js.entryIDs, job.Name())
 	}
 
-	entryID, err := js.cron.AddFunc(schedule, func() {
-		slog.InfoContext(ctx, "Job starting", "name", job.Name(), "schedule", schedule)
-		job.Run(ctx)
-		slog.InfoContext(ctx, "Job finished", "name", job.Name())
-	})
-	if err != nil {
+	if err := js.scheduleJobInternal(ctx, job); err != nil {
 		return err
 	}
 
-	js.entryIDs[job.Name()] = entryID
-	slog.DebugContext(ctx, "Job rescheduled", "name", job.Name(), "schedule", schedule, "contextCanceled", ctx.Err() != nil)
+	slog.DebugContext(ctx, "Job rescheduled", "name", job.Name(), "scheduled", js.isJobScheduledInternal(job.Name()), "contextCanceled", ctx.Err() != nil)
 	return nil
 }
 
@@ -99,4 +79,31 @@ func (js *JobScheduler) Run(ctx context.Context) error {
 	<-ctx.Done()
 	js.cron.Stop()
 	return nil
+}
+
+func (js *JobScheduler) scheduleJobInternal(ctx context.Context, job schedulertypes.Job) error {
+	if conditionalJob, ok := job.(schedulertypes.ConditionalJob); ok && !conditionalJob.ShouldSchedule(ctx) {
+		slog.DebugContext(ctx, "Job disabled; not scheduling", "name", job.Name())
+		return nil
+	}
+
+	schedule := job.Schedule(ctx)
+	slog.InfoContext(ctx, "Starting Job", "name", job.Name(), "schedule", schedule)
+
+	entryID, err := js.cron.AddFunc(schedule, func() {
+		slog.InfoContext(ctx, "Job starting", "name", job.Name(), "schedule", schedule)
+		job.Run(ctx)
+		slog.InfoContext(ctx, "Job finished", "name", job.Name())
+	})
+	if err != nil {
+		return err
+	}
+
+	js.entryIDs[job.Name()] = entryID
+	return nil
+}
+
+func (js *JobScheduler) isJobScheduledInternal(jobName string) bool {
+	_, ok := js.entryIDs[jobName]
+	return ok
 }

--- a/backend/pkg/scheduler/scheduler_test.go
+++ b/backend/pkg/scheduler/scheduler_test.go
@@ -25,6 +25,98 @@ func (j *testSchedulerJob) Run(ctx context.Context) {
 	}
 }
 
+type conditionalTestSchedulerJob struct {
+	*testSchedulerJob
+	shouldSchedule func(context.Context) bool
+}
+
+func (j *conditionalTestSchedulerJob) ShouldSchedule(ctx context.Context) bool {
+	if j.shouldSchedule == nil {
+		return true
+	}
+
+	return j.shouldSchedule(ctx)
+}
+
+func TestJobScheduler_StartScheduler_SkipsDisabledConditionalJobs(t *testing.T) {
+	js := NewJobScheduler(context.Background(), nil)
+
+	job := &conditionalTestSchedulerJob{
+		testSchedulerJob: &testSchedulerJob{
+			name:     "test-disabled-startup",
+			schedule: "*/1 * * * * *",
+		},
+		shouldSchedule: func(context.Context) bool { return false },
+	}
+
+	js.RegisterJob(job)
+	js.StartScheduler()
+	defer js.cron.Stop()
+
+	require.NotContains(t, js.entryIDs, job.Name())
+	require.Empty(t, js.cron.Entries())
+}
+
+func TestJobScheduler_RescheduleJob_RemovesEntryWhenDisabled(t *testing.T) {
+	js := NewJobScheduler(context.Background(), nil)
+	enabled := true
+
+	job := &conditionalTestSchedulerJob{
+		testSchedulerJob: &testSchedulerJob{
+			name:     "test-disabled-reschedule",
+			schedule: "*/1 * * * * *",
+		},
+		shouldSchedule: func(context.Context) bool { return enabled },
+	}
+
+	require.NoError(t, js.RescheduleJob(context.Background(), job))
+	require.Contains(t, js.entryIDs, job.Name())
+
+	enabled = false
+
+	require.NoError(t, js.RescheduleJob(context.Background(), job))
+	require.NotContains(t, js.entryIDs, job.Name())
+	require.Empty(t, js.cron.Entries())
+}
+
+func TestJobScheduler_RescheduleJob_AddsEntryWhenEnabled(t *testing.T) {
+	js := NewJobScheduler(context.Background(), nil)
+	enabled := false
+
+	job := &conditionalTestSchedulerJob{
+		testSchedulerJob: &testSchedulerJob{
+			name:     "test-enabled-reschedule",
+			schedule: "*/1 * * * * *",
+		},
+		shouldSchedule: func(context.Context) bool { return enabled },
+	}
+
+	require.NoError(t, js.RescheduleJob(context.Background(), job))
+	require.NotContains(t, js.entryIDs, job.Name())
+
+	enabled = true
+
+	require.NoError(t, js.RescheduleJob(context.Background(), job))
+	require.Contains(t, js.entryIDs, job.Name())
+	require.Len(t, js.cron.Entries(), 1)
+}
+
+func TestJobScheduler_StartScheduler_SchedulesNonConditionalJobs(t *testing.T) {
+	js := NewJobScheduler(context.Background(), nil)
+
+	job := &testSchedulerJob{
+		name:     "test-non-conditional-startup",
+		schedule: "*/1 * * * * *",
+	}
+
+	js.RegisterJob(job)
+	js.StartScheduler()
+	defer js.cron.Stop()
+
+	require.Contains(t, js.entryIDs, job.Name())
+	require.Len(t, js.cron.Entries(), 1)
+}
+
 func TestJobScheduler_RescheduleJob_UsesProvidedContext(t *testing.T) {
 	js := NewJobScheduler(context.Background(), nil)
 

--- a/backend/pkg/scheduler/vulnerability_scan_job.go
+++ b/backend/pkg/scheduler/vulnerability_scan_job.go
@@ -38,6 +38,10 @@ func (j *VulnerabilityScanJob) Name() string {
 	return VulnerabilityScanJobName
 }
 
+func (j *VulnerabilityScanJob) ShouldSchedule(ctx context.Context) bool {
+	return j.settingsService.GetBoolSetting(ctx, "vulnerabilityScanEnabled", false)
+}
+
 // Schedule returns the cron expression for the job. Defaults to daily at midnight.
 func (j *VulnerabilityScanJob) Schedule(ctx context.Context) string {
 	schedule := j.settingsService.GetStringSetting(ctx, "vulnerabilityScanInterval", "0 0 0 * * *")

--- a/types/scheduler/job.go
+++ b/types/scheduler/job.go
@@ -7,3 +7,9 @@ type Job interface {
 	Schedule(ctx context.Context) string
 	Run(ctx context.Context)
 }
+
+// ConditionalJob allows a job to opt out of cron registration when it is disabled.
+// Jobs that do not implement this interface are always scheduled.
+type ConditionalJob interface {
+	ShouldSchedule(ctx context.Context) bool
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `ConditionalJob` opt-in interface so that disabled jobs are never registered with the cron scheduler in the first place, rather than silently no-oping inside `Run`. All six configurable jobs (`AutoHeal`, `AutoUpdate`, `GitOpsSync`, `ImagePolling`, `ScheduledPrune`, `VulnerabilityScan`) implement the new `ShouldSchedule` method, and the scheduler's `StartScheduler` / `RescheduleJob` paths are unified through a new shared `scheduleJob` helper that performs the conditional check via a type assertion.

- `types/scheduler/job.go` — adds the `ConditionalJob` interface, cleanly separated from the base `Job` interface so non-conditional jobs continue to be always-scheduled
- `scheduler.go` — `StartScheduler` and `RescheduleJob` are refactored to delegate to a shared `scheduleJob` helper; `RescheduleJob` now correctly calls `delete(js.entryIDs, job.Name())` before re-adding, keeping the map in sync when a job becomes disabled
- Each job file — `ShouldSchedule` implementations read the same settings keys used by their `Run` guards, keeping the two checks consistent
- `auto_update_job.go` — `ShouldSchedule` correctly requires *both* `autoUpdate` and `pollingEnabled`, matching the existing `Run` guard
- Tests are comprehensive: scheduler-level tests cover all four enable/disable transition scenarios, and per-job unit tests verify the new method in isolation
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- PR is safe to merge after renaming the two new unexported scheduler methods to follow the project's `Internal` suffix convention.
- The core logic is correct and well-tested. The only outstanding item is a naming-convention violation on `scheduleJob` and `isJobScheduled` in `scheduler.go`, which is a non-blocking style fix rather than a functional issue.
- `backend/pkg/scheduler/scheduler.go` — the two new unexported methods need the `Internal` suffix.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/pkg/scheduler/scheduler.go | Core refactor: extracts shared `scheduleJob` helper, adds `ConditionalJob` type-assertion gate, and correctly cleans up `entryIDs` on reschedule. Two new unexported methods (`scheduleJob`, `isJobScheduled`) are missing the required `Internal` suffix. |
| types/scheduler/job.go | Adds `ConditionalJob` interface as an opt-in extension to `Job`; well-documented and cleanly separated from the base interface. |
| backend/pkg/scheduler/auto_update_job.go | Adds `ShouldSchedule` requiring both `autoUpdate` and `pollingEnabled`; consistent with the existing guard in `Run`. |
| backend/pkg/scheduler/auto_heal_job.go | Adds `ShouldSchedule` backed by `autoHealEnabled` setting; mirrors the existing enabled-check in `Run`. |
| backend/pkg/scheduler/scheduler_test.go | Comprehensive new tests cover: disabled conditional jobs not scheduled at start, reschedule removing entry when disabled, reschedule adding entry when re-enabled, and non-conditional jobs always scheduled. |

</details>

</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fpkg%2Fscheduler%2Fscheduler.go%3A84-109%0A**Unexported%20methods%20missing%20%60Internal%60%20suffix**%0A%0ABoth%20%60scheduleJob%60%20and%20%60isJobScheduled%60%20are%20unexported%20methods%20but%20are%20missing%20the%20required%20%60Internal%60%20suffix%20per%20the%20project's%20naming%20convention%20for%20unexported%20functions.%0A%0A%60%60%60suggestion%0Afunc%20%28js%20*JobScheduler%29%20scheduleJobInternal%28ctx%20context.Context%2C%20job%20schedulertypes.Job%29%20error%20%7B%0A%09if%20conditionalJob%2C%20ok%20%3A%3D%20job.%28schedulertypes.ConditionalJob%29%3B%20ok%20%26%26%20!conditionalJob.ShouldSchedule%28ctx%29%20%7B%0A%09%09slog.DebugContext%28ctx%2C%20%22Job%20disabled%3B%20not%20scheduling%22%2C%20%22name%22%2C%20job.Name%28%29%29%0A%09%09return%20nil%0A%09%7D%0A%0A%09schedule%20%3A%3D%20job.Schedule%28ctx%29%0A%09slog.InfoContext%28ctx%2C%20%22Starting%20Job%22%2C%20%22name%22%2C%20job.Name%28%29%2C%20%22schedule%22%2C%20schedule%29%0A%0A%09entryID%2C%20err%20%3A%3D%20js.cron.AddFunc%28schedule%2C%20func%28%29%20%7B%0A%09%09slog.InfoContext%28ctx%2C%20%22Job%20starting%22%2C%20%22name%22%2C%20job.Name%28%29%2C%20%22schedule%22%2C%20schedule%29%0A%09%09job.Run%28ctx%29%0A%09%09slog.InfoContext%28ctx%2C%20%22Job%20finished%22%2C%20%22name%22%2C%20job.Name%28%29%29%0A%09%7D%29%0A%09if%20err%20!%3D%20nil%20%7B%0A%09%09return%20err%0A%09%7D%0A%0A%09js.entryIDs%5Bjob.Name%28%29%5D%20%3D%20entryID%0A%09return%20nil%0A%7D%0A%0Afunc%20%28js%20*JobScheduler%29%20isJobScheduledInternal%28jobName%20string%29%20bool%20%7B%0A%09_%2C%20ok%20%3A%3D%20js.entryIDs%5BjobName%5D%0A%09return%20ok%0A%7D%0A%60%60%60%0A%0AThe%20call%20sites%20in%20%60StartScheduler%60%2C%20%60RescheduleJob%60%2C%20and%20the%20debug%20log%20should%20also%20be%20updated%20to%20use%20the%20%60Internal%60%20suffixed%20names.%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/scheduler/scheduler.go
Line: 84-109

Comment:
**Unexported methods missing `Internal` suffix**

Both `scheduleJob` and `isJobScheduled` are unexported methods but are missing the required `Internal` suffix per the project's naming convention for unexported functions.

```suggestion
func (js *JobScheduler) scheduleJobInternal(ctx context.Context, job schedulertypes.Job) error {
	if conditionalJob, ok := job.(schedulertypes.ConditionalJob); ok && !conditionalJob.ShouldSchedule(ctx) {
		slog.DebugContext(ctx, "Job disabled; not scheduling", "name", job.Name())
		return nil
	}

	schedule := job.Schedule(ctx)
	slog.InfoContext(ctx, "Starting Job", "name", job.Name(), "schedule", schedule)

	entryID, err := js.cron.AddFunc(schedule, func() {
		slog.InfoContext(ctx, "Job starting", "name", job.Name(), "schedule", schedule)
		job.Run(ctx)
		slog.InfoContext(ctx, "Job finished", "name", job.Name())
	})
	if err != nil {
		return err
	}

	js.entryIDs[job.Name()] = entryID
	return nil
}

func (js *JobScheduler) isJobScheduledInternal(jobName string) bool {
	_, ok := js.entryIDs[jobName]
	return ok
}
```

The call sites in `StartScheduler`, `RescheduleJob`, and the debug log should also be updated to use the `Internal` suffixed names.

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: dont schedule disabled jobs"](https://github.com/getarcaneapp/arcane/commit/c68542cebc197797a2bd6cda8a20a87c1dea54a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25995833)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->