### PR TITLE
fix: simplify YAML editor indentation to prevent excessive indent

### DIFF
--- a/frontend/src/lib/components/code-editor/enter-indentation.ts
+++ b/frontend/src/lib/components/code-editor/enter-indentation.ts
@@ -3,22 +3,17 @@ import { EditorState, Prec, type Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import type { CodeLanguage } from './analysis/types';
 
-function getYamlIndent(
-	lineBreakState: EditorState,
-	textBeforeCursor: string,
-	currentIndent: string,
-	isCursorAtLineEnd: boolean
-): string {
+function getYamlIndent(state: EditorState, textBeforeCursor: string, currentIndent: string, isCursorAtLineEnd: boolean): string {
 	if (!isCursorAtLineEnd) return currentIndent;
 
 	const trimmedBeforeCursor = textBeforeCursor.trimEnd();
 	const startsYamlBlock =
 		/:\s*(?:#.*)?$/.test(trimmedBeforeCursor) ||
 		/:\s*[|>][-+0-9]*\s*(?:#.*)?$/.test(trimmedBeforeCursor) ||
-		/^-\s*(?:#.*)?$/.test(trimmedBeforeCursor);
+		/^-\s*(?:#.*)?$/.test(trimmedBeforeCursor.trimStart());
 
 	if (startsYamlBlock) {
-		return indentString(lineBreakState, currentIndent.length + getIndentUnit(lineBreakState));
+		return indentString(state, currentIndent.length + getIndentUnit(state));
 	}
 
 	return currentIndent;
@@ -54,10 +49,7 @@ export function createEnterIndentKeymap(language: CodeLanguage): Extension {
 				let indentation: string;
 
 				if (language === 'yaml') {
-					const lineBreakTransaction = view.state.update({
-						changes: { from, to, insert: '\n' }
-					});
-					indentation = getYamlIndent(lineBreakTransaction.state, textBeforeCursor, currentIndent, isCursorAtLineEnd);
+					indentation = getYamlIndent(view.state, textBeforeCursor, currentIndent, isCursorAtLineEnd);
 				} else {
 					indentation = textBeforeCursor.match(/^\s*/)?.[0] ?? '';
 				}


### PR DESCRIPTION
## Summary
- The Enter key handler in the code editor produced unpredictable indentation when editing YAML/compose files — users reported needing to hit backspace 4-5 times after every Enter
- Root cause: the handler relied on CodeMirror's `getIndentation()` which returns incorrect values when the YAML document is in an intermediate parse state (i.e. during active editing). A secondary issue was the "copy next line's indent" heuristic that ignored YAML block starters entirely
- Fix: replace with a simple, predictable heuristic — indent one level deeper after block starters (`:`, `|`, `>`, `-`), maintain current indentation otherwise. This matches VS Code and other YAML editors

Fixes #2192

## Changes
**`frontend/src/lib/components/code-editor/enter-indentation.ts`**
- Removed dependency on `getIndentation` from `@codemirror/language` (unreliable during editing)
- Removed the "copy next line's indent" branch that ignored YAML context
- Simplified YAML indent function: block starters get +1 indent level, everything else maintains current indent
- ENV files maintain current indentation (same as before)

## Test plan
- [ ] Open a compose file editor, type `services:` and press Enter → cursor should be at 2 spaces
- [ ] Type `web:` and press Enter → cursor at 4 spaces
- [ ] Type `image: nginx` and press Enter → cursor stays at 4 spaces (same level)
- [ ] Type `ports:` and press Enter → cursor at 6 spaces
- [ ] Type `- "80:80"` and press Enter → cursor stays at 6 spaces
- [ ] Existing test `should preserve YAML indentation when pressing Enter in compose editor` still passes
- [ ] Verify ENV file editing still works correctly

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR simplifies the Enter-key indentation handler in the YAML/compose code editor by replacing the previous multi-path logic (which relied on CodeMirror's `getIndentation()` and a "copy next line's indent" heuristic) with a single, predictable rule: indent one level deeper after block starters (`:`/`|`/`>`/`-`), and otherwise preserve the current line's indentation. Non-YAML (ENV) files now always fall back to the current line's leading whitespace, dropping the previously unreliable `getIndentation` call.

- **Removed**: `getIndentation` import and its call site (was returning wrong values mid-edit)
- **Removed**: "copy next line's indent" branch (`hasNextNonEmptyLine`) — could mask incorrect YAML context
- **Renamed**: `getYamlHeuristicIndent` → `getYamlIndent`; return type changed from `string | null` to `string` (always returns a usable indentation)
- **Simplified**: `lineBreakTransaction` creation moved inside the YAML branch (no longer needed for non-YAML paths)
- **Potential issue**: The bare-dash block-starter regex (`/^-\s*(?:#.*)?$/`) anchors on `^`, so it only fires when `-` is at column 0. Indented list openers (e.g. `      -`) do not match, and no extra indent level is added for them — which may surprise users writing nested lists.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the logic is simpler and more predictable than before, with one pre-existing edge case around indented bare dashes worth addressing.

The change is well-scoped to a single file, removes demonstrably buggy code (`getIndentation` during mid-edit), and replaces it with a straightforward heuristic consistent with VS Code behavior. The main concern is the bare-dash regex that only matches column-0 dashes, leaving indented list openers without auto-indent — but this limitation existed in the original code and isn't a regression.

frontend/src/lib/components/code-editor/enter-indentation.ts — specifically the dash-pattern regex and the unnecessary `lineBreakTransaction` creation in the YAML branch.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/lib/components/code-editor/enter-indentation.ts | YAML Enter-key indentation simplified: removed unreliable `getIndentation`/next-line heuristics, replaced with deterministic block-starter detection; non-YAML (env) falls back to current-line leading whitespace. One potential edge case with indented bare dashes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[keydown: Enter] --> B{Skip conditions?}
    B -- "key != Enter / defaultPrevented / readOnly / modifier key" --> Z[return false]
    B -- proceed --> C[Compute currentLine, currentIndent, textBeforeCursor]
    C --> D{language === 'yaml'?}
    D -- yes --> E[Create lineBreakTransaction]
    E --> F[getYamlIndent]
    F --> G{isCursorAtLineEnd?}
    G -- no --> H[return currentIndent]
    G -- yes --> I{startsYamlBlock?}
    I -- "ends with ':' / ':|>' / bare '-'" --> J[return currentIndent + indentUnit]
    I -- no --> H
    D -- "no / env" --> K[indentation = leading whitespace of textBeforeCursor]
    H --> L
    J --> L
    K --> L[view.dispatch: insert newline + indentation]
    L --> M[return true]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/lib/components/code-editor/enter-indentation.ts
Line: 18

Comment:
**Bare-dash detection only works at column 0**

The regex `/^-\s*(?:#.*)?$/` is tested against `trimmedBeforeCursor`, which is the text from the start of the line to the cursor position with trailing whitespace removed (e.g. `  -` for an indented list opener). Because the regex anchors with `^` and requires `-` to be the very first character, it will never match a dash that is preceded by any indentation.

Concrete example — in a compose file:
```yaml
services:
  web:
    ports:
      -
```
When the cursor is at the end of the `      -` line, `trimmedBeforeCursor` is `"      -"`. The regex does not match, so no extra indent is added and the cursor stays at 6 spaces instead of advancing to 8. This means the "block starter" case for indented list items silently falls through to the `return currentIndent` path.

A minimal fix would be to strip leading whitespace from `trimmedBeforeCursor` before testing the dash pattern:
```
const dashOnlyLine = /^-\s*(?:#.*)?$/.test(trimmedBeforeCursor.trimStart());
```
(The leading-whitespace stripping is safe here because `currentIndent` already captures the actual indentation level.)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: frontend/src/lib/components/code-editor/enter-indentation.ts
Line: 56-60

Comment:
**`lineBreakTransaction` created unnecessarily**

`lineBreakState` is passed into `getYamlIndent` only so it can be forwarded to `getIndentUnit` and `indentString`. Both of those functions read language-configuration facets (indent unit size, indent character), which are identical in `view.state` and `lineBreakTransaction.state` — neither function inspects the document content.

Creating the transaction on every YAML Enter key event is a small but avoidable allocation. You can pass `view.state` directly and remove the transaction:

```suggestion
				if (language === 'yaml') {
					indentation = getYamlIndent(view.state, textBeforeCursor, currentIndent, isCursorAtLineEnd);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: simplify YAML editor indentation to..."](https://github.com/getarcaneapp/arcane/commit/f4734340c35aa178dc383d68fb364a3db4ed601d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27260373)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->