### PR TITLE
fix: frontend timeout config for api actions

### DIFF
--- a/frontend/src/lib/services/api-service.ts
+++ b/frontend/src/lib/services/api-service.ts
@@ -188,7 +188,7 @@ class APIClient {
 				headers: config.headers,
 				retry: config.retry ?? 0,
 				searchParams: config.params,
-				timeout: config.timeout
+				timeout: config.timeout ?? false
 			};
 
 			const bodyData = data !== undefined ? data : config.data;

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -545,6 +545,65 @@ test.describe('New Compose Project Page', () => {
 		}
 	});
 
+	test('should allow redeploy requests to complete after 10 seconds without client timeout', async ({
+		page
+	}) => {
+		test.slow();
+
+		const projectName = `test-redeploy-timeout-${Date.now()}`;
+		let redeployRequestStartedAt: number | undefined;
+
+		try {
+			await createProjectViaUI(page, projectName);
+			await page.goto(ROUTES.page);
+			await page.waitForLoadState('networkidle');
+
+			await page.route('**/api/environments/*/projects/*/redeploy', async (route) => {
+				if (route.request().method() !== 'POST') {
+					await route.continue();
+					return;
+				}
+
+				redeployRequestStartedAt = Date.now();
+				await new Promise((resolve) => setTimeout(resolve, 11_000));
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify({
+						success: true,
+						data: {
+							message: 'Project redeployed successfully'
+						}
+					})
+				});
+			});
+
+			const searchInput = page.getByPlaceholder('Search…');
+			await expect(searchInput).toBeVisible();
+			await searchInput.fill(projectName);
+
+			const row = page.locator('tbody tr').filter({ hasText: projectName }).first();
+			await expect(row).toBeVisible();
+			await row.getByRole('button', { name: 'Open menu' }).click();
+			const redeployMenuItem = page.getByRole('menuitem', { name: 'Pull & Redeploy' }).first();
+			await expect(redeployMenuItem).toBeVisible();
+			await redeployMenuItem.click({ force: true });
+
+			await expect
+				.poll(() => redeployRequestStartedAt, {
+					message: 'Expected the redeploy request to be issued'
+				})
+				.toBeDefined();
+
+			await expect(page.getByText('Project pulled successfully.', { exact: true })).toBeVisible({
+				timeout: 20_000
+			});
+			expect(Date.now() - redeployRequestStartedAt!).toBeGreaterThanOrEqual(11_000);
+		} finally {
+			await destroyProjectByNameViaUI(page, projectName);
+		}
+	});
+
 	test('should destroy the project and remove files from disk', async ({ page }) => {
 		const projectName = `test-destroy-${Date.now()}`;
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2230

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a client-side timeout regression in `api-service.ts` where `timeout: undefined` in per-request ky options was overriding the instance-level `timeout: false`, causing long-running API actions (e.g. Pull & Redeploy) to fail after ky's built-in 10-second default. The single-character fix `config.timeout ?? false` preserves the no-timeout intent whenever callers omit a timeout, and is validated by a new integration test that mocks an 11-second delayed redeploy response to confirm no client-side abort fires.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted one-line fix with a new integration test covering the exact regression scenario

No P0 or P1 issues found. The fix is correct and minimal, and all remaining feedback is P2 style. Score is 5.

No files require special attention
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/lib/services/api-service.ts | Adds `?? false` fallback so per-request options never pass `undefined` as timeout, preserving the instance-level `timeout: false` and preventing ky from reverting to its 10-second default |
| tests/spec/project.spec.ts | Adds integration test that intercepts the redeploy route with an 11-second delay to verify no client-side timeout fires; well-structured with proper cleanup in a finally block |

</details>

</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fspec%2Fproject.spec.ts%3A590%0A**%60force%3A%20true%60%20bypasses%20actionability%20checks**%0A%0AUsing%20%60click%28%7B%20force%3A%20true%20%7D%29%60%20skips%20Playwright's%20visibility%20and%20enabled-state%20checks%2C%20which%20could%20allow%20this%20click%20to%20succeed%20even%20when%20the%20menu%20item%20is%20obscured%20or%20disabled%20in%20the%20real%20UI%20%E2%80%94%20potentially%20hiding%20real%20regressions.%20Consider%20removing%20it%3B%20if%20the%20menu%20item%20is%20occasionally%20not%20yet%20in%20a%20clickable%20state%2C%20a%20%60waitFor%60%20or%20%60expect%28...%29.toBeEnabled%28%29%60%20guard%20would%20be%20more%20robust.%0A%0A&repo=getarcaneapp%2Farcane"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/spec/project.spec.ts
Line: 590

Comment:
**`force: true` bypasses actionability checks**

Using `click({ force: true })` skips Playwright's visibility and enabled-state checks, which could allow this click to succeed even when the menu item is obscured or disabled in the real UI — potentially hiding real regressions. Consider removing it; if the menu item is occasionally not yet in a clickable state, a `waitFor` or `expect(...).toBeEnabled()` guard would be more robust.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: frontend timeout config for api act..."](https://github.com/getarcaneapp/arcane/commit/af56b7cc8705af4b43fe973bfe3745bcb63be494) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27413039)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->