### PR TITLE
fix: project save button not showing in tree view

### DIFF
--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -123,14 +123,20 @@
 	let composeValidationReady = $state(false);
 	let envValidationReady = $state(false);
 	let includeFilesValidationReady = $state<Record<string, boolean>>({});
+	let composeHasChanges = $derived($inputs.composeContent.value !== originalComposeContent);
+	let envHasChanges = $derived($inputs.envContent.value !== originalEnvContent);
+	let changedIncludeFilePaths = $derived.by(() =>
+		Object.keys(includeFilesState).filter(
+			(relativePath) => includeFilesState[relativePath] !== originalIncludeFiles[relativePath]
+		)
+	);
 
 	let hasAnyErrors = $derived(
-		!composeValidationReady ||
-			!envValidationReady ||
-			Object.values(includeFilesValidationReady).some((isReady) => !isReady) ||
-			composeHasErrors ||
-			envHasErrors ||
-			Object.values(includeFilesHasErrors).some((hasError) => hasError)
+		(composeHasChanges && (!composeValidationReady || composeHasErrors)) ||
+			(envHasChanges && (!envValidationReady || envHasErrors)) ||
+			changedIncludeFilePaths.some(
+				(relativePath) => !includeFilesValidationReady[relativePath] || !!includeFilesHasErrors[relativePath]
+			)
 	);
 
 	let canSave = $derived(hasChanges && !hasAnyErrors);
