### PR TITLE
refactor: add dynamic env config schema generation

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -210,6 +210,24 @@ deploy scope kind *args:
 proto-backend:
     cd {{ edge_proto_dir }} && go run github.com/bufbuild/buf/cmd/buf@v1.65.0 generate
 
+# Generate the docs config schema JSON.
+[group('docs')]
+_docs-config output="" source_root=".":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    cmd=(go run -tags exclude_frontend ./backend/cmd config-schema --source-root "{{ source_root }}")
+    if [ -n "{{ output }}" ]; then
+        cmd+=(--output "{{ output }}")
+    fi
+
+    "${cmd[@]}"
+
+# Docs targets. Example: just docs config
+[group('docs')]
+docs target *args:
+    @just "_docs-{{ target }}" {{ args }}
+
 # Benchmark edge tunnel transport performance (gRPC vs WebSocket) with allocations.
 
 # Usage: just bench-edge-tunnel [count] [benchtime]

--- a/backend/cli/config_schema.go
+++ b/backend/cli/config_schema.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/getarcaneapp/arcane/backend/internal/configschema"
+	"github.com/spf13/cobra"
+)
+
+var configSchemaCmd = &cobra.Command{
+	Use:   "config-schema",
+	Short: "Export the config/settings schema for docs",
+	Long:  "Export the canonical JSON schema for runtime config and settings environment overrides",
+	Run: func(cmd *cobra.Command, args []string) {
+		outputFile, err := cmd.Flags().GetString("output")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading --output flag: %v\n", err)
+			os.Exit(1)
+		}
+
+		sourceRoot, err := cmd.Flags().GetString("source-root")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading --source-root flag: %v\n", err)
+			os.Exit(1)
+		}
+
+		doc, err := configschema.GenerateWithSourceRoot(sourceRoot)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error generating config schema: %v\n", err)
+			os.Exit(1)
+		}
+
+		output, err := configschema.MarshalJSON(doc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error encoding config schema: %v\n", err)
+			os.Exit(1)
+		}
+
+		if outputFile != "" {
+			if err := os.WriteFile(outputFile, output, 0o600); err != nil {
+				fmt.Fprintf(os.Stderr, "Error writing file: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Fprintf(os.Stderr, "Config schema written to %s\n", outputFile)
+			return
+		}
+
+		fmt.Print(string(output))
+	},
+}
+
+func init() {
+	configSchemaCmd.Flags().StringP("output", "o", "", "Output file (default: stdout)")
+	configSchemaCmd.Flags().String("source-root", "", "Repository root or backend source root (default: auto-detect from working directory)")
+	rootCmd.AddCommand(configSchemaCmd)
+}

