### PR TITLE
fix: override browser autofill background color in dark mode

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -888,7 +888,11 @@ main {
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,
-input:-webkit-autofill:active {
+input:-webkit-autofill:active,
+input:autofill,
+input:autofill:hover,
+input:autofill:focus,
+input:autofill:active {
 	-webkit-box-shadow: 0 0 0 9999px transparent inset !important;
 	box-shadow: 0 0 0 9999px transparent inset !important;
 	-webkit-text-fill-color: var(--foreground) !important;


### PR DESCRIPTION
## What This PR Fixes

Fixes #1651

When password managers (1Password, Bitwarden, etc.) autofill the login form, the browser applies `:-webkit-autofill` styling which forces a light/white background on input fields. This clashes with dark mode themes, making the inputs unreadable.

## Changes Made

**`frontend/src/app.css`** — Added `:-webkit-autofill` override rules:

- `box-shadow: 0 0 0 9999px transparent inset` — neutralizes the browser-forced background with a transparent inset shadow
- `-webkit-text-fill-color: var(--foreground)` — keeps text color matching the current theme
- `transition: background-color 5000s` — prevents the browser from re-applying its autofill background

This works across all themes (light, dark, and all color variants) since it uses the existing `--foreground` CSS variable.

## How to Test

1. Use a password manager (1Password, Bitwarden, browser built-in, etc.)
2. Set Arcane to dark mode
3. Navigate to the login page
4. Autofill the username and password fields
5. The input fields should retain the dark background instead of turning white/light

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a dark mode UX bug where browser/password-manager autofill forces a light background on input fields, clashing with the dark theme. It applies the well-established inset `box-shadow` trick on `input:-webkit-autofill` selectors in `frontend/src/app.css` to neutralise the browser-forced background and keeps text legible using the existing `--foreground` CSS variable — meaning the fix is automatically theme-aware across all colour variants.\n\n**Key changes:**\n- Adds `:-webkit-autofill` (+ `:hover`, `:focus`, `:active`) rules with a `0 0 0 9999px transparent inset` box-shadow to cancel the browser autofill background\n- Sets `-webkit-text-fill-color: var(--foreground)` so text colour always matches the active theme\n- Uses `transition: background-color 5000s` to delay the browser re-applying its autofill style\n\n**Findings:**\n- The standard, unprefixed `:autofill` pseudo-class (Firefox 86+) is absent. Firefox password-manager autofill would not be covered by this fix — adding the unprefixed selectors alongside the `-webkit-` variants would make the fix cross-browser.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a well-known, additive CSS-only fix with no risk of regressions.

The only finding is a P2 suggestion to also include the standard `:autofill` pseudo-class for Firefox coverage. There are no logic errors, security issues, or breaking changes. The existing approach (inset shadow + CSS variable) is correct and widely used.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/app.css | Adds :-webkit-autofill override rules using the inset box-shadow trick and --foreground CSS variable; works across all themes but only covers WebKit browsers (Chrome/Safari), not Firefox. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Browser / Password Manager autofills input] --> B{Which browser?}
    B -->|Chrome / Safari / Edge\nWebKit-based| C[:-webkit-autofill fires]
    B -->|Firefox 86+| D[:autofill fires]
    C --> E[inset box-shadow covers\nbrowser-forced background]
    E --> F[-webkit-text-fill-color\nset to var--foreground]
    F --> G[transition: background-color 5000s\ndelays re-application]
    G --> H[✅ Dark background preserved]
    D -->|rule NOT present in this PR| I[⚠️ Browser forced background\nnot overridden]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/app.css
Line: 888-896

Comment:
**Missing standard `:autofill` for Firefox**

Firefox 86+ supports the unprefixed standard `:autofill` pseudo-class. The current rules are WebKit-only (`-webkit-autofill`), so Firefox users who autofill via a password manager would still see the forced browser background in dark mode.

Adding the unprefixed selectors alongside the existing ones would cover Firefox as well:

```suggestion
input:-webkit-autofill,
input:-webkit-autofill:hover,
input:-webkit-autofill:focus,
input:-webkit-autofill:active,
input:autofill,
input:autofill:hover,
input:autofill:focus,
input:autofill:active {
	-webkit-box-shadow: 0 0 0 9999px transparent inset !important;
	box-shadow: 0 0 0 9999px transparent inset !important;
	-webkit-text-fill-color: var(--foreground) !important;
	transition: background-color 5000s ease-in-out 0s;
}
```

Note: Firefox's autofill implementation differs — it typically uses a backdrop filter rather than a forced `background-color`, so the visual improvement in Firefox may be less dramatic, but including the standard selector is still good defensive practice and aligns with the spec.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: override browser autofill backgroun..."](https://github.com/getarcaneapp/arcane/commit/9c70417dd2b39021af6c28a80e2b5dfd1b3a9c14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26557846)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->