### PR TITLE
fix: proper back button logic for gitops syncs

### DIFF
--- a/frontend/src/routes/(app)/environments/[id]/gitops/sync-table.svelte
+++ b/frontend/src/routes/(app)/environments/[id]/gitops/sync-table.svelte
@@ -49,6 +49,15 @@
 	});
 	let mobileFieldVisibility = $state<Record<string, boolean>>({});
 
+	function getProjectDetailsUrl(projectId: string): string {
+		const params = new URLSearchParams({
+			from: 'gitops',
+			environmentId
+		});
+
+		return `/projects/${projectId}?${params.toString()}`;
+	}
+
 	async function handleDeleteSelected(ids: string[]) {
 		if (!ids?.length) return;
 
@@ -203,9 +212,13 @@
 </script>
 
 {#snippet NameCell({ item, value }: { item: GitOpsSync; value: any; row: Row<GitOpsSync> })}
-	<a class="font-medium hover:underline" href="/projects/{item.projectId}">
-		{value}
-	</a>
+	{#if item.projectId}
+		<a class="font-medium hover:underline" href={getProjectDetailsUrl(item.projectId)}>
+			{value}
+		</a>
+	{:else}
+		<span class="font-medium">{value}</span>
+	{/if}
 {/snippet}
 
 {#snippet BranchCell({ value }: { value: any; item: GitOpsSync; row: Row<GitOpsSync> })}

--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -12,6 +12,7 @@
 	import StatusBadge from '$lib/components/badges/status-badge.svelte';
 	import { getStatusVariant } from '$lib/utils/status.utils';
 	import { capitalizeFirstLetter } from '$lib/utils/string.utils';
+	import { page } from '$app/state';
 	import { invalidateAll } from '$app/navigation';
 	import { toast } from 'svelte-sonner';
 	import { tryCatch } from '$lib/utils/try-catch';
@@ -427,11 +428,22 @@
 			return trimmed;
 		}
 	}
+
+	const backUrl = $derived.by(() => {
+		const from = page.url.searchParams.get('from');
+		const sourceEnvironmentId = page.url.searchParams.get('environmentId');
+
+		if (from === 'gitops' && sourceEnvironmentId) {
+			return `/environments/${sourceEnvironmentId}/gitops`;
+		}
+
+		return '/projects';
+	});
 </script>
 
 {#if project}
 	<TabbedPageLayout
-		backUrl="/projects"
+		{backUrl}
 		backLabel={m.common_back()}
 		{tabItems}
 		{selectedTab}

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -28,7 +28,22 @@ async function setCodeMirrorValue(page: Page, editor: Locator, text: string) {
 async function getCodeMirrorValue(editor: Locator) {
 	const content = editor.locator('.cm-content').first();
 	await expect(content).toBeVisible();
-	return content.evaluate((node) => (node as HTMLElement).innerText ?? '');
+	return content.evaluate((node) => {
+		const lineNodes = Array.from(node.querySelectorAll('.cm-line'));
+		if (lineNodes.length > 0) {
+			return lineNodes.map((line) => line.textContent ?? '').join('\n');
+		}
+
+		return (node as { textContent?: string | null }).textContent ?? '';
+	});
+}
+
+function getPathname(url: string): string {
+	return url.replace(/^[a-z]+:\/\/[^/]+/i, '').split(/[?#]/)[0] || '/';
+}
+
+function getProjectIdFromPageUrl(url: string): string {
+	return url.split('/projects/')[1]?.split(/[?#]/)[0] ?? '';
 }
 
 async function createProjectViaUI(page: Page, projectName: string) {
@@ -60,7 +75,7 @@ async function createProjectViaUI(page: Page, projectName: string) {
 	await page.waitForURL(/\/projects\/(?!new$).+/, { timeout: 10000 });
 	await expect(page.getByRole('button', { name: projectName })).toBeVisible();
 
-	return new URL(page.url()).pathname.split('/').pop()!;
+	return getProjectIdFromPageUrl(page.url());
 }
 
 async function destroyCurrentProjectViaUI(page: Page) {
@@ -462,7 +477,7 @@ test.describe('New Compose Project Page', () => {
 			await createProjectViaUI(page, projectName);
 
 			// Reset scroll so the floating header doesn't appear from stale scroll state
-			await page.evaluate(() => window.scrollTo(0, 0));
+			await page.mouse.wheel(0, -100000);
 
 			await page.route('**/api/environments/*/projects/*/up', async (route) => {
 				await route.fulfill({
@@ -503,9 +518,7 @@ test.describe('New Compose Project Page', () => {
 			// Set up request listener right before clicking to minimize timeout window
 			const deployRequestPromise = page.waitForRequest((request) => {
 				if (request.method() !== 'POST') return false;
-				return /\/api\/environments\/[^/]+\/projects\/[^/]+\/up$/.test(
-					new URL(request.url()).pathname
-				);
+				return /\/api\/environments\/[^/]+\/projects\/[^/]+\/up$/.test(getPathname(request.url()));
 			});
 
 			await page.getByRole('button', { name: 'Up', exact: true }).click();
@@ -524,7 +537,7 @@ test.describe('New Compose Project Page', () => {
 				forceRecreate: true
 			});
 		} finally {
-			if (!page.isClosed() && /\/projects\/.+/.test(new URL(page.url()).pathname)) {
+			if (!page.isClosed() && /\/projects\/.+/.test(getPathname(page.url()))) {
 				await destroyCurrentProjectViaUI(page);
 			} else {
 				await destroyProjectByNameViaUI(page, projectName);
@@ -582,6 +595,24 @@ test.describe('New Compose Project Page', () => {
 });
 
 test.describe('GitOps Managed Project', () => {
+	test('should navigate back to gitops when opened from the git syncs page', async ({ page }) => {
+		await page.goto('/environments/0/gitops');
+		await page.waitForLoadState('networkidle');
+
+		const projectLink = page.locator('tbody tr').locator('a[href^="/projects/"]').first();
+		test.skip((await projectLink.count()) === 0, 'No GitOps project links found');
+
+		await projectLink.click();
+		await page.waitForURL(/\/projects\/.+/, { timeout: 10000 });
+
+		const backLink = page.getByRole('link', { name: /^Back$/i }).first();
+		await expect(backLink).toBeVisible();
+		await backLink.click();
+
+		await page.waitForURL('/environments/0/gitops', { timeout: 10000 });
+		await expect(page).toHaveURL('/environments/0/gitops');
+	});
+
 	test('should show read-only alert when project is GitOps managed', async ({ page }) => {
 		const gitOpsProject = realProjects.find((p) => p.gitOpsManagedBy);
 		test.skip(!gitOpsProject, 'No GitOps-managed projects found');
@@ -669,9 +700,9 @@ test.describe('GitOps Managed Project', () => {
 
 		await page.waitForTimeout(800);
 		const envEditor = page.locator('.cm-editor:visible').nth(1);
-		const envContent = envEditor.locator('.cm-content');
 		const marker = `ARCANE_E2E_${Date.now()}`;
-		const originalEnv = await envContent.evaluate((node) => (node as HTMLElement).innerText ?? '');
+		const envContent = envEditor.locator('.cm-content');
+		const originalEnv = await getCodeMirrorValue(envEditor);
 		const updatedEnv = `${originalEnv.trimEnd()}\n${marker}=1\n`;
 
 		await expect(envContent).not.toHaveAttribute('aria-readonly', 'true');
@@ -740,6 +771,21 @@ test.describe('GitOps Managed Project', () => {
 });
 
 test.describe('Project Detail Page', () => {
+	test('should navigate back to projects by default', async ({ page }) => {
+		test.skip(!realProjects.length, 'No projects available for back navigation test');
+
+		const firstProject = realProjects[0];
+		await page.goto(`/projects/${firstProject.id || firstProject.name}`);
+		await page.waitForLoadState('networkidle');
+
+		const backLink = page.getByRole('link', { name: /^Back$/i }).first();
+		await expect(backLink).toBeVisible();
+		await backLink.click();
+
+		await page.waitForURL(ROUTES.page, { timeout: 10000 });
+		await expect(page).toHaveURL(ROUTES.page);
+	});
+
 	test('should display project details for existing project', async ({ page }) => {
 		test.skip(!realProjects.length, 'No projects available for detail page test');
 
@@ -768,7 +814,8 @@ test.describe('Project Detail Page', () => {
 	test('should display services tab content', async ({ page }) => {
 		test.skip(!realProjects.length, 'No projects available for services test');
 
-		const projectWithServices = realProjects.find((p) => p.serviceCount > 0) || realProjects[0];
+		const projectWithServices =
+			realProjects.find((p) => (p.serviceCount ?? 0) > 0) ?? realProjects[0]!;
 		await page.goto(`/projects/${projectWithServices.id || projectWithServices.name}`);
 		await page.waitForLoadState('networkidle');
 
@@ -856,8 +903,9 @@ test.describe('Project Detail Page', () => {
 
 		const runningProject = realProjects.find((p) => p.status === 'running');
 		test.skip(!runningProject, 'No running projects found for logs test');
+		const targetProject = runningProject!;
 
-		await page.goto(`/projects/${runningProject.id || runningProject.name}`);
+		await page.goto(`/projects/${targetProject.id || targetProject.name}`);
 		await page.waitForLoadState('networkidle');
 
 		const logsTab = page.getByRole('tab', { name: /Logs/i });


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2126

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the back button behavior on the project detail page when navigating from the GitOps syncs table. Previously, clicking Back always returned the user to `/projects`, even if they had arrived via the gitops page. Now, the sync table embeds `from=gitops&environmentId=...` query params in project links, and the project page reads those params reactively via `$derived.by` to route the Back button to the correct destination.

Key changes:
- **`sync-table.svelte`**: New `getProjectDetailsUrl` helper appends context query params to project links; adds a null guard so syncs without a `projectId` render plain text instead of a broken anchor.
- **`+page.svelte`**: Adds a `$derived.by` computed `backUrl` that conditionally returns `/environments/{id}/gitops` or falls back to `/projects`.
- **`project.spec.ts`**: Adds two E2E tests covering both navigation paths; refactors fragile `new URL()` constructor calls to a lightweight `getPathname` helper; switches CodeMirror content reads from `innerText` to `textContent` for more reliable evaluation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — the fix is targeted, the logic is sound, and both navigation paths are covered by new E2E tests.
- The implementation is minimal and correct: query params are added in one place and consumed in one other. The `$derived.by` pattern is idiomatic Svelte 5 and avoids any `$state`/`$effect` anti-patterns. The null guard on `item.projectId` is a positive defensive improvement. Tests cover both the new gitops-origin path and the existing default path. No logic errors, security concerns, or regressions were identified.
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/routes/(app)/environments/[id]/gitops/sync-table.svelte | Adds `getProjectDetailsUrl` helper that appends `from=gitops&environmentId=...` query params to project links, and guards the anchor render against a null `projectId`. Clean and correct. |
| frontend/src/routes/(app)/projects/[projectId]/+page.svelte | Introduces a reactive `backUrl` via `$derived.by` that reads `from` and `environmentId` query params and conditionally returns the gitops route. Correctly uses `$app/state` (Svelte 5) and `$derived` instead of `$state`/`$effect`. |
| tests/spec/project.spec.ts | Adds E2E tests for both gitops and default back-navigation, refactors URL parsing away from `new URL()` constructor for safer path extraction, and switches `innerText` → `textContent` for CodeMirror content evaluation. Well-structured additions. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: proper back button logic for gitops..."](https://github.com/getarcaneapp/arcane/commit/b0878d75af07920f38378e599fcb069844b36845) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26118672)</sub>

<!-- /greptile_comment -->