--- a/backend/internal/configschema/schema.go
+++ b/backend/internal/configschema/schema.go
@@ -1,0 +1,479 @@
+package configschema
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/internal/services"
+	"github.com/getarcaneapp/arcane/backend/pkg/utils"
+)
+
+const (
+	schemaVersion                = 1
+	sourceFileConfig             = "backend/internal/config/config.go"
+	sourceFileBuildablesConfig   = "backend/internal/config/buildables_config.go"
+	sourceFileSettings           = "backend/internal/models/settings.go"
+	sourceSymbolConfig           = "config.Config"
+	sourceSymbolBuildablesConfig = "config.BuildablesConfig"
+)
+
+var documentNotes = []string{
+	"When AGENT_MODE=true or UI_CONFIGURATION_DISABLED=true, Arcane manages non-internal settings through environment variables more broadly than the always-on envOverride path.",
+	"The settingEnvOverrides section includes stable envOverride settings plus non-internal settings that are env-managed in env-only modes.",
+}
+
+// SchemaDocument is the canonical JSON artifact consumed by the docs site.
+type SchemaDocument struct {
+	SchemaVersion       int                    `json:"schemaVersion"`
+	Notes               []string               `json:"notes,omitempty"`
+	EnvConfig           []ConfigEntry          `json:"envConfig"`
+	SettingEnvOverrides []SettingOverrideEntry `json:"settingEnvOverrides"`
+}
+
+// ConfigEntry describes an environment-backed runtime config value.
+type ConfigEntry struct {
+	Env          string   `json:"env"`
+	Field        string   `json:"field"`
+	Type         string   `json:"type"`
+	DefaultValue string   `json:"defaultValue,omitempty"`
+	Description  string   `json:"description,omitempty"`
+	Options      []string `json:"options,omitempty"`
+	SupportsFile bool     `json:"supportsFile,omitempty"`
+	Conditional  bool     `json:"conditional,omitempty"`
+	BuildTags    []string `json:"buildTags,omitempty"`
+	Source       string   `json:"source"`
+	SourceFile   string   `json:"sourceFile"`
+	SourceSymbol string   `json:"sourceSymbol"`
+}
+
+// SettingOverrideEntry describes a database-backed setting that can be controlled by env vars.
+type SettingOverrideEntry struct {
+	Env          string `json:"env"`
+	SettingKey   string `json:"settingKey"`
+	Description  string `json:"description,omitempty"`
+	DefaultValue string `json:"defaultValue,omitempty"`
+	Type         string `json:"type"`
+	Sensitive    bool   `json:"sensitive"`
+	Deprecated   bool   `json:"deprecated"`
+	Category     string `json:"category,omitempty"`
+	Public       bool   `json:"public"`
+	Requires     string `json:"requires,omitempty"`
+	Note         string `json:"note,omitempty"`
+	Source       string `json:"source"`
+	SourceFile   string `json:"sourceFile"`
+	SourceSymbol string `json:"sourceSymbol"`
+}
+
+type envFieldOptions struct {
+	conditional bool
+	buildTags   []string
+	sourceFile  string
+	sourceType  string
+}
+
+type overrideDocRule struct {
+	requires   string
+	note       string
+	deprecated bool
+}
+
+var overrideDocRules = map[string]overrideDocRule{
+	"authOidcConfig": {
+		deprecated: true,
+		note:       "Deprecated legacy JSON OIDC configuration. Prefer the discrete OIDC_* environment variables.",
+	},
+	"autoUpdateInterval": {
+		requires: "AUTO_UPDATE=true to have effect at runtime.",
+	},
+	"scheduledPruneInterval": {
+		requires: "SCHEDULED_PRUNE_ENABLED=true to have effect at runtime.",
+	},
+	"scheduledPruneContainers": {
+		requires: "SCHEDULED_PRUNE_ENABLED=true to have effect at runtime.",
+	},
+	"scheduledPruneImages": {
+		requires: "SCHEDULED_PRUNE_ENABLED=true to have effect at runtime.",
+	},
+	"scheduledPruneVolumes": {
+		requires: "SCHEDULED_PRUNE_ENABLED=true to have effect at runtime.",
+	},
+	"scheduledPruneNetworks": {
+		requires: "SCHEDULED_PRUNE_ENABLED=true to have effect at runtime.",
+	},
+	"scheduledPruneBuildCache": {
+		requires: "SCHEDULED_PRUNE_ENABLED=true to have effect at runtime.",
+	},
+	"vulnerabilityScanInterval": {
+		requires: "VULNERABILITY_SCAN_ENABLED=true to have effect at runtime.",
+	},
+	"autoHealInterval": {
+		requires: "AUTO_HEAL_ENABLED=true to have effect at runtime.",
+	},
+	"autoHealExcludedContainers": {
+		requires: "AUTO_HEAL_ENABLED=true to have effect at runtime.",
+	},
+	"autoHealMaxRestarts": {
+		requires: "AUTO_HEAL_ENABLED=true to have effect at runtime.",
+	},
+	"autoHealRestartWindow": {
+		requires: "AUTO_HEAL_ENABLED=true to have effect at runtime.",
+	},
+}
+
+// GenerateWithSourceRoot builds the canonical schema document for config and settings docs.
+func GenerateWithSourceRoot(sourceRoot string) (*SchemaDocument, error) {
+	envConfig, err := collectEnvConfigInternal(sourceRoot)
+	if err != nil {
+		return nil, fmt.Errorf("collect env config: %w", err)
+	}
+
+	settingOverrides, err := collectSettingEnvOverridesInternal()
+	if err != nil {
+		return nil, fmt.Errorf("collect setting env overrides: %w", err)
+	}
+
+	doc := &SchemaDocument{
+		SchemaVersion:       schemaVersion,
+		Notes:               slices.Clone(documentNotes),
+		EnvConfig:           envConfig,
+		SettingEnvOverrides: settingOverrides,
+	}
+
+	return doc, nil
+}
+
+// MarshalJSON returns a stable, indented JSON encoding of the schema document.
+func MarshalJSON(doc *SchemaDocument) ([]byte, error) {
+	output, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal schema document: %w", err)
+	}
+
+	output = append(output, '\n')
+	return output, nil
+}
+
+func collectEnvConfigInternal(sourceRoot string) ([]ConfigEntry, error) {
+	root, err := resolveSourceRootInternal(sourceRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	configEntries, err := parseStructEnvFieldsInternal(
+		filepath.Join(root, "internal/config/config.go"),
+		"Config",
+		envFieldOptions{
+			sourceFile: sourceFileConfig,
+			sourceType: sourceSymbolConfig,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	buildablesEntries, err := parseStructEnvFieldsInternal(
+		filepath.Join(root, "internal/config/buildables_config.go"),
+		"BuildablesConfig",
+		envFieldOptions{
+			conditional: true,
+			buildTags:   []string{"buildables"},
+			sourceFile:  sourceFileBuildablesConfig,
+			sourceType:  sourceSymbolBuildablesConfig,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	configEntries = append(configEntries, buildablesEntries...)
+	sort.Slice(configEntries, func(i, j int) bool {
+		return configEntries[i].Env < configEntries[j].Env
+	})
+
+	return configEntries, nil
+}
+
+func parseStructEnvFieldsInternal(filename, structName string, opts envFieldOptions) ([]ConfigEntry, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", filename, err)
+	}
+
+	structType, err := findStructTypeInternal(file, structName)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]ConfigEntry, 0, len(structType.Fields.List))
+	for _, field := range structType.Fields.List {
+		if len(field.Names) == 0 || field.Tag == nil {
+			continue
+		}
+
+		tagValue, err := strconv.Unquote(field.Tag.Value)
+		if err != nil {
+			return nil, fmt.Errorf("unquote struct tag for %s: %w", structName, err)
+		}
+
+		structTag := reflect.StructTag(tagValue)
+		envName := structTag.Get("env")
+		if envName == "" {
+			continue
+		}
+
+		options := splitTagListInternal(structTag.Get("options"))
+		typeName, err := exprStringInternal(field.Type)
+		if err != nil {
+			return nil, fmt.Errorf("render type for %s.%s: %w", structName, field.Names[0].Name, err)
+		}
+
+		description := normalizeCommentInternal(field.Doc.Text())
+		if description == "" {
+			description = normalizeCommentInternal(field.Comment.Text())
+		}
+
+		for _, name := range field.Names {
+			entries = append(entries, ConfigEntry{
+				Env:          envName,
+				Field:        name.Name,
+				Type:         typeName,
+				DefaultValue: structTag.Get("default"),
+				Description:  description,
+				Options:      options,
+				SupportsFile: slices.Contains(options, "file"),
+				Conditional:  opts.conditional,
+				BuildTags:    slices.Clone(opts.buildTags),
+				Source:       opts.sourceType,
+				SourceFile:   opts.sourceFile,
+				SourceSymbol: opts.sourceType + "." + name.Name,
+			})
+		}
+	}
+
+	return entries, nil
+}
+
+func collectSettingEnvOverridesInternal() ([]SettingOverrideEntry, error) {
+	defaults := services.DefaultSettingsConfig()
+	settingsType := reflect.TypeFor[models.Settings]()
+	entries := make([]SettingOverrideEntry, 0, settingsType.NumField())
+
+	for field := range settingsType.Fields() {
+		keyTag := field.Tag.Get("key")
+		if keyTag == "" {
+			continue
+		}
+
+		tagParts := splitTagListInternal(keyTag)
+		if len(tagParts) == 0 {
+			continue
+		}
+
+		key := tagParts[0]
+		attrs := tagParts[1:]
+		hasEnvOverride := slices.Contains(attrs, "envOverride")
+		isInternal := slices.Contains(attrs, "internal")
+		if !hasEnvOverride && isInternal {
+			continue
+		}
+
+		defaultValue, isPublic, isSensitive, err := defaults.FieldByKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("lookup default value for %q: %w", key, err)
+		}
+		if isSensitive {
+			defaultValue = ""
+		}
+
+		meta := utils.ParseMetaTag(field.Tag.Get("meta"))
+		rule := overrideDocRules[key]
+		requires := rule.requires
+		if !hasEnvOverride {
+			requires = joinRequirementsInternal(
+				"AGENT_MODE=true or UI_CONFIGURATION_DISABLED=true to manage this setting via env.",
+				requires,
+			)
+		}
+
+		entries = append(entries, SettingOverrideEntry{
+			Env:          utils.CamelCaseToScreamingSnakeCase(key),
+			SettingKey:   key,
+			Description:  meta["description"],
+			DefaultValue: defaultValue,
+			Type:         defaultStringInternal(meta["type"], "text"),
+			Sensitive:    isSensitive,
+			Deprecated:   rule.deprecated || slices.Contains(attrs, "deprecated"),
+			Category:     meta["category"],
+			Public:       isPublic,
+			Requires:     requires,
+			Note:         rule.note,
+			Source:       "models.Settings + services.DefaultSettingsConfig",
+			SourceFile:   sourceFileSettings,
+			SourceSymbol: "models.Settings." + field.Name,
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Category == entries[j].Category {
+			return entries[i].Env < entries[j].Env
+		}
+		return entries[i].Category < entries[j].Category
+	})
+
+	return entries, nil
+}
+
+func findStructTypeInternal(file *ast.File, structName string) (*ast.StructType, error) {
+	for _, decl := range file.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.TYPE {
+			continue
+		}
+
+		for _, spec := range genDecl.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok || typeSpec.Name.Name != structName {
+				continue
+			}
+
+			structType, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				return nil, fmt.Errorf("%s is not a struct", structName)
+			}
+
+			return structType, nil
+		}
+	}
+
+	return nil, fmt.Errorf("struct %s not found", structName)
+}
+
+func exprStringInternal(expr ast.Expr) (string, error) {
+	var buf bytes.Buffer
+	if err := format.Node(&buf, token.NewFileSet(), expr); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func splitTagListInternal(value string) []string {
+	if value == "" {
+		return nil
+	}
+
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		result = append(result, trimmed)
+	}
+
+	return result
+}
+
+func normalizeCommentInternal(comment string) string {
+	return strings.TrimSpace(strings.Join(strings.Fields(comment), " "))
+}
+
+func joinRequirementsInternal(parts ...string) string {
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		filtered = append(filtered, part)
+	}
+
+	return strings.Join(filtered, " ")
+}
+
+func defaultStringInternal(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func resolveSourceRootInternal(sourceRoot string) (string, error) {
+	candidates := make([]string, 0, 2)
+	if strings.TrimSpace(sourceRoot) != "" {
+		candidates = append(candidates, sourceRoot)
+	} else {
+		wd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("get working directory: %w", err)
+		}
+		candidates = append(candidates, wd)
+	}
+
+	for _, candidate := range candidates {
+		resolved, err := resolveSourceRootCandidateInternal(candidate)
+		if err == nil {
+			return resolved, nil
+		}
+	}
+
+	if strings.TrimSpace(sourceRoot) != "" {
+		return "", fmt.Errorf("resolve source root from %q: expected backend/internal/config/config.go", sourceRoot)
+	}
+
+	return "", fmt.Errorf("resolve source root: run from the repository root/backend directory or pass --source-root")
+}
+
+func resolveSourceRootCandidateInternal(candidate string) (string, error) {
+	candidate, err := filepath.Abs(candidate)
+	if err != nil {
+		return "", fmt.Errorf("abs path for %q: %w", candidate, err)
+	}
+
+	for current := candidate; ; current = filepath.Dir(current) {
+		if hasSchemaSourceFilesInternal(current) {
+			return current, nil
+		}
+
+		backendRoot := filepath.Join(current, "backend")
+		if hasSchemaSourceFilesInternal(backendRoot) {
+			return backendRoot, nil
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+	}
+
+	return "", fmt.Errorf("schema sources not found from %q", candidate)
+}
+
+func hasSchemaSourceFilesInternal(root string) bool {
+	required := []string{
+		filepath.Join(root, "internal/config/config.go"),
+		filepath.Join(root, "internal/config/buildables_config.go"),
+	}
+
+	for _, filename := range required {
+		if _, err := os.Stat(filename); err != nil {
+			return false
+		}
+	}
+
+	return true
+}

--- a/backend/internal/configschema/schema_test.go
+++ b/backend/internal/configschema/schema_test.go
@@ -1,0 +1,333 @@
+package configschema
+
+import (
+	"reflect"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerate_EnvConfigIncludesTaggedFields(t *testing.T) {
+	doc, err := GenerateWithSourceRoot("")
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedEnvConfigVars, envNames(doc.EnvConfig))
+
+	entries := mapEnvEntries(doc.EnvConfig)
+
+	appURL, ok := entries["APP_URL"]
+	require.True(t, ok)
+	assert.Equal(t, "AppUrl", appURL.Field)
+	assert.Equal(t, "string", appURL.Type)
+	assert.Equal(t, "http://localhost:3552", appURL.DefaultValue)
+	assert.Equal(t, "config.Config", appURL.Source)
+	assert.Equal(t, sourceFileConfig, appURL.SourceFile)
+
+	encryptionKey, ok := entries["ENCRYPTION_KEY"]
+	require.True(t, ok)
+	assert.True(t, encryptionKey.SupportsFile)
+	assert.Contains(t, encryptionKey.Options, "file")
+
+	buildableUsername, ok := entries["AUTO_LOGIN_USERNAME"]
+	require.True(t, ok)
+	assert.True(t, buildableUsername.Conditional)
+	assert.Equal(t, []string{"buildables"}, buildableUsername.BuildTags)
+	assert.Equal(t, sourceFileBuildablesConfig, buildableUsername.SourceFile)
+	assert.Equal(t, "config.BuildablesConfig", buildableUsername.Source)
+}
+
+func TestGenerate_SettingEnvOverridesMatchModelMetadata(t *testing.T) {
+	doc, err := GenerateWithSourceRoot("")
+	require.NoError(t, err)
+
+	expectedCount := countDocumentedSettingOverrides()
+	assert.Len(t, doc.SettingEnvOverrides, expectedCount)
+	assert.Equal(t, expectedSettingOverrideKeys, sortedSettingKeys(doc.SettingEnvOverrides))
+
+	entries := mapSettingOverrideEntries(doc.SettingEnvOverrides)
+
+	dockerTimeout, ok := entries["dockerApiTimeout"]
+	require.True(t, ok)
+	assert.Equal(t, "DOCKER_API_TIMEOUT", dockerTimeout.Env)
+	assert.Equal(t, "30", dockerTimeout.DefaultValue)
+	assert.Equal(t, "number", dockerTimeout.Type)
+	assert.Equal(t, "timeouts", dockerTimeout.Category)
+	assert.Equal(t, "models.Settings + services.DefaultSettingsConfig", dockerTimeout.Source)
+
+	oidcSecret, ok := entries["oidcClientSecret"]
+	require.True(t, ok)
+	assert.True(t, oidcSecret.Sensitive)
+	assert.Equal(t, "OIDC_CLIENT_SECRET", oidcSecret.Env)
+
+	legacyOIDC, ok := entries["authOidcConfig"]
+	require.True(t, ok)
+	assert.True(t, legacyOIDC.Deprecated)
+	assert.NotEmpty(t, legacyOIDC.Note)
+	assert.Contains(t, legacyOIDC.Requires, "AGENT_MODE=true")
+	assert.Empty(t, legacyOIDC.DefaultValue)
+
+	trivyImage, ok := entries["trivyImage"]
+	require.True(t, ok)
+	assert.Contains(t, trivyImage.Requires, "UI_CONFIGURATION_DISABLED=true")
+
+	assert.Empty(t, oidcSecret.DefaultValue)
+
+	_, hasRuntimeDerived := entries["uiConfigDisabled"]
+	assert.False(t, hasRuntimeDerived)
+}
+
+func TestGenerate_DocumentIncludesEnvOnlyModeNote(t *testing.T) {
+	doc, err := GenerateWithSourceRoot("")
+	require.NoError(t, err)
+
+	notes := strings.Join(doc.Notes, " ")
+	assert.Contains(t, notes, "AGENT_MODE=true")
+	assert.Contains(t, notes, "UI_CONFIGURATION_DISABLED=true")
+}
+
+func TestGenerate_OutputOrderingIsStable(t *testing.T) {
+	doc, err := GenerateWithSourceRoot("")
+	require.NoError(t, err)
+
+	assert.Equal(t, envNames(doc.EnvConfig), sortedStrings(envNames(doc.EnvConfig)))
+	assert.Equal(t, categoriesThenEnv(doc.SettingEnvOverrides), sortedCategoryEnvPairs(doc.SettingEnvOverrides))
+}
+
+func mapEnvEntries(entries []ConfigEntry) map[string]ConfigEntry {
+	result := make(map[string]ConfigEntry, len(entries))
+	for _, entry := range entries {
+		result[entry.Env] = entry
+	}
+	return result
+}
+
+func mapSettingOverrideEntries(entries []SettingOverrideEntry) map[string]SettingOverrideEntry {
+	result := make(map[string]SettingOverrideEntry, len(entries))
+	for _, entry := range entries {
+		result[entry.SettingKey] = entry
+	}
+	return result
+}
+
+func envNames(entries []ConfigEntry) []string {
+	result := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		result = append(result, entry.Env)
+	}
+	return result
+}
+
+func sortedSettingKeys(entries []SettingOverrideEntry) []string {
+	result := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		result = append(result, entry.SettingKey)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func sortedStrings(values []string) []string {
+	result := append([]string(nil), values...)
+	sort.Strings(result)
+	return result
+}
+
+func categoriesThenEnv(entries []SettingOverrideEntry) []string {
+	result := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		result = append(result, entry.Category+"|"+entry.Env)
+	}
+	return result
+}
+
+func sortedCategoryEnvPairs(entries []SettingOverrideEntry) []string {
+	copied := append([]SettingOverrideEntry(nil), entries...)
+	sort.Slice(copied, func(i, j int) bool {
+		if copied[i].Category == copied[j].Category {
+			return copied[i].Env < copied[j].Env
+		}
+		return copied[i].Category < copied[j].Category
+	})
+
+	result := make([]string, 0, len(copied))
+	for _, entry := range copied {
+		result = append(result, entry.Category+"|"+entry.Env)
+	}
+	return result
+}
+
+func countDocumentedSettingOverrides() int {
+	settingsType := reflect.TypeFor[models.Settings]()
+	count := 0
+
+	for field := range settingsType.Fields() {
+		keyTag := field.Tag.Get("key")
+		if keyTag == "" {
+			continue
+		}
+
+		tagParts := splitTagListInternal(keyTag)
+		if len(tagParts) == 0 {
+			continue
+		}
+
+		attrs := tagParts[1:]
+		if slices.Contains(attrs, "envOverride") || !slices.Contains(attrs, "internal") {
+			count++
+		}
+	}
+
+	return count
+}
+
+var expectedEnvConfigVars = []string{
+	"ADMIN_STATIC_API_KEY",
+	"AGENT_MODE",
+	"AGENT_TOKEN",
+	"ALLOW_DOWNGRADE",
+	"ANALYTICS_DISABLED",
+	"APP_URL",
+	"ARCANE_BACKUP_VOLUME_NAME",
+	"AUTO_LOGIN_PASSWORD",
+	"AUTO_LOGIN_USERNAME",
+	"DATABASE_URL",
+	"DIR_PERM",
+	"DOCKER_API_TIMEOUT",
+	"DOCKER_HOST",
+	"DOCKER_IMAGE_PULL_TIMEOUT",
+	"EDGE_AGENT",
+	"EDGE_RECONNECT_INTERVAL",
+	"EDGE_TRANSPORT",
+	"ENCRYPTION_KEY",
+	"ENVIRONMENT",
+	"FILE_PERM",
+	"GIT_OPERATION_TIMEOUT",
+	"GIT_WORK_DIR",
+	"GPU_MONITORING_ENABLED",
+	"GPU_TYPE",
+	"HTTP_CLIENT_TIMEOUT",
+	"JWT_REFRESH_EXPIRY",
+	"JWT_SECRET",
+	"LISTEN",
+	"LOG_JSON",
+	"LOG_LEVEL",
+	"MANAGER_API_URL",
+	"OIDC_ADMIN_CLAIM",
+	"OIDC_ADMIN_VALUE",
+	"OIDC_AUTO_REDIRECT_TO_PROVIDER",
+	"OIDC_CLIENT_ID",
+	"OIDC_CLIENT_SECRET",
+	"OIDC_ENABLED",
+	"OIDC_ISSUER_URL",
+	"OIDC_PROVIDER_LOGO_URL",
+	"OIDC_PROVIDER_NAME",
+	"OIDC_SCOPES",
+	"OIDC_SKIP_TLS_VERIFY",
+	"PORT",
+	"PROJECTS_DIRECTORY",
+	"PROXY_REQUEST_TIMEOUT",
+	"REGISTRY_TIMEOUT",
+	"TLS_CERT_FILE",
+	"TLS_ENABLED",
+	"TLS_KEY_FILE",
+	"TRIVY_SCAN_TIMEOUT",
+	"TZ",
+	"UI_CONFIGURATION_DISABLED",
+	"UPDATE_CHECK_DISABLED",
+}
+
+var expectedSettingOverrideKeys = []string{
+	"accentColor",
+	"applicationTheme",
+	"authLocalEnabled",
+	"authOidcConfig",
+	"authPasswordPolicy",
+	"authSessionTimeout",
+	"autoHealEnabled",
+	"autoHealExcludedContainers",
+	"autoHealInterval",
+	"autoHealMaxRestarts",
+	"autoHealRestartWindow",
+	"autoInjectEnv",
+	"autoUpdate",
+	"autoUpdateExcludedContainers",
+	"autoUpdateInterval",
+	"baseServerUrl",
+	"buildProvider",
+	"buildTimeout",
+	"buildsDirectory",
+	"defaultDeployPullPolicy",
+	"defaultShell",
+	"depotProjectId",
+	"depotToken",
+	"diskUsagePath",
+	"dockerApiTimeout",
+	"dockerHost",
+	"dockerImagePullTimeout",
+	"dockerPruneMode",
+	"enableGravatar",
+	"environmentHealthInterval",
+	"eventCleanupInterval",
+	"followProjectSymlinks",
+	"gitOperationTimeout",
+	"gitSyncMaxBinarySizeMb",
+	"gitSyncMaxFiles",
+	"gitSyncMaxTotalSizeMb",
+	"gitopsSyncInterval",
+	"httpClientTimeout",
+	"keyboardShortcutsEnabled",
+	"maxImageUploadSize",
+	"mobileNavigationMode",
+	"mobileNavigationShowLabels",
+	"oidcAdminClaim",
+	"oidcAdminValue",
+	"oidcAuthorizationEndpoint",
+	"oidcAutoRedirectToProvider",
+	"oidcClientId",
+	"oidcClientSecret",
+	"oidcDeviceAuthorizationEndpoint",
+	"oidcEnabled",
+	"oidcIssuerUrl",
+	"oidcJwksEndpoint",
+	"oidcMergeAccounts",
+	"oidcProviderLogoUrl",
+	"oidcProviderName",
+	"oidcScopes",
+	"oidcSkipTlsVerify",
+	"oidcTokenEndpoint",
+	"oidcUserinfoEndpoint",
+	"oledMode",
+	"pollingEnabled",
+	"pollingInterval",
+	"projectsDirectory",
+	"proxyRequestTimeout",
+	"registryTimeout",
+	"scheduledPruneBuildCache",
+	"scheduledPruneContainers",
+	"scheduledPruneEnabled",
+	"scheduledPruneImages",
+	"scheduledPruneInterval",
+	"scheduledPruneNetworks",
+	"scheduledPruneVolumes",
+	"sidebarHoverExpansion",
+	"swarmStackSourcesDirectory",
+	"trivyConcurrentScanContainers",
+	"trivyConfig",
+	"trivyCpuLimit",
+	"trivyIgnore",
+	"trivyImage",
+	"trivyMemoryLimitMb",
+	"trivyNetwork",
+	"trivyPreserveCacheOnVolumePrune",
+	"trivyPrivileged",
+	"trivyResourceLimitsEnabled",
+	"trivyScanTimeout",
+	"trivySecurityOpts",
+	"vulnerabilityScanEnabled",
+	"vulnerabilityScanInterval",
+}

