### PR TITLE
feat: add toggle to hide unexposed ports in container table

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -508,7 +508,7 @@
 	"containers_env_vars_description": "Runtime environment variables for your container",
 	"containers_no_env_vars": "No environment variables",
 	"containers_no_ports": "No ports",
-	"containers_hide_exposed_ports": "Hide unexposed ports",
+	"containers_hide_unexposed_ports": "Hide unexposed ports",
 	"containers_show_fewer_ports": "Show fewer ports",
 	"containers_show_more_ports": "Show {count} more ports",
 	"containers_no_labels_defined": "No labels defined",

--- a/frontend/src/lib/components/badges/port-badge.svelte
+++ b/frontend/src/lib/components/badges/port-badge.svelte
@@ -78,7 +78,11 @@
 	);
 	const published = $derived(visiblePorts.filter((p) => p.isPublished));
 	const exposedOnly = $derived(hideExposed ? [] : visiblePorts.filter((p) => !p.isPublished));
-	const hiddenCount = $derived(allPorts.length - visiblePorts.length);
+	const hiddenCount = $derived(
+		hideExposed
+			? allPorts.filter((p) => p.isPublished).length - published.length
+			: allPorts.length - visiblePorts.length
+	);
 </script>
 
 {#if allPorts.length === 0}

--- a/frontend/src/routes/(app)/containers/container-table.svelte
+++ b/frontend/src/routes/(app)/containers/container-table.svelte
@@ -702,6 +702,6 @@
 		{`${m.common_show()} ${m.internal()} ${m.containers_title()}`}
 	</DropdownMenu.CheckboxItem>
 	<DropdownMenu.CheckboxItem bind:checked={() => hideExposedPorts, (v) => { customSettings = { ...customSettings, hideExposedPorts: !!v }; }}>
-		{m.containers_hide_exposed_ports()}
+		{m.containers_hide_unexposed_ports()}
 	</DropdownMenu.CheckboxItem>
 {/snippet}


### PR DESCRIPTION
## Checklist

- [x] This PR is **not** opened from my fork's `main` branch

## What This PR Implements

Adds a **"Hide unexposed ports"** toggle in the container table's view options dropdown (alongside "Group by project" and "Show internal containers"). When enabled, only published (host-mapped) ports are shown in the Ports column, hiding exposed-only ports that clutter the view.

Closes #1105

## Changes Made

- **`port-badge.svelte`** — New `hideExposed` prop. When `true`, the `exposedOnly` derived array returns empty, hiding all non-published ports
- **`container-table.svelte`** — New `hideExposedPorts` setting derived from persisted `customSettings`, passed to `PortBadge` in both desktop and mobile views. Toggle added to `CustomViewOptions` dropdown
- **`en.json`** — New i18n key `containers_hide_exposed_ports`

## How It Works

- The toggle is persisted via the existing `customSettings` mechanism (same as `showInternalContainers`)
- Default is `false` (show all ports, current behavior preserved)
- Applies to both desktop table and mobile card views
- The `PortBadge` component handles the filtering internally — no changes needed to data fetching

## Testing Done

- [x] Code review: all paths verified
- [x] Consistent with existing patterns (`showInternal` toggle)

## AI Tool Used (if applicable)

AI Tool: N/A
Assistance Level: N/A

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a "Hide unexposed ports" toggle to the container table's view options, filtering the `PortBadge` component to only show published (host-mapped) ports. The implementation is clean and follows the existing `customSettings` persistence pattern correctly.

Two issues in `port-badge.svelte` are worth addressing:

- **Empty ports cell (P1):** When `hideExposed=true` and a container has *only* exposed-only ports (e.g. a DB image with `EXPOSE 5432` but no `-p` mapping), `allPorts.length > 0` bypasses the "No ports" fallback, leaving the ports cell completely empty with no user feedback.
- **Misleading "show more" count (P2):** `hiddenCount` is derived from the full port list before the `hideExposed` filter, so the `+N` expand button may promise ports that are actually all hidden — clicking it reveals nothing new.
- **i18n key/value mismatch (P2):** The key `containers_hide_exposed_ports` and the displayed string `"Hide unexposed ports"` use opposite Docker terminology; aligning them would help future translators.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after addressing the empty-div P1 bug in port-badge.svelte; the misleading expand-count and i18n naming are P2 polish items.

One P1 finding (empty ports cell for exposed-only containers when hideExposed=true) should be fixed before merging; remaining issues are UX/naming quality concerns that do not block functionality for the common case.

frontend/src/lib/components/badges/port-badge.svelte — the `allPorts.length === 0` guard and `hiddenCount` derivation both need to account for the `hideExposed` filter.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/components/badges/port-badge.svelte | Adds `hideExposed` prop that zeroes out the `exposedOnly` derived array; two issues: (1) the "No ports" guard doesn't fire when all remaining ports are exposed-only and hideExposed=true, leaving an empty div; (2) `hiddenCount` still counts hidden exposed ports, making the "+N expand" button misleading. |
| frontend/src/routes/(app)/containers/container-table.svelte | Adds `hideExposedPorts` derived from `customSettings` and passes it to both desktop and mobile `PortBadge` instances; toggle correctly mutates `customSettings` inline (no server refetch needed, unlike `showInternal`). Pattern is consistent with existing custom settings. |
| frontend/messages/en.json | Adds `containers_hide_exposed_ports` key with value "Hide unexposed ports"; the key name and value use contradictory Docker terminology (exposed vs unexposed). |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens View Options] --> B[Toggles 'Hide unexposed ports']
    B --> C[customSettings.hideExposedPorts updated]
    C --> D[hideExposedPorts derived recomputes]
    D --> E[PortBadge receives hideExposed prop]
    E --> F{hideExposed = true?}
    F -- Yes --> G[exposedOnly = empty array]
    F -- No --> H[exposedOnly = non-published ports]
    G --> I{allPorts.length === 0?}
    H --> I
    I -- Yes --> J[Show 'No ports' message]
    I -- No --> K{published.length === 0 AND exposedOnly empty?}
    K -- Yes --> L[⚠️ Renders empty div - no feedback to user]
    K -- No --> M[Render published + exposedOnly badges]
    M --> N{allPorts.length > maxVisible?}
    N -- Yes --> O[Show +hiddenCount button ⚠️ count includes hidden ports]
    N -- No --> P[No expand button]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/lib/components/badges/port-badge.svelte`, line 84-85 ([link](https://github.com/getarcaneapp/arcane/blob/00fdb5581039c7eed1c17574c076aa60fdab3437/frontend/src/lib/components/badges/port-badge.svelte#L84-L85)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Empty ports cell when container only has exposed-only ports**

   When a container has only exposed-only ports (e.g., a DB image that uses `EXPOSE 5432` but is never published with `-p`) and `hideExposed=true`, the check `allPorts.length === 0` is `false` so the "No ports" message is skipped. But because `published` and `exposedOnly` are both empty arrays, the inner `<div class="flex flex-wrap gap-1.5">` renders completely empty — no badges and no fallback text. The ports cell appears blank, indistinguishable from a layout gap.

   A better guard would check whether there are any *visible* ports (after applying the filter) before entering the `{:else}` branch:

   ```svelte
   {#if allPorts.length === 0 || (hideExposed && published.length === 0)}
   	<span class="text-muted-foreground text-xs">{m.containers_no_ports()}</span>
   {:else}
   ```

   Or alternatively, keep the condition and add a fallback inside the `{:else}` branch when both `published` and `exposedOnly` are empty.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/lib/components/badges/port-badge.svelte
   Line: 84-85

   Comment:
   **Empty ports cell when container only has exposed-only ports**

   When a container has only exposed-only ports (e.g., a DB image that uses `EXPOSE 5432` but is never published with `-p`) and `hideExposed=true`, the check `allPorts.length === 0` is `false` so the "No ports" message is skipped. But because `published` and `exposedOnly` are both empty arrays, the inner `<div class="flex flex-wrap gap-1.5">` renders completely empty — no badges and no fallback text. The ports cell appears blank, indistinguishable from a layout gap.

   A better guard would check whether there are any *visible* ports (after applying the filter) before entering the `{:else}` branch:

   ```svelte
   {#if allPorts.length === 0 || (hideExposed && published.length === 0)}
   	<span class="text-muted-foreground text-xs">{m.containers_no_ports()}</span>
   {:else}
   ```

   Or alternatively, keep the condition and add a fallback inside the `{:else}` branch when both `published` and `exposedOnly` are empty.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/lib/components/badges/port-badge.svelte
Line: 84-85

Comment:
**Empty ports cell when container only has exposed-only ports**

When a container has only exposed-only ports (e.g., a DB image that uses `EXPOSE 5432` but is never published with `-p`) and `hideExposed=true`, the check `allPorts.length === 0` is `false` so the "No ports" message is skipped. But because `published` and `exposedOnly` are both empty arrays, the inner `<div class="flex flex-wrap gap-1.5">` renders completely empty — no badges and no fallback text. The ports cell appears blank, indistinguishable from a layout gap.

A better guard would check whether there are any *visible* ports (after applying the filter) before entering the `{:else}` branch:

```svelte
{#if allPorts.length === 0 || (hideExposed && published.length === 0)}
	<span class="text-muted-foreground text-xs">{m.containers_no_ports()}</span>
{:else}
```

Or alternatively, keep the condition and add a fallback inside the `{:else}` branch when both `published` and `exposedOnly` are empty.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: frontend/src/lib/components/badges/port-badge.svelte
Line: 81

Comment:
**"Show more" count includes hidden exposed-only ports**

`hiddenCount` is computed as `allPorts.length - visiblePorts.length`, which counts *all* ports beyond the `maxVisible` slice — including exposed-only ones that `hideExposed` will suppress. As a result, the `+N` expand button can display a misleading count.

**Concrete example:** a container with 1 published + 4 exposed-only ports, `maxVisible=3`, `hideExposed=true`:
- `visiblePorts = [pub1, exp1, exp2]` (sorted published-first, sliced to 3)
- User sees `pub1` badge + `+2` button
- After clicking `+2`: `visiblePorts` expands to all 5, `published=[pub1]`, `exposedOnly=[]` — so still only `pub1` is visible, and the `+2` button disappears

The user clicks a button promising two more ports and nothing new appears. Consider deriving `hiddenCount` from the actually-rendered lists:

```js
const hiddenCount = $derived(
    hideExposed
        ? allPorts.filter((p) => p.isPublished).length - published.length
        : allPorts.length - visiblePorts.length
);
```

Also consider gating the expand button on whether there are genuinely more *renderable* ports available.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: frontend/messages/en.json
Line: 511

Comment:
**i18n key name conflicts with its value**

The key is named `containers_hide_exposed_ports` (implying "hide ports that are exposed") while the displayed string is `"Hide unexposed ports"` (implying "hide ports that are not exposed to the host"). These are semantically opposite.

In Docker terminology the ports being hidden are *exposed-only* (declared via `EXPOSE` but not published with `-p`). A less ambiguous label might be `"Hide internal-only ports"` or `"Hide unpublished ports"`, and the key name should be aligned accordingly (e.g. `containers_hide_internal_ports`).

```suggestion
	"containers_hide_unexposed_ports": "Hide unexposed ports",
```

At minimum the key name and value should agree so translators aren't confused about what to translate.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add toggle to hide unexposed ports..."](https://github.com/getarcaneapp/arcane/commit/00fdb5581039c7eed1c17574c076aa60fdab3437) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26687440)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - svelte-core-bestpractices

---
name: svelte-core-b... ([source](https://app.greptile.com/review/custom-context?memory=fa55c3c6-c41e-4994-8aad-254aaf9ba60d))
- Rule used - What: Avoid updating `$state` inside `$effect` blo... ([source](https://app.greptile.com/review/custom-context?memory=8e0bee41-b073-4a49-a01c-2c2c8782b420))

<!-- /greptile_comment -->