### PR TITLE
fix: use actual container count for project status calculation

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -1094,30 +1094,7 @@ func (s *ProjectService) GetProjectStatusCounts(ctx context.Context) (folderCoun
 		if len(services) == 0 {
 			status = models.ProjectStatusStopped
 		} else {
-			// We have containers, calculate status based on their state
-			// Note: calculateProjectStatus doesn't know about "missing" services (ServiceCount)
-			// So we need to check if runningCount == p.ServiceCount here if we want strict "Running"
-
-			// Re-implement logic here to be safe or rely on calculateProjectStatus?
-			// calculateProjectStatus returns Running if ALL *present* containers are running.
-			// But if we have 2/3 containers running, it returns Running? No.
-			// calculateProjectStatus: if runningCount == len(services) -> Running.
-			// But len(services) is only the *running* containers (or present ones).
-			// If we have 3 services defined, but only 2 containers exist (both running),
-			// calculateProjectStatus will say "Running".
-			// But strictly it should be "Partial" or "Restarting" or something.
-
-			// However, for the dashboard count, "Running" usually means "Healthy".
-			// Let's stick to calculateProjectStatus for consistency with previous logic,
-			// but maybe check ServiceCount.
-
-			st := s.calculateProjectStatus(services)
-
-			// Refine: if all containers are running, but we have fewer containers than defined services
-			if st == models.ProjectStatusRunning && len(services) < p.ServiceCount {
-				st = models.ProjectStatusPartiallyRunning
-			}
-			status = st
+			status = s.calculateProjectStatus(services)
 		}
 
 		s.incrementStatusCounts(status, &runningProjects, &stoppedProjects)
@@ -3117,12 +3094,18 @@ func (s *ProjectService) mapProjectToDto(ctx context.Context, projectsDir string
 		}
 	}
 