--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -89,6 +89,11 @@ func (s *SettingsService) refreshSettingsCacheInternal(ctx context.Context) erro
 }
 
 func (s *SettingsService) getDefaultSettings() *models.Settings {
+	return DefaultSettingsConfig()
+}
+
+// DefaultSettingsConfig returns the canonical default settings model used by Arcane.
+func DefaultSettingsConfig() *models.Settings {
 	return &models.Settings{
 		ProjectsDirectory:               models.SettingVariable{Value: "/app/data/projects"},
 		FollowProjectSymlinks:           models.SettingVariable{Value: "false"},


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds dynamic schema generation for environment config and settings documentation, implemented as a new `configschema` package that AST-parses Go config structs and reflects over `models.Settings` to produce a canonical JSON artifact, exposed via a new `config-schema` CLI subcommand and a `just docs config` target. All previous review concerns (silent `FieldByKey` error discard, missing `Internal` suffixes, ignored `GetString` error) have been addressed. Two minor P2 findings remain: the output file is written with `0o600` instead of the conventional `0o644`, and a diagnostic error message incompletely describes the required source files.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all previous blocking concerns are resolved and only minor P2 style findings remain

All P0/P1 issues from prior review rounds (silent error discard, missing Internal suffixes, ignored GetString error) have been fully addressed. The two remaining findings are P2 style suggestions that do not affect correctness or runtime behaviour.

No files require special attention; backend/cli/config_schema.go and backend/internal/configschema/schema.go have cosmetic P2 suggestions only
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| backend/internal/configschema/schema.go | Core schema generation logic — AST-parses config structs and reflects over models.Settings; well-structured with Internal suffixes and proper error propagation; minor error message gap on line 437 |
| backend/cli/config_schema.go | CLI entry point for config-schema command; error handling is correct but output file permission uses 0o600 instead of the conventional 0o644 |
| backend/internal/configschema/schema_test.go | Comprehensive integration tests covering env config, setting overrides, ordering stability, and document notes; expected lists are intentionally hardcoded as snapshot assertions |
| backend/internal/services/settings_service.go | Exposes DefaultSettingsConfig() used by schema generation; FieldByKey returns errors correctly with no silent discard |
| Justfile | Adds _docs-config target to invoke go run -tags exclude_frontend; default source_root=. works correctly with the tree-walking resolver |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `backend/internal/configschema/schema.go`, line 410-417 ([link](https://github.com/getarcaneapp/arcane/blob/cd9273068ef80284a8ebc4bb068cc0e24728ded2/backend/internal/configschema/schema.go#L410-L417)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`runtime.Caller` path breaks outside the source tree**

   `runtime.Caller(0)` embeds the compile-time absolute path of this source file in the binary. When `arcane config-schema` is invoked anywhere the binary wasn't compiled — a CI artifact runner, a Docker image, or a different developer's clone — `filepath.Dir(currentFile)` resolves to a nonexistent path, and the subsequent `parser.ParseFile` call in `parseStructEnvFields` immediately returns a "no such file or directory" OS error. The command is broken outside the original build machine, yet generating this schema is the entire purpose of this PR.

   Consider accepting an explicit `--source-root` flag, or use `//go:embed` to bundle the two source files that need parsing.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/configschema/schema.go
   Line: 410-417

   Comment:
   **`runtime.Caller` path breaks outside the source tree**

   `runtime.Caller(0)` embeds the compile-time absolute path of this source file in the binary. When `arcane config-schema` is invoked anywhere the binary wasn't compiled — a CI artifact runner, a Docker image, or a different developer's clone — `filepath.Dir(currentFile)` resolves to a nonexistent path, and the subsequent `parser.ParseFile` call in `parseStructEnvFields` immediately returns a "no such file or directory" OS error. The command is broken outside the original build machine, yet generating this schema is the entire purpose of this PR.

   Consider accepting an explicit `--source-root` flag, or use `//go:embed` to bundle the two source files that need parsing.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fconfigschema%2Fschema.go%0ALine%3A%20410-417%0A%0AComment%3A%0A**%60runtime.Caller%60%20path%20breaks%20outside%20the%20source%20tree**%0A%0A%60runtime.Caller%280%29%60%20embeds%20the%20compile-time%20absolute%20path%20of%20this%20source%20file%20in%20the%20binary.%20When%20%60arcane%20config-schema%60%20is%20invoked%20anywhere%20the%20binary%20wasn't%20compiled%20%E2%80%94%20a%20CI%20artifact%20runner%2C%20a%20Docker%20image%2C%20or%20a%20different%20developer's%20clone%20%E2%80%94%20%60filepath.Dir%28currentFile%29%60%20resolves%20to%20a%20nonexistent%20path%2C%20and%20the%20subsequent%20%60parser.ParseFile%60%20call%20in%20%60parseStructEnvFields%60%20immediately%20returns%20a%20%22no%20such%20file%20or%20directory%22%20OS%20error.%20The%20command%20is%20broken%20outside%20the%20original%20build%20machine%2C%20yet%20generating%20this%20schema%20is%20the%20entire%20purpose%20of%20this%20PR.%0A%0AConsider%20accepting%20an%20explicit%20%60--source-root%60%20flag%2C%20or%20use%20%60%2F%2Fgo%3Aembed%60%20to%20bundle%20the%20two%20source%20files%20that%20need%20parsing.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>

2. `backend/internal/configschema/schema_test.go`, line 332-339 ([link](https://github.com/getarcaneapp/arcane/blob/cd9273068ef80284a8ebc4bb068cc0e24728ded2/backend/internal/configschema/schema_test.go#L332-L339)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`slicesContains` duplicates `slices.Contains`**

   This helper re-implements `slices.Contains` from the standard library. The main package already imports and uses `"slices"`; importing it here and removing this helper keeps things consistent.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/configschema/schema_test.go
   Line: 332-339

   Comment:
   **`slicesContains` duplicates `slices.Contains`**

   This helper re-implements `slices.Contains` from the standard library. The main package already imports and uses `"slices"`; importing it here and removing this helper keeps things consistent.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fconfigschema%2Fschema_test.go%0ALine%3A%20332-339%0A%0AComment%3A%0A**%60slicesContains%60%20duplicates%20%60slices.Contains%60**%0A%0AThis%20helper%20re-implements%20%60slices.Contains%60%20from%20the%20standard%20library.%20The%20main%20package%20already%20imports%20and%20uses%20%60%22slices%22%60%3B%20importing%20it%20here%20and%20removing%20this%20helper%20keeps%20things%20consistent.%0A%0A%60%60%60suggestion%0A%2F%2F%20Delete%20slicesContains%20and%20import%20%22slices%22%3B%20replace%20call%20sites%20with%20slices.Contains%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Fcli%2Fconfig_schema.go%3A41%0A**Overly%20restrictive%20file%20permission%20for%20a%20documentation%20artifact**%0A%0AThe%20schema%20file%20is%20written%20with%20%600o600%60%20%28owner%20read%2Fwrite%20only%29.%20Since%20this%20is%20a%20documentation%20artifact%20intended%20to%20be%20committed%2C%20uploaded%20to%20a%20docs%20site%2C%20or%20consumed%20by%20other%20CI%20steps%2C%20%600o644%60%20is%20the%20conventional%20permission%20%E2%80%94%20otherwise%20any%20process%20running%20as%20a%20different%20user%20cannot%20read%20the%20file.%0A%0A%60%60%60suggestion%0A%09%09%09if%20err%20%3A%3D%20os.WriteFile%28outputFile%2C%20output%2C%200o644%29%3B%20err%20!%3D%20nil%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Finternal%2Fconfigschema%2Fschema.go%3A437%0A**Incomplete%20error%20message%20omits%20the%20second%20required%20source%20file**%0A%0A%60hasSchemaSourceFilesInternal%60%20requires%20*both*%20%60config.go%60%20and%20%60buildables_config.go%60%2C%20but%20this%20diagnostic%20only%20mentions%20%60config.go%60.%20A%20user%20whose%20%60--source-root%60%20is%20missing%20%60buildables_config.go%60%20will%20follow%20the%20wrong%20hint.%0A%0A%60%60%60suggestion%0A%09return%20%22%22%2C%20fmt.Errorf%28%22resolve%20source%20root%20from%20%25q%3A%20expected%20backend%2Finternal%2Fconfig%2Fconfig.go%20and%20backend%2Finternal%2Fconfig%2Fbuildables_config.go%22%2C%20sourceRoot%29%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/cli/config_schema.go
Line: 41

Comment:
**Overly restrictive file permission for a documentation artifact**

The schema file is written with `0o600` (owner read/write only). Since this is a documentation artifact intended to be committed, uploaded to a docs site, or consumed by other CI steps, `0o644` is the conventional permission — otherwise any process running as a different user cannot read the file.

```suggestion
			if err := os.WriteFile(outputFile, output, 0o644); err != nil {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/configschema/schema.go
Line: 437

Comment:
**Incomplete error message omits the second required source file**

`hasSchemaSourceFilesInternal` requires *both* `config.go` and `buildables_config.go`, but this diagnostic only mentions `config.go`. A user whose `--source-root` is missing `buildables_config.go` will follow the wrong hint.

```suggestion
	return "", fmt.Errorf("resolve source root from %q: expected backend/internal/config/config.go and backend/internal/config/buildables_config.go", sourceRoot)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: add dynamic env config schema ..."](https://github.com/getarcaneapp/arcane/commit/4fcb3c776136ea5828a4bf219c0fa2ea274e298b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27415012)</sub>

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->