### PR TITLE
fix: use opaque background for sheet content in light mode

### DIFF
--- a/frontend/src/lib/components/ui/sheet/sheet-content.svelte
+++ b/frontend/src/lib/components/ui/sheet/sheet-content.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
 	import { tv, type VariantProps } from 'tailwind-variants';
 	export const sheetVariants = tv({
-		base: 'text-foreground bg-white/10 dark:bg-surface/10 backdrop-blur-md border border-white/80 dark:border-border/80 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+		base: 'text-foreground bg-white dark:bg-surface/10 backdrop-blur-md border border-white/80 dark:border-border/80 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
 		variants: {
 			side: {
 				top: 'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto rounded-b-2xl',


### PR DESCRIPTION
## Summary
- The sheet sidebar (used by "Pull Image" and other features) had `bg-white/10` (10% opacity) making it nearly invisible in light mode
- Changed to `bg-white` to match `dialog-content` which already uses an opaque background
- Dark mode (`dark:bg-surface/10`) is unchanged as it matches the dialog component

Fixes #2202

## Test plan
- [ ] Open the Images page, select images, click "Pull image" → sidebar should be clearly visible in light mode
- [ ] Verify dark mode still looks correct with the glassmorphism effect
- [ ] Verify other sheets (e.g. settings, webhook form) also render correctly

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a light mode visibility bug in the sheet sidebar component by changing `bg-white/10` (10% opacity white) to `bg-white` (fully opaque), matching the existing pattern used in `dialog-content.svelte`. The dark mode class `dark:bg-surface/10` is correctly left unchanged.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, targeted fix with no logic changes.

Single CSS class change that correctly aligns the sheet component with the established dialog pattern. No regressions introduced; dark mode is untouched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/lib/components/ui/sheet/sheet-content.svelte | Single-class change: `bg-white/10` → `bg-white` in light mode, bringing sheet styling in line with dialog-content; dark mode and all other classes unchanged. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sheet Content Rendered] --> B{Color Mode?}
    B -->|Light Mode| C["bg-white (opaque) ✅"]
    B -->|Dark Mode| D["dark:bg-surface/10 (glassmorphism) ✅"]
    C --> E[backdrop-blur-md applied]
    D --> E
    E --> F[Sheet fully visible in both modes]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use opaque background for sheet con..."](https://github.com/getarcaneapp/arcane/commit/1c5f886b09b2deba08103903baf91baad74f21df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27256793)</sub>

<!-- /greptile_comment -->