@@ -334,9 +340,14 @@
 				let savedProject = updatedProject;
 
 				for (const relativePath of Object.keys(includeFilesState)) {
-					if (includeFilesState[relativePath] !== originalIncludeFiles[relativePath]) {
+					const includeFileContent = includeFilesState[relativePath];
+					if (includeFileContent === undefined) {
+						continue;
+					}
+
+					if (includeFileContent !== originalIncludeFiles[relativePath]) {
 						const includeResult = await tryCatch(
-							projectService.updateProjectIncludeFile(projectId, relativePath, includeFilesState[relativePath])
+							projectService.updateProjectIncludeFile(projectId, relativePath, includeFileContent)
 						);
 						if (includeResult.error) {
 							toast.error(includeResult.error.message || m.common_update_failed({ resource: relativePath }));
@@ -529,7 +540,7 @@
 
 		{#snippet headerActions()}
 			<div class="flex items-center gap-2">
-				{#if hasChanges && !hasAnyErrors}
+				{#if hasChanges}
 					<ArcaneButton
 						action="save"
 						loading={isLoading.saving}
@@ -715,6 +726,12 @@
 												bind:value={$inputs.composeContent.value}
 												error={$inputs.composeContent.error ?? undefined}
 												readOnly={!canEditCompose}
+												bind:hasErrors={composeHasErrors}
+												bind:validationReady={composeValidationReady}
+												fileId={`project:${projectId}:compose`}
+												originalValue={originalComposeContent}
+												enableDiff={true}
+												editorContext={codeEditorContext}
 											/>
 										{:else if selectedFile === 'env'}
 											<CodePanel
@@ -723,6 +740,13 @@
 												language="env"
 												bind:value={$inputs.envContent.value}
 												error={$inputs.envContent.error ?? undefined}
+												readOnly={!canEditEnv}
+												bind:hasErrors={envHasErrors}
+												bind:validationReady={envValidationReady}
+												fileId={`project:${projectId}:env`}
+												originalValue={originalEnvContent}
+												enableDiff={true}
+												editorContext={codeEditorContext}
 											/>
 										{:else if selectedFile.startsWith('dir:')}
 											{@const dirRelPath = selectedFile.slice(4)}
@@ -744,6 +768,12 @@
 													title={includeFile.relativePath}
 													language="yaml"
 													bind:value={includeFilesState[includeFile.relativePath]}
+													bind:hasErrors={includeFilesHasErrors[includeFile.relativePath]}
+													bind:validationReady={includeFilesValidationReady[includeFile.relativePath]}
+													fileId={`project:${projectId}:include:${includeFile.relativePath}`}
+													originalValue={originalIncludeFiles[includeFile.relativePath]}
+													enableDiff={true}
+													editorContext={codeEditorContext}
 												/>
 											{/if}
 										{/if}

--- a/frontend/src/routes/(app)/projects/components/CodePanel.svelte
+++ b/frontend/src/routes/(app)/projects/components/CodePanel.svelte
@@ -10,9 +10,9 @@
 
 	let {
 		title,
-		open = $bindable(),
+		open = $bindable(true),
 		language,
-		value = $bindable(),
+		value = $bindable(''),
 		error,
 		autoHeight = false,
 		readOnly = false,
@@ -38,9 +38,9 @@
 		commandPaletteOpen = $bindable(false)
 	}: {
 		title: string;
-		open: boolean;
+		open?: boolean;
 		language: CodeLanguage;
-		value: string;
+		value?: string;
 		error?: string;
 		autoHeight?: boolean;
 		readOnly?: boolean;

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -898,6 +898,72 @@ test.describe('Project Detail Page', () => {
 		}
 	});
 
+	test('should enable Save when editing the initial file in restored tree view', async ({
+		page
+	}) => {
+		const regularProject = realProjects.find((p) => !p.gitOpsManagedBy);
+		test.skip(!regularProject, 'No regular (non-GitOps) projects found');
+
+		await page.goto(`/projects/${regularProject!.id || regularProject!.name}`);
+		await page.waitForLoadState('networkidle');
+
+		const configTab = page.getByRole('tab', { name: /Configuration|Config/i });
+		await configTab.click();
+		await page.waitForLoadState('networkidle');
+
+		let layoutSwitch = page.getByRole('switch', {
+			name: /Classic|Tree View/i
+		});
+		test.skip(
+			(await layoutSwitch.count()) === 0,
+			'No layout switch available for project configuration'
+		);
+
+		const projectFilesHeading = page.getByRole('heading', {
+			name: /Project Files/i
+		});
+
+		if (!(await projectFilesHeading.isVisible().catch(() => false))) {
+			await layoutSwitch.click();
+			await expect(projectFilesHeading).toBeVisible();
+		}
+
+		await page.reload();
+		await page.waitForLoadState('networkidle');
+
+		const restoredConfigTab = page.getByRole('tab', { name: /Configuration|Config/i });
+		if ((await restoredConfigTab.getAttribute('aria-selected')) !== 'true') {
+			await restoredConfigTab.click();
+			await page.waitForLoadState('networkidle');
+		}
+
+		await expect(projectFilesHeading).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'compose.yaml' })).toBeVisible();
+
+		const treeComposeEditor = page.locator('.cm-editor:visible').first();
+		await expect(treeComposeEditor).toBeVisible();
+
+		const marker = `ARCANE_TREE_SAVE_${Date.now()}`;
+		const originalCompose = await getCodeMirrorValue(treeComposeEditor);
+		const updatedCompose = `${originalCompose.trimEnd()}\n# ${marker}\n`;
+		await setCodeMirrorValue(page, treeComposeEditor, updatedCompose);
+
+		const saveButton = page.getByRole('button', { name: 'Save', exact: true }).first();
+		await expect(saveButton).toBeVisible();
+		await expect(saveButton).toBeEnabled();
+
+		const envFileButton = page.getByRole('button', { name: '.env' }).first();
+		await expect(envFileButton).toBeVisible();
+
+		layoutSwitch = page.getByRole('switch', {
+			name: /Classic|Tree View/i
+		});
+		await layoutSwitch.click();
+		await expect(page.getByRole('heading', { name: 'compose.yaml' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Save', exact: true }).first()).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Save', exact: true }).first()).toBeEnabled();
+	});
+
 	test('should show logs tab for running projects', async ({ page }) => {
 		test.skip(!realProjects.length, 'No projects available for logs test');
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2099

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the bug where the Save button was not appearing in the project tree-view layout. The root causes were: (1) the tree-view `CodePanel` instances were missing `bind:hasErrors` and `bind:validationReady` props, so validation state was never propagated back and `hasAnyErrors` remained permanently `true`; and (2) the old `hasAnyErrors` logic blocked saving whenever *any* file's validation was not ready, even for files the user had not touched. The fix addresses both problems and improves UX by keeping the Save button visible-but-disabled while validation is in progress rather than hiding it entirely.\n\n**Key changes:**\n- Added `bind:hasErrors`, `bind:validationReady`, `fileId`, `originalValue`, `enableDiff`, and `editorContext` to all three tree-view `CodePanel` usages (compose, env, include files).\n- Refactored `hasAnyErrors` to only gate on files that were actually changed (`composeHasChanges`, `envHasChanges`, `changedIncludeFilePaths`), avoiding false-positive blocking from unchanged files whose validators haven't initialised.\n- Changed save-button visibility from `{#if hasChanges && !hasAnyErrors}` to `{#if hasChanges}` with `disabled={!canSave}`, giving users visible feedback when validation is pending.\n- Made `open` and `value` optional in `CodePanel` to reduce prop-drilling requirements.\n- Added a defensive `undefined` guard in the include-file save loop.\n- Added a focused E2E test covering the restored tree-view save scenario.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — fixes a clear regression with no new correctness issues introduced.

All changes are well-scoped to the reported bug. The hasAnyErrors logic is sound: it still blocks saving when a changed file has validation errors or when its validator has not yet reported, so no invalid content can be saved. The button visibility change is a pure UX improvement. The test covers the exact regression scenario. No P0/P1 findings were identified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/routes/(app)/projects/[projectId]/+page.svelte | Root-cause fix: adds missing bind:hasErrors, bind:validationReady, fileId, originalValue, enableDiff, and editorContext props to tree-view CodePanel instances; also refines hasAnyErrors to gate only on files that were actually changed, and shows the Save button whenever hasChanges (disabled when !canSave). |
| frontend/src/routes/(app)/projects/components/CodePanel.svelte | Makes open and value props optional with sensible defaults (true and '') so the component can be used in contexts (e.g. tree view) where those values may not be explicitly provided. |
| tests/spec/project.spec.ts | New E2E test verifies save button is visible and enabled after editing in a restored tree-view layout, including persistence across a classic/tree layout toggle. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: project save button not showing in ..."](https://github.com/getarcaneapp/arcane/commit/298d99e130ec3a1980f7f6ca74f802df9693b91c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26615092)</sub>

<!-- /greptile_comment -->