### PR TITLE
fix: resolve image ref from containers when local image was pruned

### DIFF
--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -269,7 +269,7 @@ func (s *ImageUpdateService) parseImageReferenceFallback(imageRef string) *Image
 	return &ImageParts{Registry: registry.NormalizeRegistryForComparison(registryHost), Repository: repository, Tag: tag}
 }
 
-func (s *ImageUpdateService) getImageRefByID(ctx context.Context, imageID string) (string, error) {
+func (s *ImageUpdateService) getImageRefByIDInternal(ctx context.Context, imageID string) (string, error) {
 	dockerClient, err := s.dockerService.GetClient(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to connect to Docker: %w", err)
@@ -417,7 +417,7 @@ func (s *ImageUpdateService) normalizeRepository(regHost, repo string) string {
 }
 
 func (s *ImageUpdateService) CheckImageUpdateByID(ctx context.Context, imageID string) (*imageupdate.Response, error) {
-	imageRef, err := s.getImageRefByID(ctx, imageID)
+	imageRef, err := s.getImageRefByIDInternal(ctx, imageID)
 	if err != nil {
 		metadata := models.JSON{
 			"action":  "check_update_by_id",

--- a/backend/internal/services/image_update_service_test.go
+++ b/backend/internal/services/image_update_service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/getarcaneapp/arcane/types/imageupdate"
 	glsqlite "github.com/glebarez/sqlite"
+	dockertypescontainer "github.com/moby/moby/api/types/container"
 	dockertypesimage "github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/client"
 	digest "github.com/opencontainers/go-digest"
@@ -401,6 +402,74 @@ func newImageUpdateFallbackServer(t *testing.T, repositoryTag, localDigest, remo
 			http.NotFound(w, r)
 		}
 	}))
+}
+
+func newImageRefResolutionServer(t *testing.T, containers []dockertypescontainer.Summary) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/images/") && strings.HasSuffix(r.URL.Path, "/json"):
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		case strings.HasSuffix(r.URL.Path, "/containers/json"):
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(containers))
+			return
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestImageUpdateService_GetImageRefByIDInternal_UsesContainerFallback(t *testing.T) {
+	t.Parallel()
+
+	const imageID = "sha256:test-image-id"
+
+	tests := []struct {
+		name       string
+		containers []dockertypescontainer.Summary
+		wantRef    string
+		wantErr    string
+	}{
+		{
+			name: "uses repo tag from matching container when inspect fails",
+			containers: []dockertypescontainer.Summary{
+				{ImageID: imageID, Image: "frooodle/s-pdf:latest"},
+			},
+			wantRef: "frooodle/s-pdf:latest",
+		},
+		{
+			name: "ignores named digest references from matching container",
+			containers: []dockertypescontainer.Summary{
+				{ImageID: imageID, Image: "frooodle/s-pdf@sha256:abc123"},
+			},
+			wantErr: "no local image or running container found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newImageRefResolutionServer(t, tt.containers)
+			defer server.Close()
+
+			svc := &ImageUpdateService{
+				dockerService: &DockerClientService{client: newTestDockerClient(t, server)},
+			}
+
+			ref, err := svc.getImageRefByIDInternal(context.Background(), imageID)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+				assert.Empty(t, ref)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRef, ref)
+		})
+	}
 }
 
 func TestImageUpdateService_CheckImageUpdate_UsesRegistryFallback(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [x] This PR is **not** opened from my fork's `main` branch

## What This PR Fixes

When checking for image updates via `POST /api/environments/{id}/image-updates/check/{imageId}`, Arcane calls `ImageInspect` with the image ID (sha256 digest). If the local image has been pruned, cleaned, or replaced, `ImageInspect` fails with:

```
No such image: sha256:...
```

This causes a 500 error even though the container is healthy, running, and the image is still available in the registry.

Fixes #2185

## Root Cause

`getImageRefByID()` only uses `dockerClient.ImageInspect()` to resolve an image ID to a `repo:tag` reference. When the local image object no longer exists (after pruning, cleanup, or container recreation), this lookup fails — there's no fallback.

## Changes Made

- **`image_update_service.go`** — When `ImageInspect` fails (or returns no valid tags/digests), fall back to searching the container list for a container using the same image ID. The container's `.Image` field contains the `repo:tag` reference that can be used for the registry update check.

## How the Fallback Works

1. Try `ImageInspect` as before (fast path, works when image exists locally)
2. If that fails or yields no usable reference, list all containers
3. Find a container whose `ImageID` matches the requested ID
4. Return its `.Image` field (e.g. `frooodle/s-pdf:latest`) if it's a valid repo:tag (not a sha256 ref)
5. If no container matches, return the original error

## Why This Is Safe

- The existing fast path (`ImageInspect`) is tried first — no behavior change when images exist locally
- The fallback only triggers on error/no-tags, so no performance impact in the happy path
- `ContainerList` with `All: true` is already used elsewhere in the codebase
- We skip container entries where `.Image` is a bare `sha256:` ref (those can't be used for registry checks)

## Testing Done

- [x] `go build ./internal/services/` — compiles cleanly
- [x] `go test ./internal/services/ -run TestImageUpdate` — all tests pass

## AI Tool Used (if applicable)

AI Tool: N/A
Assistance Level: N/A

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a 500 error in `POST /api/environments/{id}/image-updates/check/{imageId}` that occurred when a container's local image had been pruned — by adding a container-list fallback inside `getImageRefByID` so that a usable `repo:tag` reference can still be recovered from a running container's `.Image` field.

**Key changes:**
- `getImageRefByID` in `image_update_service.go` now falls back to `ContainerList` when `ImageInspect` fails or returns no usable tags/digests.
- The fallback iterates all containers (`All: true`), matches on `ImageID`, and returns the container's `.Image` string if it is a non-digest reference.
- The original fast path (`ImageInspect`) is unchanged — the fallback only activates on error or missing tags, so there is no performance impact in the common case.

**Concerns found:**
- The guard `!strings.HasPrefix(c.Image, "sha256:")` does not catch named-digest references (`frooodle/s-pdf@sha256:…`), which could be returned to `CheckImageUpdate` even though they are not `repo:tag` references (see inline comment).
- The new fallback code path has no dedicated tests; a table-driven test for the pruned-image scenario would improve confidence.
- The function `getImageRefByID` is unexported but lacks the required `Internal` suffix per the project naming convention.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fallback is only triggered on the previously-crashing code path and all remaining findings are P2 style/quality suggestions.

The fix correctly preserves the original fast path and only activates the container-list fallback when ImageInspect fails or yields no usable reference. All identified issues (named-digest filtering gap, missing tests, naming convention) are P2 and do not block merging.

backend/internal/services/image_update_service.go — specifically the c.Image filter and the absence of fallback tests.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/image_update_service.go | Adds a container-list fallback to `getImageRefByID` when the local image has been pruned; logic is sound but named-digest references (`repo@sha256:…`) are not filtered in the fallback, a naming-convention violation exists, and the new code path lacks test coverage. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getImageRefByID(ctx, imageID)"] --> B["ImageInspect(imageID)"]
    B -- "success" --> C{RepoTags available?}
    C -- "yes (non-none)" --> D["return repo:tag ✓"]
    C -- "no" --> E{RepoDigests available?}
    E -- "yes (non-none)" --> F["return repo:latest ✓"]
    E -- "no" --> G["fallback: ContainerList(All: true)"]
    B -- "error (image pruned)" --> G
    G -- "listErr != nil" --> H{Original ImageInspect err?}
    H -- "yes" --> I["return 'image not found' error"]
    H -- "no" --> J["return 'no valid tags' error"]
    G -- "success" --> K["iterate containers"]
    K --> L{c.ImageID matches fullID or imageID?}
    L -- "no match" --> M["next container"]
    M --> L
    L -- "match" --> N{c.Image non-empty AND not sha256: prefix?}
    N -- "yes" --> O["return c.Image repo:tag ✓"]
    N -- "no (bare digest or empty)" --> M
    K -- "exhausted" --> H
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/internal/services/image_update_service.go`, line 272 ([link](https://github.com/getarcaneapp/arcane/blob/3b4c1b0ebc6f9a0d5d4a947e1a559640f931c68d/backend/internal/services/image_update_service.go#L272)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Naming convention: unexported function missing `Internal` suffix**

   Per the project's Go naming convention, all unexported functions must be suffixed with `Internal`. The existing (and now modified) function `getImageRefByID` should be renamed to `getImageRefByIDInternal`.

   

   The corresponding call site at line 414 would also need to be updated to `s.getImageRefByIDInternal(ctx, imageID)`.

   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/image_update_service.go
   Line: 272
   
   Comment:
   **Naming convention: unexported function missing `Internal` suffix**
   
   Per the project's Go naming convention, all unexported functions must be suffixed with `Internal`. The existing (and now modified) function `getImageRefByID` should be renamed to `getImageRefByIDInternal`.
   
   
   
   The corresponding call site at line 414 would also need to be updated to `s.getImageRefByIDInternal(ctx, imageID)`.
   
   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/image_update_service.go
Line: 312-314

Comment:
**Named-digest references not filtered out**

The guard `!strings.HasPrefix(c.Image, "sha256:")` only blocks *bare* digest refs (e.g. `sha256:abc123…`). A container started with `docker run image@sha256:…` stores a *named+digest* ref like `frooodle/s-pdf@sha256:abc123…` in its `.Image` field. That string does not start with `sha256:`, so it would pass through and be returned to `CheckImageUpdate`, which may not handle `repo@digest` references the same way it handles `repo:tag` ones — potentially yielding a confusing or incorrect result.

Consider also excluding `@sha256:` references:

```suggestion
			if c.Image != "" && !strings.HasPrefix(c.Image, "sha256:") && !strings.Contains(c.Image, "@sha256:") {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/services/image_update_service.go
Line: 272

Comment:
**Naming convention: unexported function missing `Internal` suffix**

Per the project's Go naming convention, all unexported functions must be suffixed with `Internal`. The existing (and now modified) function `getImageRefByID` should be renamed to `getImageRefByIDInternal`.

```suggestion
func (s *ImageUpdateService) getImageRefByIDInternal(ctx context.Context, imageID string) (string, error) {
```

The corresponding call site at line 414 would also need to be updated to `s.getImageRefByIDInternal(ctx, imageID)`.

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/services/image_update_service.go
Line: 300-316

Comment:
**No test coverage for the container-list fallback path**

The existing test suite does not appear to exercise the new fallback branch (where `ImageInspect` fails but `ContainerList` finds a matching container). Since this is the core of the bug fix, a table-driven test that mocks:
1. `ImageInspect` returning an error
2. `ContainerList` returning a container whose `ImageID` matches and whose `Image` is a valid `repo:tag`

…would help prevent regressions and confirm the expected behaviour under the pruned-image scenario described in the PR.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve image ref from containers w..."](https://github.com/getarcaneapp/arcane/commit/3b4c1b0ebc6f9a0d5d4a947e1a559640f931c68d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26692878)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->