### PR TITLE
fix: git sync is not pulling full folders, no longer deploy on creation of sync

### DIFF
--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -1,12 +1,14 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -44,6 +46,26 @@ type scheduledGitOpsSync struct {
 	EnvironmentID string
 	SyncInterval  int
 	LastSyncAt    *time.Time
+}
+
+// preparedSyncSource captures the repository data needed by the sync execution
+// paths after the source repository has been cloned and validated.
+type preparedSyncSource struct {
+	repoPath       string
+	commitHash     string
+	composeContent string
+	envContent     *string
+}
+
+// stagedDirectorySync holds the fully prepared directory-sync result before it
+// is promoted into the live project path.
+type stagedDirectorySync struct {
+	stagePath       string
+	composeFileName string
+	project         *models.Project
+	syncedFiles     []string
+	serviceCount    int
+	contentsChanged bool
 }
 
 func validateSyncLimits(maxFiles *int, maxTotalSize, maxBinarySize *int64) error {
@@ -458,123 +480,146 @@ func (s *GitOpsSyncService) PerformSync(ctx context.Context, environmentID, id s
 		SyncedAt: time.Now(),
 	}
 
-	// Get repository and auth config
+	source, err := s.prepareSyncSource(syncCtx, sync, result, actor)
+	if source != nil && source.repoPath != "" {
+		defer func() {
+			if cleanupErr := s.repoService.gitClient.Cleanup(source.repoPath); cleanupErr != nil {
+				slog.WarnContext(syncCtx, "Failed to cleanup repository", "path", source.repoPath, "error", cleanupErr)
+			}
+		}()
+	}
+	if err != nil {
+		return result, err
+	}
+
+	if sync.SyncDirectory {
+		return s.performDirectorySync(syncCtx, sync, id, actor, result, source)
+	}
+
+	return s.performSingleFileSync(syncCtx, sync, id, actor, result, source)
+}
+
+// prepareSyncSource clones the source repository, validates that the configured
+// compose file exists, and reads the compose/env inputs for the sync flow.
+func (s *GitOpsSyncService) prepareSyncSource(ctx context.Context, sync *models.GitOpsSync, result *gitops.SyncResult, actor models.User) (*preparedSyncSource, error) {
 	repository := sync.Repository
 	if repository == nil {
-		return result, s.failSync(syncCtx, id, result, sync, actor, "Repository not found", "repository not found")
+		return nil, s.failSync(ctx, sync.ID, result, sync, actor, "Repository not found", "repository not found")
 	}
 
-	authConfig, err := s.repoService.GetAuthConfig(syncCtx, repository)
+	authConfig, err := s.repoService.GetAuthConfig(ctx, repository)
 	if err != nil {
-		return result, s.failSync(syncCtx, id, result, sync, actor, "Failed to get authentication config", err.Error())
+		return nil, s.failSync(ctx, sync.ID, result, sync, actor, "Failed to get authentication config", err.Error())
 	}
 
-	// Clone the repository
-	repoPath, err := s.repoService.gitClient.Clone(syncCtx, repository.URL, sync.Branch, authConfig)
+	repoPath, err := s.repoService.gitClient.Clone(ctx, repository.URL, sync.Branch, authConfig)
 	if err != nil {
-		return result, s.failSync(syncCtx, id, result, sync, actor, "Failed to clone repository", err.Error())
+		return nil, s.failSync(ctx, sync.ID, result, sync, actor, "Failed to clone repository", err.Error())
 	}
-	defer func() {
-		if cleanupErr := s.repoService.gitClient.Cleanup(repoPath); cleanupErr != nil {
-			slog.WarnContext(syncCtx, "Failed to cleanup repository", "path", repoPath, "error", cleanupErr)
-		}
-	}()
 
-	// Get the current commit hash
-	commitHash, err := s.repoService.gitClient.GetCurrentCommit(syncCtx, repoPath)
+	commitHash, err := s.repoService.gitClient.GetCurrentCommit(ctx, repoPath)
 	if err != nil {
-		slog.WarnContext(syncCtx, "Failed to get commit hash", "error", err)
+		slog.WarnContext(ctx, "Failed to get commit hash", "error", err)
 		commitHash = ""
 	}
 
-	// Check if compose file exists
-	if !s.repoService.gitClient.FileExists(syncCtx, repoPath, sync.ComposePath) {
+	if !s.repoService.gitClient.FileExists(ctx, repoPath, sync.ComposePath) {
 		errMsg := fmt.Sprintf("compose file not found: %s", sync.ComposePath)
-		return result, s.failSync(syncCtx, id, result, sync, actor, fmt.Sprintf("Compose file not found at %s", sync.ComposePath), errMsg)
+		return &preparedSyncSource{repoPath: repoPath, commitHash: commitHash}, s.failSync(ctx, sync.ID, result, sync, actor, fmt.Sprintf("Compose file not found at %s", sync.ComposePath), errMsg)
 	}
 
-	// Read compose file content
-	composeContent, err := s.repoService.gitClient.ReadFile(syncCtx, repoPath, sync.ComposePath)
+	composeContent, err := s.repoService.gitClient.ReadFile(ctx, repoPath, sync.ComposePath)
 	if err != nil {
-		return result, s.failSync(syncCtx, id, result, sync, actor, "Failed to read compose file", err.Error())
+		return &preparedSyncSource{repoPath: repoPath, commitHash: commitHash}, s.failSync(ctx, sync.ID, result, sync, actor, "Failed to read compose file", err.Error())
 	}
 
-	// Try to read .env file from the same directory as the compose file
-	var envContent *string
+	source := &preparedSyncSource{
+		repoPath:       repoPath,
+		commitHash:     commitHash,
+		composeContent: composeContent,
+	}
+
 	envPath := filepath.Join(filepath.Dir(sync.ComposePath), ".env")
-	if s.repoService.gitClient.FileExists(syncCtx, repoPath, envPath) {
-		content, err := s.repoService.gitClient.ReadFile(syncCtx, repoPath, envPath)
+	if s.repoService.gitClient.FileExists(ctx, repoPath, envPath) {
+		content, err := s.repoService.gitClient.ReadFile(ctx, repoPath, envPath)
 		if err != nil {
-			slog.WarnContext(syncCtx, "Failed to read .env file", "path", envPath, "error", err)
+			slog.WarnContext(ctx, "Failed to read .env file", "path", envPath, "error", err)
 		} else {
-			envContent = &content
+			source.envContent = &content
 		}
 	}
 
-	var project *models.Project
-	var syncedFiles []string
+	return source, nil
+}
 
-	if sync.SyncDirectory {
-		// Directory sync mode - sync entire directory containing compose file
-		slog.InfoContext(syncCtx, "Using directory sync mode", "syncId", id, "composePath", sync.ComposePath)
+// performDirectorySync runs the directory-sync path and only triggers a
+// redeploy when an already running project's synced contents changed.
+func (s *GitOpsSyncService) performDirectorySync(ctx context.Context, sync *models.GitOpsSync, id string, actor models.User, result *gitops.SyncResult, source *preparedSyncSource) (*gitops.SyncResult, error) {
+	slog.InfoContext(ctx, "Using directory sync mode", "syncId", id, "composePath", sync.ComposePath)
 
-		// Walk directory once and get all files
-		var dirComposeContent string
-		var syncFiles []projects.SyncFile
-		var err error
-		dirComposeContent, syncFiles, err = s.walkAndParseSyncDirectory(syncCtx, sync, repoPath)
-		if err != nil {
-			return result, s.failSync(syncCtx, id, result, sync, actor, "Failed to walk directory", err.Error())
-		}
-
-		// Get or create project with compose content
-		project, err = s.getOrCreateProjectInternal(syncCtx, sync, id, dirComposeContent, nil, result, actor)
-		if err != nil {
-			return result, err
-		}
-
-		// Write all directory files to the project
-		oldSyncedFiles := parseSyncedFiles(sync.SyncedFiles)
-		syncedFiles, err = s.writeSyncFilesToProject(syncCtx, sync, project, syncFiles, oldSyncedFiles)
-		if err != nil {
-			slog.ErrorContext(syncCtx, "Failed to write directory files to project", "error", err, "syncId", id)
-			// Don't fail the sync - the project was created/updated with compose content
-			// Fall back to just tracking the file paths
-			syncedFiles = make([]string, len(syncFiles))
-			for i, f := range syncFiles {
-				syncedFiles[i] = f.RelativePath
-			}
-		}
-
-		// Update sync status with synced files
-		s.updateSyncStatusWithFiles(syncCtx, id, "success", "", commitHash, syncedFiles)
-	} else {
-		// Single file sync mode - existing behavior
-		slog.InfoContext(syncCtx, "Using single file sync mode", "syncId", id, "composePath", sync.ComposePath)
-
-		// Get or create project (uses composeContent and envContent already read above)
-		var err error
-		project, err = s.getOrCreateProjectInternal(syncCtx, sync, id, composeContent, envContent, result, actor)
-		if err != nil {
-			return result, err
-		}
-
-		// Track single compose file as synced
-		syncedFiles = []string{filepath.Base(sync.ComposePath)}
-
-		// Update sync status with synced files
-		s.updateSyncStatusWithFiles(syncCtx, id, "success", "", commitHash, syncedFiles)
+	_, syncFiles, err := s.walkAndParseSyncDirectory(ctx, sync, source.repoPath)
+	if err != nil {
+		return result, s.failSync(ctx, id, result, sync, actor, "Failed to walk directory", err.Error())
 	}
 
+	project, syncedFiles, _, contentsChanged, err := s.syncProjectDirectoryInternal(ctx, sync, syncFiles, actor)
+	if err != nil {
+		return result, s.failSync(ctx, id, result, sync, actor, "Failed to sync project directory", err.Error())
+	}
+
+	if contentsChanged {
+		s.redeployIfRunningAfterSync(ctx, project, actor, "directory")
+	}
+
+	s.updateSyncStatusWithFiles(ctx, id, "success", "", source.commitHash, syncedFiles)
 	result.Success = true
-	if sync.SyncDirectory {
-		result.Message = fmt.Sprintf("Successfully synced directory with %d files to project %s", len(syncedFiles), project.Name)
-	} else {
-		result.Message = fmt.Sprintf("Successfully synced compose file from %s to project %s", sync.ComposePath, project.Name)
+	result.Message = fmt.Sprintf("Successfully synced directory with %d files to project %s", len(syncedFiles), project.Name)
+	s.logSyncSuccess(ctx, sync, project, actor)
+	slog.InfoContext(ctx, "GitOps sync completed", "syncId", id, "project", project.Name)
+
+	return result, nil
+}
+
+// performSingleFileSync preserves the legacy compose-only Git sync behavior.
+func (s *GitOpsSyncService) performSingleFileSync(ctx context.Context, sync *models.GitOpsSync, id string, actor models.User, result *gitops.SyncResult, source *preparedSyncSource) (*gitops.SyncResult, error) {
+	slog.InfoContext(ctx, "Using single file sync mode", "syncId", id, "composePath", sync.ComposePath)
+
+	project, err := s.getOrCreateProjectInternal(ctx, sync, id, source.composeContent, source.envContent, result, actor)
+	if err != nil {
+		return result, err
 	}
 
-	// Log success event
-	_, _ = s.eventService.CreateEvent(syncCtx, CreateEventRequest{
+	syncedFiles := []string{filepath.Base(sync.ComposePath)}
+	s.updateSyncStatusWithFiles(ctx, id, "success", "", source.commitHash, syncedFiles)
+	result.Success = true
+	result.Message = fmt.Sprintf("Successfully synced compose file from %s to project %s", sync.ComposePath, project.Name)
+	s.logSyncSuccess(ctx, sync, project, actor)
+	slog.InfoContext(ctx, "GitOps sync completed", "syncId", id, "project", project.Name)
+
+	return result, nil
+}
+
+// redeployIfRunningAfterSync redeploys a project only when it is already
+// running and the latest sync actually changed managed content.
+func (s *GitOpsSyncService) redeployIfRunningAfterSync(ctx context.Context, project *models.Project, actor models.User, syncMode string) {
+	details, err := s.projectService.GetProjectDetails(ctx, project.ID)
+	if err != nil {
+		return
+	}
+	if details.Status != string(models.ProjectStatusRunning) && details.Status != string(models.ProjectStatusPartiallyRunning) {
+		return
+	}
+
+	slog.InfoContext(ctx, "Redeploying project due to content change from Git sync", "syncMode", syncMode, "projectName", project.Name, "projectId", project.ID)
+	if err := s.projectService.RedeployProject(ctx, project.ID, actor); err != nil {
+		slog.ErrorContext(ctx, "Failed to redeploy project after Git sync", "syncMode", syncMode, "error", err, "projectId", project.ID)
+	}
+}
+
+// logSyncSuccess records the Git sync completion event once the filesystem and
+// sync-status updates have already succeeded.
+func (s *GitOpsSyncService) logSyncSuccess(ctx context.Context, sync *models.GitOpsSync, project *models.Project, actor models.User) {
+	_, _ = s.eventService.CreateEvent(ctx, CreateEventRequest{
 		Type:          models.EventTypeGitSyncRun,
 		Severity:      models.EventSeveritySuccess,
 		Title:         "Git sync completed",
@@ -586,10 +631,6 @@ func (s *GitOpsSyncService) PerformSync(ctx context.Context, environmentID, id s
 		Username:      new(actor.Username),
 		EnvironmentID: new(sync.EnvironmentID),
 	})
-
-	slog.InfoContext(syncCtx, "GitOps sync completed", "syncId", id, "project", project.Name)
-
-	return result, nil
 }
 
 func (s *GitOpsSyncService) updateSyncStatus(ctx context.Context, id, status, errorMsg, commitHash string) {
@@ -803,12 +844,6 @@ func (s *GitOpsSyncService) createProjectForSyncInternal(ctx context.Context, sy
 
 	slog.InfoContext(ctx, "Created project for GitOps sync", "projectName", sync.ProjectName, "projectId", project.ID)
 
-	// Deploy the project immediately after creation
-	slog.InfoContext(ctx, "Deploying project after initial Git sync", "projectName", project.Name, "projectId", project.ID)
-	if err := s.projectService.DeployProject(ctx, project.ID, actor, nil); err != nil {
-		slog.ErrorContext(ctx, "Failed to deploy project after initial Git sync", "error", err, "projectId", project.ID)
-	}
-
 	return project, nil
 }
 
@@ -870,12 +905,6 @@ func envContentChangedInternal(oldEnv, newEnv string) bool {
 	}
 
 	return !maps.Equal(oldEnvMap, newEnvMap)
-}
-
-// getProjectsDirectory returns the configured projects directory path
-func (s *GitOpsSyncService) getProjectsDirectory(ctx context.Context) (string, error) {
-	projectsDirSetting := s.settingsService.GetStringSetting(ctx, "projectsDirectory", "/app/data/projects")
-	return projects.GetProjectsDirectory(ctx, strings.TrimSpace(projectsDirSetting))
 }
 
 // parseSyncedFiles parses the JSON array of synced file paths from the database
@@ -946,36 +975,401 @@ func (s *GitOpsSyncService) walkAndParseSyncDirectory(ctx context.Context, sync 
 	return composeContent, syncFiles, nil
 }
 
-// writeSyncFilesToProject writes the given sync files to the project directory.
-// If oldSyncedFiles is provided, removed files will be cleaned up first.
-func (s *GitOpsSyncService) writeSyncFilesToProject(ctx context.Context, sync *models.GitOpsSync, project *models.Project, syncFiles []projects.SyncFile, oldSyncedFiles []string) ([]string, error) {
-	projectsDir, err := s.getProjectsDirectory(ctx)
+// syncProjectDirectoryInternal runs the new directory-sync path end to end:
+// stage files, validate the staged tree, then create or update the project.
+func (s *GitOpsSyncService) syncProjectDirectoryInternal(ctx context.Context, sync *models.GitOpsSync, syncFiles []projects.SyncFile, actor models.User) (*models.Project, []string, bool, bool, error) {
+	stage, err := s.stageDirectorySyncInternal(ctx, sync, syncFiles)
+	if err != nil {
+		return nil, nil, false, false, err
+	}
+	defer func() {
+		if stage != nil && stage.stagePath != "" {
+			_ = os.RemoveAll(stage.stagePath)
+		}
+	}()
+
+	if stage.project == nil {
+		project, err := s.createDirectorySyncProjectInternal(ctx, sync, stage, actor)
+		if err != nil {
+			return nil, nil, false, false, err
+		}
+		return project, stage.syncedFiles, true, true, nil
+	}
+
+	project, err := s.updateDirectorySyncProjectInternal(ctx, sync, stage)
+	if err != nil {
+		return nil, nil, false, false, err
+	}
+	return project, stage.syncedFiles, false, stage.contentsChanged, nil
+}
+
+// stageDirectorySyncInternal builds a temporary project tree that reflects the exact
+// repo layout after sync, including cleanup of files removed from the repo.
+func (s *GitOpsSyncService) stageDirectorySyncInternal(ctx context.Context, sync *models.GitOpsSync, syncFiles []projects.SyncFile) (*stagedDirectorySync, error) {
+	projectsDir, err := s.projectService.getProjectsDirectoryInternal(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get projects directory: %w", err)
 	}
 
-	// Build list of new file paths
-	newFiles := make([]string, len(syncFiles))
-	for i, f := range syncFiles {
-		newFiles[i] = f.RelativePath
+	stagePath, err := os.MkdirTemp(projectsDir, ".gitops-sync-stage-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create staging directory: %w", err)
 	}
 
-	// Clean up removed files if we have old sync data
-	if len(oldSyncedFiles) > 0 {
-		if err := projects.CleanupRemovedFiles(projectsDir, project.Path, oldSyncedFiles, newFiles); err != nil {
-			slog.WarnContext(ctx, "Failed to cleanup removed files", "error", err, "syncId", sync.ID)
-			// Continue despite cleanup error - it's best effort
+	project, err := s.getDirectorySyncProjectInternal(ctx, sync)
+	if err != nil {
+		_ = os.RemoveAll(stagePath)
+		return nil, err
+	}
+
+	if project != nil {
+		if err := copyDirectoryContentsInternal(project.Path, stagePath); err != nil {
+			_ = os.RemoveAll(stagePath)
+			return nil, fmt.Errorf("failed to stage current project files: %w", err)
 		}
 	}
 
-	// Write all files to project directory
-	writtenPaths, err := projects.WriteSyncedDirectory(projectsDir, project.Path, syncFiles)
-	if err != nil {
-		return nil, fmt.Errorf("failed to write synced directory: %w", err)
+	syncedFiles := make([]string, len(syncFiles))
+	for i, file := range syncFiles {
+		syncedFiles[i] = file.RelativePath
 	}
 
-	slog.InfoContext(ctx, "Directory sync written", "syncId", sync.ID, "projectId", project.ID, "filesWritten", len(writtenPaths))
-	return writtenPaths, nil
+	oldSyncedFiles := parseSyncedFiles(sync.SyncedFiles)
+	if len(oldSyncedFiles) > 0 {
+		if err := projects.CleanupRemovedFiles(projectsDir, stagePath, oldSyncedFiles, syncedFiles); err != nil {
+			_ = os.RemoveAll(stagePath)
+			return nil, fmt.Errorf("failed to clean removed synced files: %w", err)
+		}
+	}
+
+	composeFileName := filepath.Base(sync.ComposePath)
+	if err := removeStaleComposeFilesInternal(stagePath, composeFileName, syncedFiles); err != nil {
+		_ = os.RemoveAll(stagePath)
+		return nil, fmt.Errorf("failed to remove stale compose files: %w", err)
+	}
+
+	contentsChanged, err := directorySyncContentsChangedInternal(project, syncFiles, oldSyncedFiles, composeFileName)
+	if err != nil {
+		_ = os.RemoveAll(stagePath)
+		return nil, fmt.Errorf("failed to compare staged directory changes: %w", err)
+	}
+
+	// Write the repo files after cleanup so validation sees the final on-disk
+	// tree exactly as it will exist in the managed project.
+	if _, err := projects.WriteSyncedDirectory(projectsDir, stagePath, syncFiles); err != nil {
+		_ = os.RemoveAll(stagePath)
+		return nil, fmt.Errorf("failed to write staged sync files: %w", err)
+	}
+
+	serviceCount, err := s.validateDirectorySyncStageInternal(ctx, sync.ProjectName, stagePath, composeFileName)
+	if err != nil {
+		_ = os.RemoveAll(stagePath)
+		return nil, fmt.Errorf("invalid compose file: %w", err)
+	}
+
+	return &stagedDirectorySync{
+		stagePath:       stagePath,
+		composeFileName: composeFileName,
+		project:         project,
+		syncedFiles:     syncedFiles,
+		serviceCount:    serviceCount,
+		contentsChanged: contentsChanged,
+	}, nil
+}
+
+// getDirectorySyncProjectInternal resolves the linked project for a sync when one
+// exists, while tolerating deleted/stale project references.
+func (s *GitOpsSyncService) getDirectorySyncProjectInternal(ctx context.Context, sync *models.GitOpsSync) (*models.Project, error) {
+	if sync.ProjectID == nil || *sync.ProjectID == "" {
+		return nil, nil
+	}
+
+	project, err := s.projectService.GetProjectFromDatabaseByID(ctx, *sync.ProjectID)
+	if err != nil {
+		slog.WarnContext(ctx, "Existing project not found, will create new one", "projectId", *sync.ProjectID, "error", err)
+		return nil, nil
+	}
+
+	if err := s.projectService.ensureProjectPathUnderRoot(ctx, project, false); err != nil {
+		return nil, err
+	}
+
+	return project, nil
+}
+
+// validateDirectorySyncStageInternal loads the staged compose project using the real
+// synced compose filename so include/env_file resolution happens against the
+// fully copied directory contents.
+func (s *GitOpsSyncService) validateDirectorySyncStageInternal(ctx context.Context, projectName, stagePath, composeFileName string) (int, error) {
+	projectsDir, err := s.projectService.getProjectsDirectoryInternal(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	pathMapper, pmErr := s.projectService.getPathMapper(ctx)
+	if pmErr != nil {
+		slog.WarnContext(ctx, "failed to create path mapper for directory sync validation, continuing without translation", "error", pmErr)
+	}
+
+	autoInjectEnv := s.settingsService.GetBoolSetting(ctx, "autoInjectEnv", false)
+	project, err := projects.LoadComposeProject(
+		ctx,
+		filepath.Join(stagePath, composeFileName),
+		normalizeComposeProjectName(projectName),
+		projectsDir,
+		autoInjectEnv,
+		pathMapper,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(project.Services), nil
+}
+
+// createDirectorySyncProjectInternal promotes a validated staged tree into a new
+// managed project directory and links it back to the Git sync record.
+func (s *GitOpsSyncService) createDirectorySyncProjectInternal(ctx context.Context, sync *models.GitOpsSync, stage *stagedDirectorySync, actor models.User) (*models.Project, error) {
+	projectsDir, err := s.projectService.getProjectsDirectoryInternal(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get projects directory: %w", err)
+	}
+
+	basePath := filepath.Join(projectsDir, projects.SanitizeProjectName(sync.ProjectName))
+	projectPath, folderName, err := projects.CreateUniqueDir(projectsDir, basePath, sync.ProjectName, 0o755)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create project directory: %w", err)
+	}
+
+	if err := os.Remove(projectPath); err != nil {
+		return nil, fmt.Errorf("failed to prepare project directory: %w", err)
+	}
+
+	if err := os.Rename(stage.stagePath, projectPath); err != nil {
+		return nil, fmt.Errorf("failed to promote staged project directory: %w", err)
+	}
+	stage.stagePath = ""
+
+	project := &models.Project{
+		Name:         sync.ProjectName,
+		DirName:      new(folderName),
+		Path:         projectPath,
+		Status:       models.ProjectStatusStopped,
+		ServiceCount: stage.serviceCount,
+		RunningCount: 0,
+	}
+
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(project).Error; err != nil {
+			return fmt.Errorf("failed to create project: %w", err)
+		}
+
+		if err := tx.Model(&models.GitOpsSync{}).Where("id = ?", sync.ID).Update("project_id", project.ID).Error; err != nil {
+			return fmt.Errorf("failed to update sync with project ID: %w", err)
+		}
+
+		if err := tx.Model(&models.Project{}).Where("id = ?", project.ID).Update("gitops_managed_by", sync.ID).Error; err != nil {
+			return fmt.Errorf("failed to mark project as GitOps-managed: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		_ = os.RemoveAll(projectPath)
+		return nil, err
+	}
+
+	sync.ProjectID = &project.ID
+	s.projectService.cacheComposeProjectIDInternal(normalizeComposeProjectName(project.Name), project.ID)
+
+	if s.projectService.eventService != nil {
+		metadata := models.JSON{"action": "create", "projectID": project.ID, "projectName": project.Name, "path": projectPath}
+		if logErr := s.projectService.eventService.LogProjectEvent(ctx, models.EventTypeProjectCreate, project.ID, project.Name, actor.ID, actor.Username, "0", metadata); logErr != nil {
+			slog.ErrorContext(ctx, "could not log project creation", "error", logErr)
+		}
+	}
+
+	return project, nil
+}
+
+// updateDirectorySyncProjectInternal swaps a validated staged tree into the existing
+// project path with a temporary backup so failed promotion can roll back.
+func (s *GitOpsSyncService) updateDirectorySyncProjectInternal(ctx context.Context, sync *models.GitOpsSync, stage *stagedDirectorySync) (*models.Project, error) {
+	project := stage.project
+	projectPath := filepath.Clean(project.Path)
+	backupPath := ""
+
+	if info, err := os.Stat(projectPath); err == nil {
+		if !info.IsDir() {
+			return nil, fmt.Errorf("project path is not a directory: %s", projectPath)
+		}
+		backupPath = fmt.Sprintf("%s.gitops-backup-%d", projectPath, time.Now().UnixNano())
+		if err := os.Rename(projectPath, backupPath); err != nil {
+			return nil, fmt.Errorf("failed to move current project directory out of the way: %w", err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("failed to inspect current project directory: %w", err)
+	}
+
+	if err := os.Rename(stage.stagePath, projectPath); err != nil {
+		if backupPath != "" {
+			_ = os.Rename(backupPath, projectPath)
+		}
+		return nil, fmt.Errorf("failed to promote staged project directory: %w", err)
+	}
+	stage.stagePath = ""
+
+	if err := s.db.WithContext(ctx).Model(&models.Project{}).Where("id = ?", project.ID).Updates(map[string]any{
+		"service_count":     stage.serviceCount,
+		"gitops_managed_by": sync.ID,
+		"updated_at":        time.Now(),
+	}).Error; err != nil {
+		if backupPath != "" {
+			_ = os.RemoveAll(projectPath)
+			_ = os.Rename(backupPath, projectPath)
+		}
+		return nil, fmt.Errorf("failed to update project metadata after directory sync: %w", err)
+	}
+
+	if backupPath != "" {
+		_ = os.RemoveAll(backupPath)
+	}
+
+	return project, nil
+}
+
+// directorySyncContentsChangedInternal compares the currently managed synced files with
+// the newly fetched repo files to decide whether a redeploy is needed.
+func directorySyncContentsChangedInternal(project *models.Project, syncFiles []projects.SyncFile, oldSyncedFiles []string, composeFileName string) (bool, error) {
+	if project == nil {
+		return true, nil
+	}
+
+	if info, err := os.Stat(project.Path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		}
+		return false, err
+	} else if !info.IsDir() {
+		return false, fmt.Errorf("project path is not a directory: %s", project.Path)
+	}
+
+	newFileSet := make(map[string]struct{}, len(syncFiles))
+	for _, file := range syncFiles {
+		newFileSet[file.RelativePath] = struct{}{}
+		existingContent, err := os.ReadFile(filepath.Join(project.Path, file.RelativePath))
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return true, nil
+			}
+			return false, err
+		}
+		if !bytes.Equal(existingContent, file.Content) {
+			return true, nil
+		}
+	}
+
+	for _, oldFile := range oldSyncedFiles {
+		if _, exists := newFileSet[oldFile]; exists {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(project.Path, oldFile)); err == nil {
+			return true, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+	}
+
+	for _, candidate := range projects.ComposeFileCandidates() {
+		if candidate == composeFileName {
+			continue
+		}
+		if _, exists := newFileSet[candidate]; exists {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(project.Path, candidate)); err == nil {
+			return true, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+	}
+
+	return false, nil
+}
+
+// removeStaleComposeFilesInternal drops old canonical compose filenames from the staged
+// project when the repo now uses a different compose filename.
+func removeStaleComposeFilesInternal(projectPath, composeFileName string, syncedFiles []string) error {
+	syncedFileSet := make(map[string]struct{}, len(syncedFiles))
+	for _, file := range syncedFiles {
+		syncedFileSet[file] = struct{}{}
+	}
+
+	for _, candidate := range projects.ComposeFileCandidates() {
+		if candidate == composeFileName {
+			continue
+		}
+		if _, exists := syncedFileSet[candidate]; exists {
+			continue
+		}
+		if err := os.Remove(filepath.Join(projectPath, candidate)); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// copyDirectoryContentsInternal clones the current project tree into the staging
+// directory so directory sync updates can preserve non-synced local files.
+func copyDirectoryContentsInternal(srcDir, destDir string) error {
+	srcRoot, err := os.OpenRoot(srcDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = srcRoot.Close() }()
+
+	destRoot, err := os.OpenRoot(destDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = destRoot.Close() }()
+
+	return filepath.WalkDir(srcDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == srcDir {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return destRoot.MkdirAll(relPath, 0o755)
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		content, err := srcRoot.ReadFile(relPath)
+		if err != nil {
+			return err
+		}
+
+		if err := destRoot.MkdirAll(filepath.Dir(relPath), 0o755); err != nil {
+			return err
+		}
+
+		return destRoot.WriteFile(relPath, content, info.Mode())
+	})
 }
 
 // updateSyncStatusWithFiles updates sync status including the list of synced files

--- a/backend/internal/services/gitops_sync_service_test.go
+++ b/backend/internal/services/gitops_sync_service_test.go
@@ -2,12 +2,245 @@ package services
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/pkg/projects"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
+
+func setupGitOpsSyncDirectoryTestService(t *testing.T) (*GitOpsSyncService, *database.DB, string) {
+	t.Helper()
+
+	ctx := context.Background()
+	db := setupProjectTestDB(t)
+	require.NoError(t, db.AutoMigrate(&models.GitOpsSync{}))
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectsDir := t.TempDir()
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
+
+	projectService := NewProjectService(db, settingsService, nil, nil, nil, nil)
+
+	return NewGitOpsSyncService(db, nil, projectService, nil, settingsService), db, projectsDir
+}
+
+func TestGitOpsSyncService_SyncProjectDirectory_CreatesProjectPreservingRepoLayout(t *testing.T) {
+	ctx := context.Background()
+	svc, db, _ := setupGitOpsSyncDirectoryTestService(t)
+
+	sync := &models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-directory-create"},
+		Name:          "demo-sync",
+		EnvironmentID: "0",
+		RepositoryID:  "repo-1",
+		ComposePath:   "apps/demo/docker-compose.yaml",
+		ProjectName:   "demo-project",
+		SyncDirectory: true,
+	}
+	require.NoError(t, db.Create(sync).Error)
+
+	syncFiles := []projects.SyncFile{
+		{
+			RelativePath: "docker-compose.yaml",
+			Content: []byte(`include:
+  - meta.yaml
+services:
+  app:
+    image: nginx:alpine
+    env_file:
+      - .env
+`),
+		},
+		{
+			RelativePath: "meta.yaml",
+			Content: []byte(`services:
+  helper:
+    image: busybox:latest
+`),
+		},
+		{
+			RelativePath: ".env",
+			Content:      []byte("APP_MODE=production\n"),
+		},
+	}
+
+	project, syncedFiles, created, changed, err := svc.syncProjectDirectoryInternal(ctx, sync, syncFiles, models.User{})
+	require.NoError(t, err)
+	require.NotNil(t, project)
+	require.True(t, created)
+	require.True(t, changed)
+	require.ElementsMatch(t, []string{"docker-compose.yaml", "meta.yaml", ".env"}, syncedFiles)
+
+	composePath, detectErr := projects.DetectComposeFile(project.Path)
+	require.NoError(t, detectErr)
+	assert.Equal(t, filepath.Join(project.Path, "docker-compose.yaml"), composePath)
+
+	composeBytes, err := os.ReadFile(filepath.Join(project.Path, "docker-compose.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(composeBytes), "include:")
+
+	metaBytes, err := os.ReadFile(filepath.Join(project.Path, "meta.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(metaBytes), "helper:")
+
+	envBytes, err := os.ReadFile(filepath.Join(project.Path, ".env"))
+	require.NoError(t, err)
+	assert.Equal(t, "APP_MODE=production\n", string(envBytes))
+
+	_, statErr := os.Stat(filepath.Join(project.Path, "compose.yaml"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestGitOpsSyncService_SyncProjectDirectory_UpdatesProjectAndCleansOldSyncedFiles(t *testing.T) {
+	ctx := context.Background()
+	svc, db, projectsDir := setupGitOpsSyncDirectoryTestService(t)
+
+	projectPath := filepath.Join(projectsDir, "demo-project")
+	require.NoError(t, os.MkdirAll(filepath.Join(projectPath, "nested"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "docker-compose.yaml"), []byte(`include:
+  - meta.yaml
+services:
+  app:
+    image: nginx:1.26-alpine
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "meta.yaml"), []byte(`services:
+  helper:
+    image: busybox:1.36
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "old.txt"), []byte("remove me\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "keep.txt"), []byte("keep me\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services: {}\n"), 0o644))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-directory-update"},
+		Name:      "demo-project",
+		DirName:   new("demo-project"),
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	oldSyncedFilesJSON, err := json.Marshal([]string{"docker-compose.yaml", "meta.yaml", "old.txt"})
+	require.NoError(t, err)
+
+	sync := &models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-directory-update"},
+		Name:          "demo-sync",
+		EnvironmentID: "0",
+		RepositoryID:  "repo-1",
+		ComposePath:   "apps/demo/docker-compose.yaml",
+		ProjectName:   "demo-project",
+		ProjectID:     &project.ID,
+		SyncDirectory: true,
+		SyncedFiles:   new(string(oldSyncedFilesJSON)),
+	}
+	require.NoError(t, db.Create(sync).Error)
+
+	syncFiles := []projects.SyncFile{
+		{
+			RelativePath: "docker-compose.yaml",
+			Content: []byte(`include:
+  - nested/feature.yaml
+services:
+  app:
+    image: nginx:1.27-alpine
+`),
+		},
+		{
+			RelativePath: "nested/feature.yaml",
+			Content: []byte(`services:
+  worker:
+    image: busybox:latest
+`),
+		},
+	}
+
+	updatedProject, syncedFiles, created, changed, err := svc.syncProjectDirectoryInternal(ctx, sync, syncFiles, models.User{})
+	require.NoError(t, err)
+	require.NotNil(t, updatedProject)
+	require.False(t, created)
+	require.True(t, changed)
+	require.ElementsMatch(t, []string{"docker-compose.yaml", "nested/feature.yaml"}, syncedFiles)
+
+	composePath, detectErr := projects.DetectComposeFile(updatedProject.Path)
+	require.NoError(t, detectErr)
+	assert.Equal(t, filepath.Join(updatedProject.Path, "docker-compose.yaml"), composePath)
+
+	_, statErr := os.Stat(filepath.Join(updatedProject.Path, "old.txt"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+
+	_, statErr = os.Stat(filepath.Join(updatedProject.Path, "compose.yaml"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+
+	keepBytes, err := os.ReadFile(filepath.Join(updatedProject.Path, "keep.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "keep me\n", string(keepBytes))
+
+	featureBytes, err := os.ReadFile(filepath.Join(updatedProject.Path, "nested", "feature.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(featureBytes), "worker:")
+}
+
+func TestGitOpsSyncService_CreateDirectorySyncProjectInternal_RollsBackProjectOnUpdateFailure(t *testing.T) {
+	ctx := context.Background()
+	svc, db, projectsDir := setupGitOpsSyncDirectoryTestService(t)
+
+	sync := &models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-directory-tx-rollback"},
+		Name:          "demo-sync",
+		EnvironmentID: "0",
+		RepositoryID:  "repo-1",
+		ComposePath:   "apps/demo/docker-compose.yaml",
+		ProjectName:   "demo-project",
+		SyncDirectory: true,
+	}
+	require.NoError(t, db.Create(sync).Error)
+
+	stagePath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(stagePath, "docker-compose.yaml"), []byte("services: {}\n"), 0o644))
+
+	stage := &stagedDirectorySync{
+		stagePath:       stagePath,
+		composeFileName: "docker-compose.yaml",
+		serviceCount:    1,
+	}
+
+	callbackName := "test:fail_project_gitops_update"
+	require.NoError(t, db.Callback().Update().Before("gorm:update").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Table == "projects" {
+			tx.AddError(errors.New("forced project update failure"))
+		}
+	}))
+	defer func() {
+		db.Callback().Update().Remove(callbackName)
+	}()
+
+	project, err := svc.createDirectorySyncProjectInternal(ctx, sync, stage, models.User{})
+	require.Error(t, err)
+	require.Nil(t, project)
+	assert.Contains(t, err.Error(), "failed to mark project as GitOps-managed")
+
+	var projectCount int64
+	require.NoError(t, db.Model(&models.Project{}).Count(&projectCount).Error)
+	assert.Zero(t, projectCount)
+
+	var storedSync models.GitOpsSync
+	require.NoError(t, db.First(&storedSync, "id = ?", sync.ID).Error)
+	assert.Nil(t, storedSync.ProjectID)
+
+	_, statErr := os.Stat(filepath.Join(projectsDir, "demo-project"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
 
 func TestEnvContentChangedInternal(t *testing.T) {
 	t.Run("ignores formatting-only changes", func(t *testing.T) {

--- a/backend/pkg/projects/fs_writer.go
+++ b/backend/pkg/projects/fs_writer.go
@@ -20,6 +20,12 @@ var composeFileCandidates = []string{
 	"podman-compose.yml",
 }
 
+// ComposeFileCandidates returns the supported compose filenames in Arcane's
+// detection order. A copy is returned so callers can't mutate package state.
+func ComposeFileCandidates() []string {
+	return append([]string(nil), composeFileCandidates...)
+}
+
 // detectExistingComposeFile finds an existing compose file in the directory
 func detectExistingComposeFile(dir string) string {
 	for _, filename := range composeFileCandidates {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2224

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

**[Linus Torvalds Mode]** Someone actually read their previous review comments — I'm as shocked as you are. This PR fixes two real problems: the directory sync was only pulling the compose file instead of the full directory tree, and a newly-created sync was unconditionally triggering a redeploy even before any containers existed to redeploy. Both bugs traced back to missing abstractions and a lack of change-detection logic that this PR now introduces via a staging-area pattern.

**What changed:**
- `prepareSyncSource` is extracted from `PerformSync`, and the deferred cleanup is now correctly registered *before* the error check — fixing the repo-dir leak on compose-file-not-found paths flagged in a previous review
- A new staging flow (`stageDirectorySyncInternal`) copies the live project to a temp dir, applies removals, writes the new repo files, validates the compose tree, and only then atomically promotes the stage to the live path with a backup/rollback
- `directorySyncContentsChangedInternal` compares repo content against the live project directory to gate redeployments; a new project is `Stopped` so `redeployIfRunningAfterSync` no-ops correctly
- `updateDirectorySyncProjectInternal` now removes the backup *after* a confirmed DB update — fixing the backup-deleted-before-DB-write ordering bug from a prior review thread
- `WalkDirectory` uses `fs.WalkDir` over `os.OpenRoot(syncDir).FS()` to recursively traverse the full directory tree, fixing the "not pulling full folders" root cause
- Tests added for both project-creation and project-update directory sync paths

**Remaining concern:**
- In `createDirectorySyncProjectInternal`, three sequential DB writes (`Create`, two `Update`s) operate with no wrapping transaction. A failure on the second or third write leaves an orphaned `Project` row in the database that will cause duplicate projects on the next sync run — worth fixing before this sees heavy use.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

**[Linus Torvalds Mode]** Congratulations, the author actually addressed prior review feedback — color me reluctantly impressed. The two P1s from previous rounds (leaked repo dir and backup-deleted-before-DB-write) are fixed, the `Internal` suffix convention is now followed on all new package-level helpers, and the staging logic is structurally sound. Safe to merge; the one remaining DB partial-failure scenario is a low-probability P2.

Normally I'd be sharpening my red pen right now, but the previously flagged critical issues are genuinely resolved. The only remaining finding is a low-probability DB split-brain during project creation (three sequential writes, no transaction) that degrades gracefully — the sync retries and creates a new project, leaving an orphaned row. That's P2, not a blocker. By the scoring guidance, all-P2 lands at 5/5.

Stare the hardest at `createDirectorySyncProjectInternal` (~line 1130) in `gitops_sync_service.go` — the transaction-less triple DB write is the only spot that can silently corrupt state under a partial failure.
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fgitops_sync_service.go%3A1162-1173%0A**Orphaned%20project%20row%20on%20partial%20DB%20failure**%0A%0AThree%20sequential%20DB%20writes%20stitched%20together%20with%20string%20and%20prayers%20%E2%80%94%20bold%20move%20for%20code%20that%20touches%20both%20the%20filesystem%20and%20the%20database.%20Did%20we%20lose%20a%20bet%2C%20or%20did%20someone%20just%20really%20hate%20the%20concept%20of%20atomicity%3F%0A%0AAfter%20%60s.db.Create%28project%29%60%20succeeds%20at%20line%201162%2C%20if%20%60Update%28%22project_id%22%29%60%20at%20line%201167%20or%20%60Update%28%22gitops_managed_by%22%29%60%20at%20line%201171%20fails%2C%20the%20function%20returns%20an%20error%20with%20no%20rollback%20of%20the%20already-created%20project%20record.%20The%20orphaned%20%60Project%60%20row%20stays%20in%20the%20DB%20with%20the%20filesystem%20intact%20at%20%60projectPath%60.%20On%20the%20next%20sync%20run%20%60sync.ProjectID%60%20is%20still%20%60nil%60%2C%20so%20%60createDirectorySyncProjectInternal%60%20runs%20again%20%E2%80%94%20creating%20a%20second%20project%20at%20a%20deduplicated%20path%20and%20permanently%20orphaning%20the%20first.%0A%0AWrapping%20all%20three%20writes%20in%20%60s.db.WithContext%28ctx%29.Transaction%28func%28tx%20*gorm.DB%29%20error%20%7B%20...%20%7D%29%60%20fixes%20this%3A%20a%20failure%20on%20either%20update%20rolls%20back%20the%20%60Create%60%20atomically%2C%20and%20the%20%60os.RemoveAll%60%20cleanup%20path%20at%20line%201163%20can%20be%20applied%20uniformly%20on%20any%20transaction%20error.%0A%0AThe%20orphaned%20rows%20will%20haunt%20the%20%60projects%60%20table%20until%20someone%20writes%20a%20janitor%20migration%20%E2%80%94%20and%20nobody%20wants%20to%20write%20that%20incident%20report.%0A%0A**Rule%20Used%3A**%20%23%20Go%20Development%20Patterns%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0A&repo=getarcaneapp%2Farcane"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/gitops_sync_service.go
Line: 1162-1173

Comment:
**Orphaned project row on partial DB failure**

Three sequential DB writes stitched together with string and prayers — bold move for code that touches both the filesystem and the database. Did we lose a bet, or did someone just really hate the concept of atomicity?

After `s.db.Create(project)` succeeds at line 1162, if `Update("project_id")` at line 1167 or `Update("gitops_managed_by")` at line 1171 fails, the function returns an error with no rollback of the already-created project record. The orphaned `Project` row stays in the DB with the filesystem intact at `projectPath`. On the next sync run `sync.ProjectID` is still `nil`, so `createDirectorySyncProjectInternal` runs again — creating a second project at a deduplicated path and permanently orphaning the first.

Wrapping all three writes in `s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error { ... })` fixes this: a failure on either update rolls back the `Create` atomically, and the `os.RemoveAll` cleanup path at line 1163 can be applied uniformly on any transaction error.

The orphaned rows will haunt the `projects` table until someone writes a janitor migration — and nobody wants to write that incident report.

**Rule Used:** # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: git sync is not pulling full folder..."](https://github.com/getarcaneapp/arcane/commit/eb5f6274c9475325b14bbbd6987dea6bce36d932) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27421829)</sub>

**Context used:**

- Rule used - # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))
- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->