### PR TITLE
fix: update com.docker.compose.image label when recreating container

### DIFF
--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -792,6 +792,19 @@ func (s *UpdaterService) updateContainer(ctx context.Context, cnt container.Summ
 	cfg := inspect.Config
 	cfg.Image = newRef
 
+	// Update the com.docker.compose.image label so that `docker compose up -d`
+	// recognises the container as up-to-date and does not recreate it.
+	if cfg.Labels != nil {
+		if _, ok := cfg.Labels["com.docker.compose.image"]; ok {
+			if imgInspect, err := dcli.ImageInspect(ctx, newRef); err == nil {
+				cfg.Labels["com.docker.compose.image"] = imgInspect.ID
+			} else {
+				slog.WarnContext(ctx, "updateContainer: could not inspect new image to update compose label",
+					"newRef", newRef, "err", err)
+			}
+		}
+	}
+
 	hostConfig, sanitizedMemorySwappiness, engineInfo, err := libarcane.PrepareRecreateHostConfigForEngine(ctx, dcli, inspect.HostConfig)
 	if err != nil {
 		return fmt.Errorf("prepare host config: %w", err)


### PR DESCRIPTION
## Checklist

- [x] This PR is **not** opened from my fork's `main` branch

## What This PR Fixes

When Arcane updates a container via the standalone path (i.e. when the compose project is not registered in the DB), it copies all labels from the old container verbatim — including `com.docker.compose.image`, which stores the old image ID.

After the update, running `docker compose up -d` sees that `com.docker.compose.image` doesn't match the current image ID and **recreates the container**, breaking compatibility with `docker compose`.

Fixes #1935

## Root Cause

In `updateContainer()`, the container config (including all labels) is copied from the old container and only `cfg.Image` is updated to the new ref. The `com.docker.compose.image` label is left pointing to the old image ID.

Docker Compose uses this label to determine whether a container is up-to-date. A mismatch triggers an unnecessary recreate.

## Changes Made

- **`updater_service.go`** — After setting `cfg.Image = newRef`, inspect the newly pulled image and update `com.docker.compose.image` to the new image ID (only when the label already exists on the container). Falls back gracefully with a warning log if the image inspect fails.

## Why This Is Safe

- The label is only updated when it already exists (i.e. only for compose-managed containers)
- The compose-aware update path (`UpdateProjectServices` → `docker compose up`) is not affected
- If `ImageInspect` fails for any reason, the old behavior is preserved (label unchanged) with a warning log
- No changes to container creation, networking, or other config

## Testing Done

- [x] `go vet ./internal/services/` — no issues
- [x] `go test ./internal/services/ -run TestUpdater` — all tests pass

## AI Tool Used (if applicable)

AI Tool: N/A
Assistance Level: N/A

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a label-staleness bug in the standalone (non-compose-DB) container update path: after Arcane recreates a container with a new image, the `com.docker.compose.image` label was left pointing to the old image ID, causing `docker compose up -d` to trigger a redundant recreate. The fix inspects the newly-pulled image immediately after setting `cfg.Image = newRef` and updates the label to the fresh image ID — only when the label already exists on the container, and with a graceful fallback if the inspect fails.

**Key changes**
- `updater_service.go`: After updating `cfg.Image`, calls `dcli.ImageInspect` to resolve the new image ID and writes it back to `cfg.Labels[\"com.docker.compose.image\"]`. The update is guarded by a nil-check on `cfg.Labels` and an existence-check for the label key, so containers that were never compose-managed are unaffected.
- The change is isolated to the standalone update path (`updateContainer`); the compose-aware path (`UpdateProjectServices`) is unchanged.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is narrowly scoped, well-guarded, and does not affect the compose-aware update path.

The only finding is a pre-existing P2 naming-convention issue (`updateContainer` should be `updateContainerInternal`) that this PR touches but did not introduce. The logic itself is correct: it guards against a nil Labels map, only updates the key when it already exists, and falls back gracefully on inspect failure. No new security, correctness, or reliability concerns were introduced.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/updater_service.go | Adds a guarded update of the `com.docker.compose.image` label inside `updateContainer` so that after a standalone image refresh the label reflects the new image ID, preventing Docker Compose from treating the container as stale. Logic is well-guarded (nil-check, existence-check, graceful fallback). Pre-existing naming-convention violation: function should be `updateContainerInternal`. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[updateContainer called] --> B[Stop old container]
    B --> C[Remove old container]
    C --> D["cfg := inspect.Config\ncfg.Image = newRef"]
    D --> E{cfg.Labels != nil?}
    E -- No --> H
    E -- Yes --> F{"com.docker.compose.image\nexists in labels?"}
    F -- No --> H
    F -- Yes --> G["dcli.ImageInspect(ctx, newRef)"]
    G -- success --> I["cfg.Labels[com.docker.compose.image] = imgInspect.ID"]
    G -- error --> J["slog.WarnContext: could not inspect new image"]
    I --> H
    J --> H[PrepareRecreateHostConfigForEngine]
    H --> K[ContainerCreate with updated cfg]
    K --> L[Start new container]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/internal/services/updater_service.go`, line 748 ([link](https://github.com/getarcaneapp/arcane/blob/5269499ed58e308f78e8d475bde8120b05ba6490/backend/internal/services/updater_service.go#L748)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`updateContainer` missing "Internal" suffix**

   Per the project's naming convention, all unexported functions must carry an `Internal` suffix. `updateContainer` (and its two call sites at lines 640 and 1535) should be renamed to `updateContainerInternal` for consistency with the rest of the file (e.g. `pruneImageIDsWithInUseSetInternal`, `collectUsedImagesFromContainersInternal`, `buildRunningImageIDSetInternal`).

   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/updater_service.go
   Line: 748
   
   Comment:
   **`updateContainer` missing "Internal" suffix**
   
   Per the project's naming convention, all unexported functions must carry an `Internal` suffix. `updateContainer` (and its two call sites at lines 640 and 1535) should be renamed to `updateContainerInternal` for consistency with the rest of the file (e.g. `pruneImageIDsWithInUseSetInternal`, `collectUsedImagesFromContainersInternal`, `buildRunningImageIDSetInternal`).
   
   
   
   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/updater_service.go
Line: 748

Comment:
**`updateContainer` missing "Internal" suffix**

Per the project's naming convention, all unexported functions must carry an `Internal` suffix. `updateContainer` (and its two call sites at lines 640 and 1535) should be renamed to `updateContainerInternal` for consistency with the rest of the file (e.g. `pruneImageIDsWithInUseSetInternal`, `collectUsedImagesFromContainersInternal`, `buildRunningImageIDSetInternal`).

```suggestion
func (s *UpdaterService) updateContainerInternal(ctx context.Context, cnt container.Summary, inspect container.InspectResponse, newRef string) error {
```

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: update com.docker.compose.image lab..."](https://github.com/getarcaneapp/arcane/commit/5269499ed58e308f78e8d475bde8120b05ba6490) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26686911)</sub>

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->