### PR TITLE
fix: mobile layout issues on the dashboard

### DIFF
--- a/frontend/src/lib/components/quick-actions.svelte
+++ b/frontend/src/lib/components/quick-actions.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { ArcaneButton } from '$lib/components/arcane-button/index.js';
 	import { ActionButtonGroup, type ActionButton } from '$lib/components/action-button-group/index.js';
+	import { IsTablet } from '$lib/hooks/is-tablet.svelte.js';
 	import { m } from '$lib/paraglide/messages';
 	import { StartIcon, StopIcon, TrashIcon } from '$lib/icons';
 	import { cn } from '$lib/utils';
@@ -38,6 +39,7 @@
 		class?: string;
 	} = $props();
 
+	const isTablet = new IsTablet();
 	const isAnyActionLoading = $derived(isLoading.starting || isLoading.stopping || isLoading.pruning);
 
 	const currentUserIsAdmin = $derived(!!user?.roles?.includes('admin'));
@@ -84,7 +86,26 @@
 
 <section class={cn(compact ? 'flex min-w-0 flex-1 items-center justify-end' : '', className)}>
 	{#if compact}
-		<ActionButtonGroup buttons={actionButtons} />
+		{#if isTablet.current}
+			<div class="flex w-full min-w-0 items-center justify-center gap-2">
+				{#each actionButtons as button (button.id)}
+					<ArcaneButton
+						action={button.action}
+						customLabel={button.label}
+						loadingLabel={button.loadingLabel}
+						loading={button.loading}
+						disabled={button.disabled}
+						onclick={button.onclick}
+						size="icon"
+						showLabel={false}
+						icon={button.icon}
+						class="min-w-0 flex-1"
+					/>
+				{/each}
+			</div>
+		{:else}
+			<ActionButtonGroup buttons={actionButtons} />
+		{/if}
 	{:else if currentUserIsAdmin}
 		<h2 class="mb-3 text-lg font-semibold tracking-tight">{m.quick_actions_title()}</h2>
 

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -95,14 +95,14 @@
 	<main class="flex-1">
 		<section
 			class={cn(
-				'px-2',
+				'px-3',
 				navigationMode === 'docked'
 					? navigationSettings.scrollToHide
-						? 'pt-5 sm:px-5 sm:pt-5'
-						: 'pt-5 pb-(--mobile-docked-nav-offset,calc(3.5rem+env(safe-area-inset-bottom))) sm:p-5'
+						? 'pt-5'
+						: 'pt-5 pb-(--mobile-docked-nav-offset,calc(3.5rem+env(safe-area-inset-bottom)))'
 					: navigationSettings.scrollToHide
-						? 'py-5 sm:p-5'
-						: 'py-5 pb-(--mobile-floating-nav-offset,6rem) sm:p-5'
+						? 'py-5'
+						: 'py-5 pb-(--mobile-floating-nav-offset,6rem)'
 			)}
 		>
 			{@render children()}

--- a/frontend/src/routes/(app)/dashboard/+page.svelte
+++ b/frontend/src/routes/(app)/dashboard/+page.svelte
@@ -590,7 +590,7 @@
 		</Card.Root>
 	</header>
 
-	<section class="flex min-h-0 flex-1 flex-col overflow-hidden">
+	<section class="flex flex-col lg:min-h-0 lg:flex-1 lg:overflow-hidden">
 		<div class="mb-3 flex items-center justify-between gap-3">
 			<h2 class="text-lg font-semibold tracking-tight">{m.dashboard_resource_tables_title()}</h2>
 			<div class="hidden items-center gap-2 md:flex">
@@ -602,7 +602,7 @@
 				</ArcaneButton>
 			</div>
 		</div>
-		<div class="grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-hidden lg:grid-cols-2">
+		<div class="grid grid-cols-1 gap-4 lg:min-h-0 lg:flex-1 lg:grid-cols-2 lg:overflow-hidden">
 			<DashboardContainerTable bind:containers isLoading={false} />
 			<DashboardImageTable bind:images isLoading={false} />
 		</div>

--- a/frontend/src/routes/(app)/dashboard/dash-container-table.svelte
+++ b/frontend/src/routes/(app)/dashboard/dash-container-table.svelte
@@ -30,6 +30,7 @@
 	let displayLimit = $state(containers.pagination?.itemsPerPage ?? 5);
 	let lastMeasuredHeight = $state(0);
 
+	const MOBILE_ROWS = 4;
 	const ROW_HEIGHT = 57;
 	const HEADER_HEIGHT = 145;
 	const FOOTER_HEIGHT = 48;
@@ -47,7 +48,7 @@
 	}
 
 	function calculateLimitForHeight(height: number) {
-		if (isMobile.current) return 10;
+		if (isMobile.current) return MOBILE_ROWS;
 		if (height <= 0) return 5;
 
 		let availableHeight = height - HEADER_HEIGHT;
@@ -150,8 +151,11 @@
 	/>
 {/snippet}
 
-<div class="flex h-full min-h-0 flex-col" bind:clientHeight={() => lastMeasuredHeight, (value) => handleLayoutChange(value)}>
-	<Card.Root class="flex h-full min-h-0 flex-col">
+<div
+	class="flex flex-col lg:h-full lg:min-h-0"
+	bind:clientHeight={() => lastMeasuredHeight, (value) => handleLayoutChange(value)}
+>
+	<Card.Root class="flex flex-col lg:h-full lg:min-h-0">
 		<Card.Header icon={ContainersIcon} class="shrink-0">
 			<div class="flex flex-1 items-center justify-between">
 				<div class="flex flex-col space-y-1.5">
@@ -166,7 +170,7 @@
 				</ArcaneButton>
 			</div>
 		</Card.Header>
-		<Card.Content class="flex min-h-0 flex-1 flex-col px-0">
+		<Card.Content class="px-0 lg:flex lg:min-h-0 lg:flex-1 lg:flex-col">
 			<ArcaneTable
 				items={{ ...containers, data: containers.data.slice(0, displayLimit) }}
 				bind:requestOptions

--- a/frontend/src/routes/(app)/dashboard/dash-image-table.svelte
+++ b/frontend/src/routes/(app)/dashboard/dash-image-table.svelte
@@ -26,6 +26,7 @@
 	let displayLimit = $state(images.pagination?.itemsPerPage ?? 5);
 	let lastMeasuredHeight = $state(0);
 
+	const MOBILE_ROWS = 4;
 	const ROW_HEIGHT = 57;
 	const HEADER_HEIGHT = 145;
 	const FOOTER_HEIGHT = 48;
@@ -45,7 +46,7 @@
 	}
 
 	function calculateLimitForHeight(height: number) {
-		if (isMobile.current) return 10;
+		if (isMobile.current) return MOBILE_ROWS;
 		if (height <= 0) return 5;
 
 		let availableHeight = height - HEADER_HEIGHT;
@@ -155,8 +156,11 @@
 	/>
 {/snippet}
 
-<div class="flex h-full min-h-0 flex-col" bind:clientHeight={() => lastMeasuredHeight, (value) => handleLayoutChange(value)}>
-	<Card.Root class="flex h-full min-h-0 flex-col">
+<div
+	class="flex flex-col lg:h-full lg:min-h-0"
+	bind:clientHeight={() => lastMeasuredHeight, (value) => handleLayoutChange(value)}
+>
+	<Card.Root class="flex flex-col lg:h-full lg:min-h-0">
 		<Card.Header icon={ImagesIcon} class="shrink-0">
 			<div class="flex flex-1 items-center justify-between">
 				<div class="flex flex-col space-y-1.5">
@@ -171,7 +175,7 @@
 				</ArcaneButton>
 			</div>
 		</Card.Header>
-		<Card.Content class="flex min-h-0 flex-1 flex-col px-0">
+		<Card.Content class="px-0 lg:flex lg:min-h-0 lg:flex-1 lg:flex-col">
 			<ArcaneTable
 				items={{ ...images, data: images.data.slice(0, displayLimit) }}
 				bind:requestOptions


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes mobile dashboard layout issues by making height-constraining CSS (`min-h-0`, `flex-1`, `overflow-hidden`) on the resource tables section and the individual table cards apply only at the `lg` breakpoint (≥ 1024 px), so mobile screens render with natural document flow and can scroll freely instead of being clipped inside a fixed-height container.

Key changes:
- **`+layout.svelte`**: Simplifies the mobile-path padding from a responsive `px-2 sm:px-5` scheme to a flat `px-3`, removing the `sm:` overrides that were inside the `isMobile` branch.
- **`+page.svelte`**: Prefixes `min-h-0 flex-1 overflow-hidden` on the tables section and grid with `lg:` so they only activate on large screens.
- **`dash-container-table.svelte` / `dash-image-table.svelte`**: Height and flex-fill constraints moved to `lg:` breakpoint; mobile row cap reduced from 10 → 4 via a new `MOBILE_ROWS` constant (independently defined in both files — see inline comment).
- **`quick-actions.svelte`**: Introduces a tablet-specific icon-only button row (using the existing `IsTablet` hook, which fires at ≤ 1023 px) within the `compact` quick-actions path, replacing the `ActionButtonGroup` at that width.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are purely presentational CSS/breakpoint adjustments with no data-flow or logic risk.

All five files contain straightforward Tailwind breakpoint tweaks. The only non-trivial concern is the duplicated `MOBILE_ROWS` constant across the two table files (a P2 style note), which does not affect correctness. No data, API, or security surfaces are touched.

dash-container-table.svelte and dash-image-table.svelte — duplicate MOBILE_ROWS constant worth consolidating before it drifts.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/lib/components/quick-actions.svelte | Adds tablet-specific compact icon-only button layout (screens ≤ 1023 px) using the existing `IsTablet` hook; desktop (≥ 1024 px) retains the original `ActionButtonGroup`. |
| frontend/src/routes/(app)/+layout.svelte | Simplifies mobile-layout padding from a responsive `px-2 sm:px-5` pattern to a flat `px-3`, and removes the now-redundant `sm:p-5` overrides inside the `isMobile` branch. |
| frontend/src/routes/(app)/dashboard/+page.svelte | Moves `min-h-0 flex-1 overflow-hidden` constraints on the resource-tables section and grid to `lg:` prefix so mobile renders with natural document flow instead of a clipped fixed-height container. |
| frontend/src/routes/(app)/dashboard/dash-container-table.svelte | Restricts `h-full min-h-0` and flex-fill classes to `lg:` breakpoint; reduces the mobile row cap from 10 to 4 via a new `MOBILE_ROWS` constant (duplicated across both table files). |
| frontend/src/routes/(app)/dashboard/dash-image-table.svelte | Mirrors the container-table changes: `lg:`-prefixed height constraints, `Card.Content` flex layout restricted to large screens, and a separately-defined `MOBILE_ROWS = 4` constant. |

</details>

</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fdashboard%2Fdash-container-table.svelte%3A33%0A**Duplicate%20%60MOBILE_ROWS%60%20constant**%0A%0A%60MOBILE_ROWS%20%3D%204%60%20is%20now%20independently%20defined%20in%20both%20%60dash-container-table.svelte%60%20%28line%2033%29%20and%20%60dash-image-table.svelte%60%20%28line%2029%29.%20If%20the%20desired%20mobile%20row%20count%20needs%20to%20change%20in%20the%20future%2C%20both%20files%20must%20be%20updated%20in%20sync.%20A%20mismatch%20would%20cause%20inconsistent%20behaviour%20between%20the%20two%20dashboard%20tables.%0A%0AConsider%20extracting%20this%20to%20a%20shared%20constants%20module%20%28e.g.%20%60%24lib%2Fconfig%2Fdashboard.ts%60%29%20and%20importing%20it%20in%20both%20files%3A%0A%0A%60%60%60ts%0A%2F%2F%20%24lib%2Fconfig%2Fdashboard.ts%0Aexport%20const%20DASHBOARD_MOBILE_ROWS%20%3D%204%3B%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/routes/(app)/dashboard/dash-container-table.svelte
Line: 33

Comment:
**Duplicate `MOBILE_ROWS` constant**

`MOBILE_ROWS = 4` is now independently defined in both `dash-container-table.svelte` (line 33) and `dash-image-table.svelte` (line 29). If the desired mobile row count needs to change in the future, both files must be updated in sync. A mismatch would cause inconsistent behaviour between the two dashboard tables.

Consider extracting this to a shared constants module (e.g. `$lib/config/dashboard.ts`) and importing it in both files:

```ts
// $lib/config/dashboard.ts
export const DASHBOARD_MOBILE_ROWS = 4;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: mobile layout issues on the dashboa..."](https://github.com/getarcaneapp/arcane/commit/5f863ec580605a254455de8a6e242dfaa64b9a13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26511578)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->