### PR TITLE
fix: decouple compose operations from HTTP request context

### DIFF
--- a/backend/pkg/projects/cmds.go
+++ b/backend/pkg/projects/cmds.go
@@ -39,11 +39,11 @@ func writeJSONLine(w io.Writer, v any) {
 const defaultComposeTimeout = 30 * time.Minute
 
 // detachFromHTTPContextInternal creates a new context derived from
-// context.Background() that carries any values from the parent (such as
-// ProgressWriterKey) but is **not** cancelled when the parent is.
-// This allows compose operations to survive HTTP request timeouts and
-// proxy deadline cancellations. A standalone timeout is applied so the
-// operation cannot run forever. See #1209.
+// context.WithoutCancel(parent) that carries any values from the parent
+// (such as ProgressWriterKey) but is **not** cancelled or deadline-bounded
+// by the parent. This allows compose operations to survive HTTP request
+// timeouts and proxy deadline cancellations. A standalone timeout is applied
+// so the operation cannot run forever. See #1209.
 func detachFromHTTPContextInternal(parent context.Context) (context.Context, context.CancelFunc) {
 	ctx := context.WithoutCancel(parent)
 	return context.WithTimeout(ctx, defaultComposeTimeout)

--- a/backend/pkg/projects/cmds_test.go
+++ b/backend/pkg/projects/cmds_test.go
@@ -3,6 +3,7 @@ package projects
 import (
 	"context"
 	"testing"
+	"time"
 
 	composetypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,22 @@ func TestDetachFromHTTPContextInternal(t *testing.T) {
 		deadline, ok := detached.Deadline()
 		require.True(t, ok)
 		require.False(t, deadline.IsZero())
+	})
+
+	t.Run("survives parent deadline expiry", func(t *testing.T) {
+		parent, parentCancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+		defer parentCancel()
+
+		time.Sleep(5 * time.Millisecond) // ensure parent deadline has passed
+
+		detached, detachedCancel := detachFromHTTPContextInternal(parent)
+		defer detachedCancel()
+
+		require.NoError(t, detached.Err())
+
+		deadline, ok := detached.Deadline()
+		require.True(t, ok)
+		require.InDelta(t, float64(defaultComposeTimeout), float64(time.Until(deadline)), float64(5*time.Second))
 	})
 }
 


### PR DESCRIPTION
## Checklist

- [x] This PR is **not** opened from my fork's `main` branch

## What This PR Implements

Decouples Docker Compose operations from the HTTP request lifecycle so they survive proxy timeouts and client disconnects.

Fixes #1209

## The Problem

All compose operations (`up`, `pull`, `stop`, `down`, `restart`) run within the HTTP request context. When the operation takes longer than the proxy timeout (default 60s for `ProxyRequestTimeout`, 5min for edge proxy), the context is cancelled mid-operation:

```
Failed to Redeploy project: Proxy request failed:
Post "http://192.168.2.201:3553/api/.../redeploy": context deadline exceeded
```

This leaves containers in an inconsistent state (partially stopped, partially created). The issue is especially common with:
- Remote agent setups (proxy adds an extra timeout layer)
- Projects with many services or large images to pull
- Services with health checks (adds 2min wait per service)
- Redeploying stopped projects (must pull + recreate everything)

## Changes Made

**`backend/pkg/projects/cmds.go`**:
- New `detachFromHTTPContextInternal()` uses `context.WithoutCancel()` (Go 1.21+) to create a context that preserves values (like `ProgressWriterKey` for streaming progress) but is **not** cancelled when the parent HTTP context expires
- A standalone 30-minute timeout is applied to prevent operations from running forever
- Applied to all compose commands: `ComposeUp`, `ComposePull`, `ComposeStop`, `ComposeDown`, `ComposeRestart`

**`backend/pkg/projects/cmds_test.go`**:
- Tests verifying the detached context survives parent cancellation, preserves values, and has its own deadline

## Why This Approach

- **Minimal change** — only `cmds.go` is modified, no API changes, no frontend changes
- **Safe** — operations still have a timeout (30min), just not tied to HTTP
- **Correct** — `context.WithoutCancel` preserves the value chain (progress writer, logging context) while removing the cancellation chain
- **Consistent** — all compose commands get the same treatment

## Testing Done

- [x] Unit tests for `detachFromHTTPContextInternal` (parent cancellation survival, value preservation, deadline presence)
- [x] Existing `TestComposeStopSkipsWhenNoServicesSpecified` still passes
- [x] Code review: verified no compose operation still uses the raw HTTP context

## AI Tool Used (if applicable)

AI Tool: N/A
Assistance Level: N/A

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a production reliability issue (#1209) where Docker Compose operations (`up`, `pull`, `stop`, `down`, `restart`) were silently aborted mid-execution when a proxy deadline expired, leaving containers in inconsistent states. The fix introduces `detachFromHTTPContextInternal` which uses `context.WithoutCancel` (Go 1.21+) to strip the parent HTTP context's cancellation and deadline signals while preserving its value chain (e.g. `ProgressWriterKey` for progress streaming), then applies a fresh 30-minute standalone timeout.

**Key changes:**
- New helper `detachFromHTTPContextInternal` correctly isolates all five mutating compose operations from the HTTP request lifecycle
- Read-only and streaming operations (`ComposePs`, `ComposeLogs`, `ListGlobalComposeContainers`) are intentionally left on the HTTP context — appropriate given they should be tied to the connection lifetime
- Three unit tests cover the core contract (survives explicit cancellation, value preservation, deadline presence)
- Minor issues found: the doc comment for `detachFromHTTPContextInternal` inaccurately says the context is "derived from `context.Background()`" (it is derived from `context.WithoutCancel(parent)`); `ProgressWriterKey` in `ComposeUp` is read from the original `ctx` rather than `composeCtx` (functionally equivalent today but inconsistent); tests cover explicit-cancel parents but not deadline-based parents (the actual proxy timeout scenario)
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the core logic is correct and well-tested; remaining findings are minor documentation and style issues.

All three open comments are P2 (style/docs/test-coverage gaps). The implementation correctly uses `context.WithoutCancel` which strips both the parent's cancellation and deadline, then independently applies a 30-minute timeout — this is exactly the right approach. `ComposePs`/`ComposeLogs`/`ListGlobalComposeContainers` are correctly left on the HTTP context. No correctness, data-integrity, or security concerns.

No files require special attention; the doc comment inaccuracy in `cmds.go` is the most impactful of the minor findings.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/pkg/projects/cmds.go | Introduces `detachFromHTTPContextInternal` using `context.WithoutCancel` (Go 1.21+) to decouple all mutating compose operations from the HTTP request lifecycle; implementation is correct but the doc comment misattributes the parent as `context.Background()`, and `ComposeUp` still reads `ProgressWriterKey` from the original HTTP context instead of `composeCtx`. |
| backend/pkg/projects/cmds_test.go | Adds three unit tests for `detachFromHTTPContextInternal` covering explicit-cancel survival, value preservation, and deadline presence; missing a test for deadline-based parent cancellation (the primary real-world scenario from proxy timeouts). |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Proxy as Edge Proxy
    participant HTTP as HTTP Handler
    participant ComposeOp as Compose Operation
    participant Docker as Docker Daemon

    Note over Proxy,HTTP: Before this PR
    Proxy->>HTTP: POST /api/.../redeploy
    HTTP->>ComposeOp: ComposeUp(httpCtx)
    Note over Proxy,HTTP: Proxy timeout (60s) expires
    Proxy--xHTTP: context deadline exceeded
    HTTP--xComposeOp: ctx cancelled → operation aborted mid-run
    ComposeOp--xDocker: partial state (containers half-stopped)

    Note over Proxy,HTTP: After this PR
    Proxy->>HTTP: POST /api/.../redeploy
    HTTP->>ComposeOp: ComposeUp(httpCtx)
    ComposeOp->>ComposeOp: detachFromHTTPContextInternal(httpCtx) → composeCtx (30min timeout, values preserved)
    Note over Proxy,HTTP: Proxy timeout (60s) expires
    Proxy--xHTTP: context deadline exceeded (HTTP ctx cancelled)
    Note over ComposeOp,Docker: composeCtx unaffected — operation continues
    ComposeOp->>Docker: svc.Up(composeCtx, ...)
    Docker-->>ComposeOp: complete
    ComposeOp-->>ComposeOp: done (or 30min timeout)
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/pkg/projects/cmds.go`, line 119 ([link](https://github.com/getarcaneapp/arcane/blob/9335348de4315221b7f0ba078f9389bd4b8bcf7d/backend/pkg/projects/cmds.go#L119)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`ProgressWriterKey` lookup uses original HTTP context instead of `composeCtx`**

   `progressWriter` is read from `ctx` (the raw HTTP context) while every other operation in this function already uses `composeCtx`. Because `context.WithoutCancel` preserves the value chain, both return the same writer today — but the inconsistency is a future footgun: if the lookup chain changes (e.g., a middleware wraps the key), a reader scanning this function would not immediately see that the detached context is in use for value retrieval.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/pkg/projects/cmds.go
   Line: 119

   Comment:
   **`ProgressWriterKey` lookup uses original HTTP context instead of `composeCtx`**

   `progressWriter` is read from `ctx` (the raw HTTP context) while every other operation in this function already uses `composeCtx`. Because `context.WithoutCancel` preserves the value chain, both return the same writer today — but the inconsistency is a future footgun: if the lookup chain changes (e.g., a middleware wraps the key), a reader scanning this function would not immediately see that the detached context is in use for value retrieval.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/projects/cmds.go
Line: 41-44

Comment:
**Misleading doc comment — not derived from `context.Background()`**

The comment says the returned context is "derived from `context.Background()`", but the implementation derives it from `context.WithoutCancel(parent)`, which is semantically different. The `WithoutCancel` wrapper preserves the parent's value chain while dropping its cancellation and deadline signals, then a fresh 30-minute timeout is layered on top. A reader following the comment alone would expect no values to be inherited, which is the opposite of the intent.

```suggestion
// detachFromHTTPContextInternal creates a new context derived from
// context.WithoutCancel(parent) that carries any values from the parent
// (such as ProgressWriterKey) but is **not** cancelled or deadline-bounded
// by the parent. This allows compose operations to survive HTTP request
// timeouts and proxy deadline cancellations. A standalone timeout is applied
// so the operation cannot run forever. See #1209.
func detachFromHTTPContextInternal(parent context.Context) (context.Context, context.CancelFunc) {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/projects/cmds.go
Line: 119

Comment:
**`ProgressWriterKey` lookup uses original HTTP context instead of `composeCtx`**

`progressWriter` is read from `ctx` (the raw HTTP context) while every other operation in this function already uses `composeCtx`. Because `context.WithoutCancel` preserves the value chain, both return the same writer today — but the inconsistency is a future footgun: if the lookup chain changes (e.g., a middleware wraps the key), a reader scanning this function would not immediately see that the detached context is in use for value retrieval.

```suggestion
	progressWriter, _ := composeCtx.Value(ProgressWriterKey{}).(io.Writer)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/projects/cmds_test.go
Line: 12-26

Comment:
**Test exercises explicit cancellation but not deadline-based cancellation**

The real-world scenario this PR fixes (`ProxyRequestTimeout`, edge proxy limits) produces deadline-based context cancellation — the parent is created with `context.WithTimeout` / `context.WithDeadline`, not `context.WithCancel`. Adding a subtest using a timed-out parent would directly mirror the bug scenario and protect against any future regression involving deadline propagation.

```go
t.Run("survives parent deadline expiry", func(t *testing.T) {
    parent, parentCancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
    defer parentCancel()

    time.Sleep(5 * time.Millisecond) // ensure parent deadline has passed

    detached, detachedCancel := detachFromHTTPContextInternal(parent)
    defer detachedCancel()

    require.NoError(t, detached.Err())

    deadline, ok := detached.Deadline()
    require.True(t, ok)
    require.InDelta(t, float64(defaultComposeTimeout), float64(time.Until(deadline)), float64(5*time.Second))
})
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: decouple compose operations from HT..."](https://github.com/getarcaneapp/arcane/commit/9335348de4315221b7f0ba078f9389bd4b8bcf7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26649266)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Rule used - # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

<!-- /greptile_comment -->