### PR TITLE
fix(pwa): add apple-touch-icon for iOS homescreen install

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -6,6 +6,8 @@
 		<meta http-equiv="Pragma" content="no-cache" />
 		<meta http-equiv="Expires" content="0" />
 		<link rel="icon" href="/api/app-images/favicon" />
+		<link rel="apple-touch-icon" sizes="152x152" href="/img/pwa/icon-152x152.png" />
+		<link rel="apple-touch-icon" href="/img/pwa/icon-192x192.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
 		<link rel="manifest" href="%sveltekit.assets%/app.webmanifest" />
 		<meta name="theme-color" content="oklch(1 0 0)" media="(prefers-color-scheme: light)" />


### PR DESCRIPTION
iOS does not use the Web App Manifest for homescreen icons and requires explicit apple-touch-icon link tags in the HTML head. Without these, iOS falls back to a generic "A" icon.

This PR resolves #2139.

## Checklist                    
                                                                                                                                                                                                                                 
- [x] This PR is **not** opened from my fork's `main` branch                                                                                                                                                                                                     

## What This PR Implements                                                                                                                                                                                                                                    

Adds `apple-touch-icon` link tags to the HTML `<head>` so the correct app icon appears when Arcane is installed to the iOS homescreen as a PWA.

iOS does not read the Web App Manifest for homescreen icons — it exclusively looks for `<link rel="apple-touch-icon">` tags in the HTML. Without these, iOS falls back to a generic letter icon. Android/Chrome PWA installs are unaffected since they do read the manifest.

## Changes Made

- Added `<link rel="apple-touch-icon" sizes="152x152">` for iPad retina, reusing the existing `icon-152x152.png`
- Added `<link rel="apple-touch-icon">` (no sizes) pointing to `icon-192x192.png` as the default fallback for iPhones — iOS scales 192→180 invisibly

## Testing Done

No testing steps were performed due to the simple nature of this fix.

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

AI Tool: Claude Code (claude-sonnet-4-6)
Assistance Level: Significant
What AI helped with: Investigated the root cause, identified the correct existing icon files to reference, and authored the fix.

- [x] I reviewed and edited all AI-generated output.
- [ ] I ran all required tests and manually verified changes.

## Additional Context

n/a

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the iOS PWA homescreen icon by adding two `apple-touch-icon` `<link>` tags to `app.html` — iOS does not read the Web App Manifest for homescreen icons and requires these explicit tags. The change correctly reuses two icon assets already present in `frontend/static/img/pwa/` (`icon-152x152.png` for iPad Retina and `icon-192x192.png` as the universal fallback for iPhones), with paths that correctly resolve via SvelteKit's static file serving.

Key observations:
- Both referenced icon files (`/img/pwa/icon-152x152.png` and `/img/pwa/icon-192x192.png`) exist in `frontend/static/img/pwa/` and are already declared in `app.webmanifest`.
- The absolute paths (`/img/pwa/...`) are consistent with how the rest of the project references static assets.
- There is no 180×180 icon asset in the project (the canonical Apple-recommended size for iPhone Retina), but iOS silently scales the 192×192 fallback, so this is an acceptable trade-off given current assets.
- The icons carry `"purpose": "maskable any"` in the manifest; since both `maskable` and `any` are declared, they will render correctly on iOS's rounded homescreen slots.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-file, additive HTML change using pre-existing static assets with no risk of regression.

The change is minimal (two link tags), the referenced icon files are confirmed to exist at the correct static paths, the fix directly addresses the stated iOS limitation, and no existing functionality is modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/app.html | Adds two apple-touch-icon link tags referencing existing static assets; paths, filenames, and sizing strategy are correct for iOS PWA homescreen support. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pwa): add apple-touch-icon for iOS h..."](https://github.com/getarcaneapp/arcane/commit/53faf864f9b80eccc60a5d19f6195888914d22e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26409016)</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->