-	// Calculate Status
-	if len(services) == 0 {
+	// Calculate Status using actual container count from Docker rather than the
+	// (potentially stale) DB ServiceCount. The DB value can become outdated when
+	// a service is removed from the compose file but compose parsing fails during
+	// filesystem sync, leaving the old count in the database. This mirrors the
+	// logic in calculateProjectStatus and GetProjectDetails, which both use the
+	// live container/service list as the source of truth.
+	actualServiceCount := len(services)
+	if actualServiceCount == 0 {
 		resp.Status = string(models.ProjectStatusStopped)
 	} else {
 		switch {
-		case runningCount >= resp.ServiceCount && resp.ServiceCount > 0:
+		case runningCount >= actualServiceCount:
 			resp.Status = string(models.ProjectStatusRunning)
 		case runningCount > 0:
 			resp.Status = string(models.ProjectStatusPartiallyRunning)


### PR DESCRIPTION
## Summary
- Project overview could get stuck on "Partially running" after removing a service from a compose file
- Root cause: `mapProjectToDto` and `GetProjectStatusCounts` used the DB `service_count` for status calculation, which becomes stale when compose parsing fails during filesystem sync
- Fix: use actual container count from Docker (matching `calculateProjectStatus` and `GetProjectDetails` behavior)

Fixes #1954

## Root cause

The overview status was calculated as:
```
runningCount >= DB.ServiceCount → "Running"
runningCount > 0                → "Partially running"
```

When a user removed a service (4 → 3), if the DB still had `service_count = 4` (stale from a failed compose parse), then `3 >= 4` was false, falling through to "Partially running" forever — even after `docker system prune` and server reboot.

The detail view was immune because `GetProjectDetails` always re-parses the compose file.

## Changes

**`backend/internal/services/project_service.go`**
- `mapProjectToDto`: status calculation now uses `len(services)` (actual Docker containers) instead of `resp.ServiceCount` (DB value)
- `GetProjectStatusCounts`: removed the `ServiceCount` comparison that overrode `calculateProjectStatus` — now delegates entirely to `calculateProjectStatus`, which already uses actual container count

## Test plan
- [x] `go test ./internal/services/...` passes
- [ ] Create a project with 4 services, verify "Running" status
- [ ] Remove 1 service from compose, redeploy with 3 services
- [ ] Verify overview shows "Running" (not "Partially running")
- [ ] Verify stopping all services shows "Stopped"
- [ ] Verify stopping 1 of 3 services shows "Partially running"

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the project overview status could get permanently stuck on "Partially running" after removing a service from a compose file. The root cause was that `mapProjectToDto` and `GetProjectStatusCounts` used the DB-persisted `service_count` field for the "Running" threshold, which could become stale if compose parsing failed during a filesystem sync.

**Key changes:**
- `mapProjectToDto`: status threshold now compares `runningCount` against `len(services)` (actual Docker containers) rather than `resp.ServiceCount` (potentially-stale DB value).
- `GetProjectStatusCounts`: the override block that downgraded `Running → PartiallyRunning` when `len(services) < p.ServiceCount` is removed, delegating entirely to `calculateProjectStatus(services)`.
- Both code paths now match the behavior of `GetProjectDetails`, which was already immune to the bug because it re-parses the compose file.

The fix is minimal, well-targeted, and correctly aligns all three code paths to use live Docker state as the source of truth for status calculation.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix correctly removes stale DB ServiceCount from status determination with no regressions; remaining findings are P2 style/consistency suggestions.

The core bug is fixed correctly in both affected code paths. Both changes narrow scope to actual Docker container state, consistent with how GetProjectDetails already worked. All remaining comments are non-blocking P2 suggestions about display-count consistency and refactoring toward the shared calculateProjectStatus helper.

No files require special attention; all issues are in backend/internal/services/project_service.go and are P2 only.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/services/project_service.go | Core fix: removes stale DB ServiceCount from status calculation in both mapProjectToDto and GetProjectStatusCounts, using actual Docker container count instead. Logic is correct; no regressions introduced. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `backend/internal/services/project_service.go`, line 3103-3115 ([link](https://github.com/getarcaneapp/arcane/blob/6c69e5ce8d7eb3495eaabb9991d1aeb16462bd58/backend/internal/services/project_service.go#L3103-L3115)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`resp.ServiceCount` still reflects the stale DB value**

   The status is now correctly derived from `actualServiceCount` (live Docker containers), but `resp.ServiceCount` — set earlier at line 3076 from `p.ServiceCount` — still carries the stale DB value (e.g. 4 when only 3 containers exist). This means the response will have `RunningCount: 3`, `ServiceCount: 4`, `Status: "Running"`, which is internally inconsistent: a consumer interpreting "3 of 4 services running" would expect `Status: PartiallyRunning`.

   If the frontend uses `RunningCount` / `ServiceCount` as a display label (e.g. "3/4"), the label will contradict the status badge until the next successful compose parse updates the DB. Consider also updating `resp.ServiceCount` to `actualServiceCount` once it's known to be non-zero, so the displayed count stays consistent with the status calculation:

   ```go
   actualServiceCount := len(services)
   if actualServiceCount > 0 {
       resp.ServiceCount = actualServiceCount
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/project_service.go
   Line: 3103-3115

   Comment:
   **`resp.ServiceCount` still reflects the stale DB value**

   The status is now correctly derived from `actualServiceCount` (live Docker containers), but `resp.ServiceCount` — set earlier at line 3076 from `p.ServiceCount` — still carries the stale DB value (e.g. 4 when only 3 containers exist). This means the response will have `RunningCount: 3`, `ServiceCount: 4`, `Status: "Running"`, which is internally inconsistent: a consumer interpreting "3 of 4 services running" would expect `Status: PartiallyRunning`.

   If the frontend uses `RunningCount` / `ServiceCount` as a display label (e.g. "3/4"), the label will contradict the status badge until the next successful compose parse updates the DB. Consider also updating `resp.ServiceCount` to `actualServiceCount` once it's known to be non-zero, so the displayed count stays consistent with the status calculation:

   ```go
   actualServiceCount := len(services)
   if actualServiceCount > 0 {
       resp.ServiceCount = actualServiceCount
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `backend/internal/services/project_service.go`, line 3107-3114 ([link](https://github.com/getarcaneapp/arcane/blob/6c69e5ce8d7eb3495eaabb9991d1aeb16462bd58/backend/internal/services/project_service.go#L3107-L3114)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Inline status logic diverges from `calculateProjectStatus`**

   The status switch here computes `runningCount` by checking `c.State == "running"` (exact string, line 3053) and falls through to `default → Stopped` for containers in other states (e.g. "paused", "restarting", "created"). Meanwhile, `calculateProjectStatus` also counts "up" as running and returns `ProjectStatusUnknown` (not Stopped) when no containers are running or stopped.

   The inconsistency is pre-existing, but since the PR description states that this mirrors `calculateProjectStatus`, consider calling `s.calculateProjectStatus(services)` directly here (as is done in `GetProjectStatusCounts` after this PR) to ensure the two code paths stay in sync as `calculateProjectStatus` evolves.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/project_service.go
   Line: 3107-3114

   Comment:
   **Inline status logic diverges from `calculateProjectStatus`**

   The status switch here computes `runningCount` by checking `c.State == "running"` (exact string, line 3053) and falls through to `default → Stopped` for containers in other states (e.g. "paused", "restarting", "created"). Meanwhile, `calculateProjectStatus` also counts "up" as running and returns `ProjectStatusUnknown` (not Stopped) when no containers are running or stopped.

   The inconsistency is pre-existing, but since the PR description states that this mirrors `calculateProjectStatus`, consider calling `s.calculateProjectStatus(services)` directly here (as is done in `GetProjectStatusCounts` after this PR) to ensure the two code paths stay in sync as `calculateProjectStatus` evolves.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/project_service.go
Line: 3103-3115

Comment:
**`resp.ServiceCount` still reflects the stale DB value**

The status is now correctly derived from `actualServiceCount` (live Docker containers), but `resp.ServiceCount` — set earlier at line 3076 from `p.ServiceCount` — still carries the stale DB value (e.g. 4 when only 3 containers exist). This means the response will have `RunningCount: 3`, `ServiceCount: 4`, `Status: "Running"`, which is internally inconsistent: a consumer interpreting "3 of 4 services running" would expect `Status: PartiallyRunning`.

If the frontend uses `RunningCount` / `ServiceCount` as a display label (e.g. "3/4"), the label will contradict the status badge until the next successful compose parse updates the DB. Consider also updating `resp.ServiceCount` to `actualServiceCount` once it's known to be non-zero, so the displayed count stays consistent with the status calculation:

```go
actualServiceCount := len(services)
if actualServiceCount > 0 {
    resp.ServiceCount = actualServiceCount
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/services/project_service.go
Line: 3107-3114

Comment:
**Inline status logic diverges from `calculateProjectStatus`**

The status switch here computes `runningCount` by checking `c.State == "running"` (exact string, line 3053) and falls through to `default → Stopped` for containers in other states (e.g. "paused", "restarting", "created"). Meanwhile, `calculateProjectStatus` also counts "up" as running and returns `ProjectStatusUnknown` (not Stopped) when no containers are running or stopped.

The inconsistency is pre-existing, but since the PR description states that this mirrors `calculateProjectStatus`, consider calling `s.calculateProjectStatus(services)` directly here (as is done in `GetProjectStatusCounts` after this PR) to ensure the two code paths stay in sync as `calculateProjectStatus` evolves.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use actual container count for proj..."](https://github.com/getarcaneapp/arcane/commit/6c69e5ce8d7eb3495eaabb9991d1aeb16462bd58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26874448)</sub>

<!-- /greptile_comment -->