### PR TITLE
feat: add '100' pagination option

### DIFF
--- a/frontend/src/lib/components/arcane-table/arcane-table-pagination.svelte
+++ b/frontend/src/lib/components/arcane-table/arcane-table-pagination.svelte
@@ -4,6 +4,7 @@
 	import * as Select from '$lib/components/ui/select/index.js';
 	import { m } from '$lib/paraglide/messages';
 	import { ArrowRightIcon, ArrowLeftIcon, DoubleArrowRightIcon, DoubleArrowLeftIcon } from '$lib/icons';
+	import { TABLE_PAGE_SIZE_ALL, TABLE_PAGE_SIZE_OPTIONS } from '$lib/constants/table-pagination';
 	import type { Paginated } from '$lib/types/pagination.type';
 
 	let {
@@ -29,14 +30,13 @@
 		setPageSize: (limit: number) => void;
 	} = $props();
 
-	const pageSizeOptions = [10, 20, 30, 40, 50];
-	const isAllSelected = $derived(pageSize === -1);
+	const isAllSelected = $derived(pageSize === TABLE_PAGE_SIZE_ALL);
 	const displayValue = $derived(isAllSelected ? m.common_all() : String(pageSize));
 	const selectValue = $derived(isAllSelected ? 'all' : String(pageSize));
 
 	function handlePageSizeChange(value: string) {
 		if (value === 'all') {
-			setPageSize(-1);
+			setPageSize(TABLE_PAGE_SIZE_ALL);
 		} else {
 			setPageSize(Number(value));
 		}
@@ -55,7 +55,7 @@
 					{displayValue}
 				</Select.Trigger>
 				<Select.Content side="top">
-					{#each pageSizeOptions as size (size)}
+					{#each TABLE_PAGE_SIZE_OPTIONS as size (size)}
 						<Select.Item value={`${size}`}>
 							{size}
 						</Select.Item>

--- a/frontend/src/lib/constants/table-pagination.ts
+++ b/frontend/src/lib/constants/table-pagination.ts
@@ -1,0 +1,2 @@
+export const TABLE_PAGE_SIZE_ALL = -1;
+export const TABLE_PAGE_SIZE_OPTIONS = [10, 20, 30, 40, 50, 100] as const;

--- a/frontend/src/lib/utils/table-pagination.util.ts
+++ b/frontend/src/lib/utils/table-pagination.util.ts
@@ -1,0 +1,9 @@
+import { TABLE_PAGE_SIZE_ALL, TABLE_PAGE_SIZE_OPTIONS } from '$lib/constants/table-pagination';
+
+export function normalizeTablePageSize(limit: unknown): number | undefined {
+	const parsed = typeof limit === 'number' ? limit : Number.parseInt(String(limit), 10);
+
+	if (!Number.isFinite(parsed)) return undefined;
+	if (parsed === TABLE_PAGE_SIZE_ALL) return parsed;
+	return TABLE_PAGE_SIZE_OPTIONS.includes(parsed as (typeof TABLE_PAGE_SIZE_OPTIONS)[number]) ? parsed : undefined;
+}

--- a/frontend/src/lib/utils/table-persistence.util.ts
+++ b/frontend/src/lib/utils/table-persistence.util.ts
@@ -2,6 +2,7 @@ import { browser } from '$app/environment';
 import { PersistedState } from 'runed';
 import { decodeSort, type CompactTablePrefs } from '$lib/components/arcane-table/arcane-table.types.svelte';
 import type { FilterMap, FilterValue, SearchPaginationSortRequest } from '$lib/types/pagination.type';
+import { normalizeTablePageSize } from '$lib/utils/table-pagination.util';
 
 const DEFAULT_LIMIT = 20;
 
@@ -44,15 +45,6 @@ function buildFilterMap(pairs?: [string, unknown][]): FilterMap {
 	}
 
 	return filters;
-}
-
-function normalizeLimit(limit: unknown): number | undefined {
-	if (typeof limit === 'number' && Number.isFinite(limit) && limit > 0) return limit;
-	if (typeof limit === 'string') {
-		const parsed = Number.parseInt(limit, 10);
-		if (Number.isFinite(parsed) && parsed > 0) return parsed;
-	}
-	return undefined;
 }
 
 function normalizeSearch(value: unknown): string | undefined {
@@ -99,7 +91,7 @@ export function resolveInitialTableRequest(
 			base.pagination = { ...base.pagination!, page: 1 };
 		}
 
-		const limit = normalizeLimit(current.l);
+		const limit = normalizeTablePageSize(current.l);
 		if (limit !== undefined && base.pagination?.limit !== limit) {
 			base.pagination = { page: 1, limit };
 		}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/1417

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `100` as a pagination option, extracts page-size constants into a shared `table-pagination.ts` module, and replaces the private `normalizeLimit` helper with a stricter `normalizeTablePageSize` that also validates values against the allowed list. A side-effect of the refactor is that selecting "Show All" (`-1`) will now be **persisted and restored** across page reloads, since the old `normalizeLimit` rejected negative numbers (`limit > 0`).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are additive and well-contained; the only concern is a side-effect behaviour change that is likely intentional.

All findings are P2. The code is logically correct, the constants extraction is clean, and the stricter validation in normalizeTablePageSize is an improvement over the old normalizeLimit. The 'show all' persistence behaviour change deserves a callout but does not block merge.

frontend/src/lib/constants/table-pagination.ts — verify the -1 persistence behaviour is intentional and that upstream API callers handle it on initial page load.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/lib/constants/table-pagination.ts | New constants file centralising page-size values and adding 100; exports normalizeTablePageSize which now allows -1 to persist — a behaviour change vs. the old normalizeLimit. |
| frontend/src/lib/utils/table-persistence.util.ts | Replaces private normalizeLimit with the shared normalizeTablePageSize; logic is otherwise unchanged and correct. |
| frontend/src/lib/components/arcane-table/arcane-table-pagination.svelte | Swaps local pageSizeOptions array and -1 magic number for imported constants; no logic changes to the component itself. |

</details>

</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Afrontend%2Fsrc%2Flib%2Fconstants%2Ftable-pagination.ts%3A4-10%0A**Function%20in%20a%20constants%20file**%0A%0A%60normalizeTablePageSize%60%20is%20a%20utility%20function%20%E2%80%94%20exporting%20it%20from%20a%20%60constants%2F%60%20file%20blurs%20the%20conventional%20separation%20where%20%60constants%2F%60%20holds%20only%20static%20values%20and%20%60utils%2F%60%20holds%20logic.%20Consider%20moving%20it%20to%20a%20%60utils%2F%60%20file%20%28e.g.%20alongside%20%60table-persistence.util.ts%60%29%20so%20the%20module's%20purpose%20stays%20clear%20to%20future%20contributors.%0A%0A%23%23%23%20Issue%202%20of%202%0Afrontend%2Fsrc%2Flib%2Fconstants%2Ftable-pagination.ts%3A8%0A**%22Show%20All%22%20persistence%20is%20new%2C%20silent%20behaviour**%0A%0AThe%20old%20%60normalizeLimit%60%20required%20%60limit%20%3E%200%60%2C%20so%20selecting%20%22Show%20All%22%20%28%60-1%60%29%20was%20never%20restored%20from%20localStorage%20%E2%80%94%20the%20table%20always%20fell%20back%20to%20the%20default%20on%20reload.%20%60normalizeTablePageSize%60%20now%20allows%20%60-1%60%20through%2C%20meaning%20that%20choice%20will%20persist%20across%20sessions%20for%20the%20first%20time.%20If%20the%20backend%20route%20that%20receives%20the%20hydrated%20limit%20isn't%20hardened%20against%20a%20%60-1%60%20value%20being%20sent%20on%20initial%20load%2C%20this%20could%20trigger%20an%20unexpected%20%22fetch%20all%22%20request.%20Worth%20verifying%20the%20API%20layer%20handles%20this%20sentinel%20consistently.%0A%0A&repo=getarcaneapp%2Farcane"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/lib/constants/table-pagination.ts
Line: 4-10

Comment:
**Function in a constants file**

`normalizeTablePageSize` is a utility function — exporting it from a `constants/` file blurs the conventional separation where `constants/` holds only static values and `utils/` holds logic. Consider moving it to a `utils/` file (e.g. alongside `table-persistence.util.ts`) so the module's purpose stays clear to future contributors.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: frontend/src/lib/constants/table-pagination.ts
Line: 8

Comment:
**"Show All" persistence is new, silent behaviour**

The old `normalizeLimit` required `limit > 0`, so selecting "Show All" (`-1`) was never restored from localStorage — the table always fell back to the default on reload. `normalizeTablePageSize` now allows `-1` through, meaning that choice will persist across sessions for the first time. If the backend route that receives the hydrated limit isn't hardened against a `-1` value being sent on initial load, this could trigger an unexpected "fetch all" request. Worth verifying the API layer handles this sentinel consistently.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add &#39;100&#39; pagination option"](https://github.com/getarcaneapp/arcane/commit/64b429742df5ba50c45352cd1cfd91e692a3cda2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27327405)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->