### PR TITLE
fix: validate token auth realm host for registry fallback

### DIFF
--- a/backend/pkg/utils/distribution/distribution.go
+++ b/backend/pkg/utils/distribution/distribution.go
@@ -411,7 +411,11 @@ func validateAuthRealmInternal(registryHost, realm string) error {
 		return fmt.Errorf("invalid auth realm: %w", err)
 	}
 
-	realmHost := normalizeRegistryForComparisonInternal(parsedRealm.Host)
+	if !strings.EqualFold(parsedRealm.Scheme, "https") {
+		return fmt.Errorf("auth realm must use HTTPS, got %q", parsedRealm.Scheme)
+	}
+
+	realmHost := normalizeRegistryForComparisonInternal(parsedRealm.Hostname())
 	registry := normalizeRegistryForComparisonInternal(registryHost)
 
 	if realmHost == "" {

--- a/backend/pkg/utils/distribution/distribution_test.go
+++ b/backend/pkg/utils/distribution/distribution_test.go
@@ -117,7 +117,76 @@ func TestFetchDigestWithHTTPClient_RejectsUntrustedTokenRealm(t *testing.T) {
 	assert.Contains(t, err.Error(), "untrusted auth realm host")
 }
 
-func TestValidateAuthRealmInternal_AllowsDockerHubAuthHost(t *testing.T) {
-	err := validateAuthRealmInternal("registry-1.docker.io", "https://auth.docker.io/token")
-	require.NoError(t, err)
+func TestValidateAuthRealmInternal(t *testing.T) {
+	tests := []struct {
+		name         string
+		registryHost string
+		realm        string
+		wantErr      bool
+		errContains  string
+	}{
+		{
+			name:         "same host allowed",
+			registryHost: "registry.example.com",
+			realm:        "https://registry.example.com/token",
+		},
+		{
+			name:         "same host with explicit default https port allowed",
+			registryHost: "registry.example.com",
+			realm:        "https://registry.example.com:443/token",
+		},
+		{
+			name:         "docker hub auth host allowed",
+			registryHost: "registry-1.docker.io",
+			realm:        "https://auth.docker.io/token",
+		},
+		{
+			name:         "non https realm rejected",
+			registryHost: "registry.example.com",
+			realm:        "http://registry.example.com/token",
+			wantErr:      true,
+			errContains:  "auth realm must use HTTPS",
+		},
+		{
+			name:         "empty realm rejected",
+			registryHost: "registry.example.com",
+			realm:        "",
+			wantErr:      true,
+			errContains:  "auth realm must use HTTPS",
+		},
+		{
+			name:         "malformed realm rejected",
+			registryHost: "registry.example.com",
+			realm:        "https://%zz",
+			wantErr:      true,
+			errContains:  "invalid auth realm",
+		},
+		{
+			name:         "relative realm rejected",
+			registryHost: "registry.example.com",
+			realm:        "/token",
+			wantErr:      true,
+			errContains:  "auth realm must use HTTPS",
+		},
+		{
+			name:         "untrusted realm rejected",
+			registryHost: "registry.example.com",
+			realm:        "https://evil.com/token",
+			wantErr:      true,
+			errContains:  "untrusted auth realm host",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAuthRealmInternal(tc.registryHost, tc.realm)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
 }


### PR DESCRIPTION
### Motivation
- A direct registry fallback path performed token requests to the `WWW-Authenticate` realm without validating the realm host, enabling SSRF and credential/token exfiltration when an attacker-controlled registry returned a malicious realm. 
- The change aims to block untrusted token realms while preserving legitimate token flows (including Docker Hub's `auth.docker.io`).

### Description
- Added `validateAuthRealmInternal` which parses and normalizes the realm host and only allows token realms that match the target registry host or the Docker Hub special-case `auth.docker.io` for `docker.io`.
- Wired realm validation into `fetchWithTokenAuthInternal` so the realm host is checked before any outbound token request is issued. 
- Added unit tests `TestFetchDigestWithHTTPClient_RejectsUntrustedTokenRealm` and `TestValidateAuthRealmInternal_AllowsDockerHubAuthHost` to cover rejection of untrusted realms and the Docker Hub exception.

### Testing
- Ran `go test ./backend/pkg/utils/distribution` and the package tests completed successfully. 
- New tests covering untrusted realm rejection and Docker Hub compatibility pass. 
- AI Tool: GPT-4 (assistant) — significant assistance in drafting the change and tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b781d909d083269cdc5118d26adaa0)

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR patches an SSRF and credential-exfiltration vulnerability in the direct-registry fallback path by introducing `validateAuthRealmInternal`, which ensures the token-auth realm returned in a `WWW-Authenticate` challenge originates from the same host as the target registry (with an explicit carve-out for Docker Hub's `auth.docker.io`). The validation is inserted in `fetchWithTokenAuthInternal` before any outbound token request is issued.

Key changes:
- `validateAuthRealmInternal` normalises both the registry host and the realm host via the existing `normalizeRegistryForComparisonInternal` helper and rejects any realm that does not match.
- A Docker Hub special case allows `auth.docker.io` when the normalised registry is `docker.io`.
- Two new tests cover the untrusted-realm rejection path (integration) and the Docker Hub exception (unit).

Areas for improvement:
- **Port comparison (`parsedRealm.Host` vs `parsedRealm.Hostname()`)**: because `url.Parse` retains an explicit port in `Host`, a realm URL such as `https://myregistry.com:443/token` will fail the equality check against a `registryHost` of `myregistry.com`. Using `parsedRealm.Hostname()` would make the comparison port-agnostic and avoid false-negative rejections.
- **No HTTPS scheme enforcement**: only the host is validated; a malicious registry could return an `http://` realm on the same hostname and credentials would be transmitted in plaintext. Rejecting non-HTTPS realms would improve defence-in-depth.
- **Tests are not table-driven**: per the project's Go conventions, `TestValidateAuthRealmInternal_AllowsDockerHubAuthHost` should be expanded into a table-driven test covering all branches of `validateAuthRealmInternal`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- The SSRF fix is correct and well-scoped; two targeted improvements (port normalisation and scheme enforcement) would harden it further but are not blocking.
- The core security fix is sound — host-based realm validation prevents SSRF and token exfiltration against arbitrary realms, and the Docker Hub exception is correctly implemented. The remaining gaps (explicit-default-port false-negative, missing HTTPS scheme check, non-table-driven tests) are P2 concerns that do not break the primary protection path or production reliability, warranting a 4/5.
- Pay close attention to `backend/pkg/utils/distribution/distribution.go` lines 413–414 (port comparison) and `backend/pkg/utils/distribution/distribution_test.go` (test coverage breadth).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/pkg/utils/distribution/distribution.go | Adds `validateAuthRealmInternal` to block SSRF via malicious `WWW-Authenticate` realms; wired into `fetchWithTokenAuthInternal`. Logic is sound but host comparison uses `parsedRealm.Host` (includes port) rather than `parsedRealm.Hostname()`, which can cause false-negative rejections for realms with an explicit default port, and there is no HTTPS scheme check on the realm URL. |
| backend/pkg/utils/distribution/distribution_test.go | Adds integration test for realm-rejection and a single-case unit test for the Docker Hub exception; both tests are correct but neither follows the project's required table-driven pattern, and several branches of `validateAuthRealmInternal` (direct same-host match, empty realm, malformed URL) have no direct coverage. |

</details>

</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Fpkg%2Futils%2Fdistribution%2Fdistribution_test.go%3A120-123%0A**%60validateAuthRealmInternal%60%20tests%20are%20not%20table-driven**%0A%0APer%20the%20project's%20Go%20custom%20instructions%2C%20tests%20should%20be%20table-driven%20with%20subtests.%20The%20new%20%60TestValidateAuthRealmInternal_AllowsDockerHubAuthHost%60%20only%20exercises%20a%20single%20happy-path%20scenario%20and%20skips%20the%20rejection%20branches%20entirely.%20A%20table-driven%20test%20would%20also%20confirm%20the%20%60realmHost%20%3D%3D%20registry%60%20direct-match%20path%2C%20the%20empty%2Fmalformed%20realm%20cases%2C%20and%20the%20untrusted-host%20rejection%20path%20for%20the%20function%20itself%20%28as%20opposed%20to%20the%20end-to-end%20%60TestFetchDigestWithHTTPClient_RejectsUntrustedTokenRealm%60%29.%0A%0A%60%60%60go%0Afunc%20TestValidateAuthRealmInternal%28t%20*testing.T%29%20%7B%0A%20%20%20%20tests%20%3A%3D%20%5B%5Dstruct%20%7B%0A%20%20%20%20%20%20%20%20name%20%20%20%20%20%20%20%20%20string%0A%20%20%20%20%20%20%20%20registryHost%20string%0A%20%20%20%20%20%20%20%20realm%20%20%20%20%20%20%20%20string%0A%20%20%20%20%20%20%20%20wantErr%20%20%20%20%20%20bool%0A%20%20%20%20%20%20%20%20errContains%20%20string%0A%20%20%20%20%7D%7B%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20%20%20%20%20%20%20%20%20%22same%20host%20allowed%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20registryHost%3A%20%22registry.example.com%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20realm%3A%20%20%20%20%20%20%20%20%22https%3A%2F%2Fregistry.example.com%2Ftoken%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20wantErr%3A%20%20%20%20%20%20false%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20%20%20%20%20%20%20%20%20%22docker%20hub%20auth.docker.io%20allowed%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20registryHost%3A%20%22registry-1.docker.io%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20realm%3A%20%20%20%20%20%20%20%20%22https%3A%2F%2Fauth.docker.io%2Ftoken%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20wantErr%3A%20%20%20%20%20%20false%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20%20%20%20%20%20%20%20%20%22untrusted%20realm%20rejected%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20registryHost%3A%20%22registry.example.com%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20realm%3A%20%20%20%20%20%20%20%20%22https%3A%2F%2Fevil.com%2Ftoken%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20wantErr%3A%20%20%20%20%20%20true%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20errContains%3A%20%20%22untrusted%20auth%20realm%20host%22%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20%20%20%20%20%20%20%20%20%22relative%20realm%20rejected%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20registryHost%3A%20%22registry.example.com%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20realm%3A%20%20%20%20%20%20%20%20%22%2Ftoken%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20wantErr%3A%20%20%20%20%20%20true%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20errContains%3A%20%20%22invalid%20auth%20realm%20host%22%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%7D%0A%20%20%20%20for%20_%2C%20tc%20%3A%3D%20range%20tests%20%7B%0A%20%20%20%20%20%20%20%20t.Run%28tc.name%2C%20func%28t%20*testing.T%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20err%20%3A%3D%20validateAuthRealmInternal%28tc.registryHost%2C%20tc.realm%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20tc.wantErr%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20require.Error%28t%2C%20err%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20assert.Contains%28t%2C%20err.Error%28%29%2C%20tc.errContains%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20require.NoError%28t%2C%20err%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%29%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20%23%20Golang%20Pro%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A%23%23%23%20Issue%202%20of%203%0Abackend%2Fpkg%2Futils%2Fdistribution%2Fdistribution.go%3A408-431%0A**No%20HTTPS%20scheme%20enforcement%20on%20realm%20URL**%0A%0A%60validateAuthRealmInternal%60%20only%20validates%20the%20realm%20*host*%20but%20does%20not%20require%20the%20realm%20scheme%20to%20be%20HTTPS.%20An%20attacker-controlled%20registry%20that%20has%20already%20obtained%20the%20registry's%20own%20hostname%20could%20return%20a%20realm%20like%20%60http%3A%2F%2Fregistry.example.com%2Fevil-token%60%2C%20which%20would%20pass%20the%20host%20check%20but%20cause%20registry%20credentials%20%28sent%20via%20%60req.SetBasicAuth%60%29%20to%20be%20transmitted%20in%20plaintext.%20While%20this%20is%20partially%20mitigated%20by%20the%20host%20check%2C%20defence-in-depth%20would%20reject%20any%20non-HTTPS%20realm%20unless%20in%20development%2Ftest%20scenarios.%0A%0AConsider%20adding%20a%20scheme%20guard%3A%0A%0A%60%60%60go%0Afunc%20validateAuthRealmInternal%28registryHost%2C%20realm%20string%29%20error%20%7B%0A%20%20%20%20parsedRealm%2C%20err%20%3A%3D%20url.Parse%28strings.TrimSpace%28realm%29%29%0A%20%20%20%20if%20err%20!%3D%20nil%20%7B%0A%20%20%20%20%20%20%20%20return%20fmt.Errorf%28%22invalid%20auth%20realm%3A%20%25w%22%2C%20err%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20parsedRealm.Scheme%20!%3D%20%22https%22%20%7B%0A%20%20%20%20%20%20%20%20return%20fmt.Errorf%28%22auth%20realm%20must%20use%20HTTPS%2C%20got%20%25q%22%2C%20parsedRealm.Scheme%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20realmHost%20%3A%3D%20normalizeRegistryForComparisonInternal%28parsedRealm.Host%29%0A%20%20%20%20%2F%2F%20...%20rest%20of%20checks%20unchanged%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Abackend%2Fpkg%2Futils%2Fdistribution%2Fdistribution.go%3A413-414%0A**Port%20comparison%20can%20produce%20false%20negatives%20for%20default-port%20registries**%0A%0A%60url.Parse%28realm%29.Host%60%20retains%20an%20explicit%20port%20even%20when%20it%20matches%20the%20default%20for%20the%20scheme%20%28e.g.%2C%20%60%3A443%60%20for%20HTTPS%29.%20%60normalizeRegistryForComparisonInternal%60%20does%20not%20strip%20ports.%20As%20a%20result%2C%20if%20%60registryHost%60%20is%20%60%22myregistry.example.com%22%60%20%28no%20port%29%20but%20the%20%60WWW-Authenticate%60%20realm%20URL%20is%20%60https%3A%2F%2Fmyregistry.example.com%3A443%2Ftoken%60%20%28explicit%20default%20port%29%2C%20the%20comparison%20%60realmHost%20%3D%3D%20registry%60%20becomes%20%60%22myregistry.example.com%3A443%22%20%3D%3D%20%22myregistry.example.com%22%60%20which%20evaluates%20to%20%60false%60%2C%20incorrectly%20rejecting%20a%20legitimate%20realm.%0A%0AA%20low-friction%20fix%20is%20to%20extract%20only%20the%20hostname%20for%20comparison%3A%0A%0A%60%60%60go%0ArealmHost%20%3A%3D%20normalizeRegistryForComparisonInternal%28parsedRealm.Hostname%28%29%29%20%2F%2F%20Hostname%28%29%20strips%20port%0Aregistry%20%20%3A%3D%20normalizeRegistryForComparisonInternal%28registryHost%29%0A%60%60%60%0A%0ANote%3A%20%60parsedRealm.Hostname%28%29%60%20already%20strips%20the%20port%2C%20so%20the%20%60normalizeRegistryForComparisonInternal%60%20slash-stripping%20logic%20remains%20harmless.%20Registries%20that%20intentionally%20differ%20by%20port%20%28e.g.%2C%20%60myregistry.com%3A5000%60%20vs%20%60myregistry.com%3A5001%60%29%20would%20no%20longer%20be%20distinguished%2C%20but%20that%20scenario%20is%20an%20unusual%20deployment%20and%20the%20host-only%20check%20is%20a%20safe%20upgrade%20over%20the%20current%20behaviour.%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/utils/distribution/distribution_test.go
Line: 120-123

Comment:
**`validateAuthRealmInternal` tests are not table-driven**

Per the project's Go custom instructions, tests should be table-driven with subtests. The new `TestValidateAuthRealmInternal_AllowsDockerHubAuthHost` only exercises a single happy-path scenario and skips the rejection branches entirely. A table-driven test would also confirm the `realmHost == registry` direct-match path, the empty/malformed realm cases, and the untrusted-host rejection path for the function itself (as opposed to the end-to-end `TestFetchDigestWithHTTPClient_RejectsUntrustedTokenRealm`).

```go
func TestValidateAuthRealmInternal(t *testing.T) {
    tests := []struct {
        name         string
        registryHost string
        realm        string
        wantErr      bool
        errContains  string
    }{
        {
            name:         "same host allowed",
            registryHost: "registry.example.com",
            realm:        "https://registry.example.com/token",
            wantErr:      false,
        },
        {
            name:         "docker hub auth.docker.io allowed",
            registryHost: "registry-1.docker.io",
            realm:        "https://auth.docker.io/token",
            wantErr:      false,
        },
        {
            name:         "untrusted realm rejected",
            registryHost: "registry.example.com",
            realm:        "https://evil.com/token",
            wantErr:      true,
            errContains:  "untrusted auth realm host",
        },
        {
            name:         "relative realm rejected",
            registryHost: "registry.example.com",
            realm:        "/token",
            wantErr:      true,
            errContains:  "invalid auth realm host",
        },
    }
    for _, tc := range tests {
        t.Run(tc.name, func(t *testing.T) {
            err := validateAuthRealmInternal(tc.registryHost, tc.realm)
            if tc.wantErr {
                require.Error(t, err)
                assert.Contains(t, err.Error(), tc.errContains)
            } else {
                require.NoError(t, err)
            }
        })
    }
}
```

**Rule Used:** # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/utils/distribution/distribution.go
Line: 408-431

Comment:
**No HTTPS scheme enforcement on realm URL**

`validateAuthRealmInternal` only validates the realm *host* but does not require the realm scheme to be HTTPS. An attacker-controlled registry that has already obtained the registry's own hostname could return a realm like `http://registry.example.com/evil-token`, which would pass the host check but cause registry credentials (sent via `req.SetBasicAuth`) to be transmitted in plaintext. While this is partially mitigated by the host check, defence-in-depth would reject any non-HTTPS realm unless in development/test scenarios.

Consider adding a scheme guard:

```go
func validateAuthRealmInternal(registryHost, realm string) error {
    parsedRealm, err := url.Parse(strings.TrimSpace(realm))
    if err != nil {
        return fmt.Errorf("invalid auth realm: %w", err)
    }

    if parsedRealm.Scheme != "https" {
        return fmt.Errorf("auth realm must use HTTPS, got %q", parsedRealm.Scheme)
    }

    realmHost := normalizeRegistryForComparisonInternal(parsedRealm.Host)
    // ... rest of checks unchanged
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/utils/distribution/distribution.go
Line: 413-414

Comment:
**Port comparison can produce false negatives for default-port registries**

`url.Parse(realm).Host` retains an explicit port even when it matches the default for the scheme (e.g., `:443` for HTTPS). `normalizeRegistryForComparisonInternal` does not strip ports. As a result, if `registryHost` is `"myregistry.example.com"` (no port) but the `WWW-Authenticate` realm URL is `https://myregistry.example.com:443/token` (explicit default port), the comparison `realmHost == registry` becomes `"myregistry.example.com:443" == "myregistry.example.com"` which evaluates to `false`, incorrectly rejecting a legitimate realm.

A low-friction fix is to extract only the hostname for comparison:

```go
realmHost := normalizeRegistryForComparisonInternal(parsedRealm.Hostname()) // Hostname() strips port
registry  := normalizeRegistryForComparisonInternal(registryHost)
```

Note: `parsedRealm.Hostname()` already strips the port, so the `normalizeRegistryForComparisonInternal` slash-stripping logic remains harmless. Registries that intentionally differ by port (e.g., `myregistry.com:5000` vs `myregistry.com:5001`) would no longer be distinguished, but that scenario is an unusual deployment and the host-only check is a safe upgrade over the current behaviour.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into codex/fix-ssrf-..."](https://github.com/getarcaneapp/arcane/commit/49e64bcb1346995a3dafaff43281d7831673155c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26116622)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Rule used - # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

<!-- /greptile_comment -->