### PR TITLE
fix: gitsync SyncDirectory toggle not being passed correctly

### DIFF
--- a/backend/internal/models/gitops_sync.go
+++ b/backend/internal/models/gitops_sync.go
@@ -17,7 +17,7 @@ type GitOpsSync struct {
 	Project           *Project       `json:"project,omitempty" gorm:"foreignKey:ProjectID"`
 	AutoSync          bool           `json:"autoSync" sortable:"true" search:"auto,automatic,sync,continuous,scheduled"`
 	SyncInterval      int            `json:"syncInterval" sortable:"true" search:"interval,frequency,schedule,cron,minutes"` // in minutes
-	SyncDirectory     bool           `json:"syncDirectory" gorm:"column:sync_directory;default:true"`                        // Sync entire directory containing compose file
+	SyncDirectory     bool           `json:"syncDirectory" gorm:"column:sync_directory"`                                     // Sync entire directory containing compose file
 	SyncedFiles       *string        `json:"syncedFiles,omitempty" gorm:"column:synced_files"`                               // JSON array of synced file paths
 	MaxSyncFiles      int            `json:"maxSyncFiles" gorm:"column:max_sync_files;default:500"`                          // 0 = inherit environment limit; unlimited only if the effective environment limit is also 0
 	MaxSyncTotalSize  int64          `json:"maxSyncTotalSize" gorm:"column:max_sync_total_size;default:52428800"`            // bytes; 0 = inherit environment limit; unlimited only if the effective environment limit is also 0

--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -295,7 +295,7 @@ func (s *GitOpsSyncService) CreateSync(ctx context.Context, environmentID string
 		ProjectID:         nil, // Will be set during first sync
 		AutoSync:          false,
 		SyncInterval:      60,
-		SyncDirectory:     true, // Default to directory sync
+		SyncDirectory:     false, // Default to single-file sync
 		MaxSyncFiles:      defaultMaxFiles,
 		MaxSyncTotalSize:  defaultMaxTotalSize,
 		MaxSyncBinarySize: defaultMaxBinarySize,

--- a/frontend/src/lib/components/dialogs/gitops-sync-dialog.svelte
+++ b/frontend/src/lib/components/dialogs/gitops-sync-dialog.svelte
@@ -34,7 +34,7 @@
 		repositoryId: z.string().min(1, m.common_required()),
 		branch: z.string().min(1, m.common_required()),
 		composePath: z.string().min(1, m.common_required()),
-		syncDirectory: z.boolean().default(true),
+		syncDirectory: z.boolean().default(false),
 		autoSync: z.boolean().default(true),
 		syncInterval: z.number().min(1).default(5)
 	});
@@ -44,7 +44,7 @@
 		repositoryId: open && syncToEdit ? syncToEdit.repositoryId : '',
 		branch: open && syncToEdit ? syncToEdit.branch : 'main',
 		composePath: open && syncToEdit ? syncToEdit.composePath : 'docker-compose.yml',
-		syncDirectory: open && syncToEdit ? (syncToEdit.syncDirectory ?? true) : true,
+		syncDirectory: open && syncToEdit ? (syncToEdit.syncDirectory ?? false) : false,
 		autoSync: open && syncToEdit ? (syncToEdit.autoSync ?? true) : true,
 		syncInterval: open && syncToEdit ? (syncToEdit.syncInterval ?? 5) : 5
 	});


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2261

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

**[Linus Torvalds Mode]** Oh look, someone finally noticed that slapping `default:true` on a GORM struct tag and then wondering why `false` never makes it to the database is, in fact, a beginner mistake documented clearly in the GORM docs. This PR fixes the root GORM zero-value problem by removing the `default:true` tag from the `SyncDirectory` field in the model, aligns the Go service default to `false`, and updates the Svelte dialog schema and form initializer to match — so the frontend, service layer, and ORM are finally speaking the same language.

- **`backend/internal/models/gitops_sync.go`**: Drops `default:true` from the GORM column tag on `SyncDirectory`. GORM's zero-value elision was silently discarding the user's `false` choice on every INSERT, making the toggle useless.
- **`backend/internal/services/gitops_sync_service.go`**: Changes the explicit struct default from `true` to `false` so new syncs are created as single-file mode, consistent with the now-correct GORM behaviour.
- **`frontend/src/lib/components/dialogs/gitops-sync-dialog.svelte`**: Updates both the Zod schema default and the `formData` `$derived` initializer (including the `?? false` fallback) to `false`, keeping the UI in sync with the backend.

Three files, one real fix — surprising nobody needed a flowchart to figure out what the GORM docs say explicitly about zero-value elision.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

**[Linus Torvalds Mode]** Three files touched, one real idea executed, and the database column default still disagrees with the application — this is the kind of fix that solves the symptom in the app layer while leaving a landmine in the schema for fresh installs and direct-SQL paths. The application-level fix is correct and safe to merge, but the unresolved schema-default gap identified in prior review threads keeps this below a clean 5.

Who needs a complete fix when you can fix two out of three layers and call it done? The GORM tag removal is the right call — it stops zero-value elision and makes `false` persist correctly on INSERT. The service and frontend defaults are now consistent. However, a prior review thread already identified that the database column default remains `DEFAULT true` at the SQL level with no accompanying migration to correct it, and that migration is still absent from this PR. That leaves the schema and application intent out of sync for new installations and any direct-SQL access paths. The code logic itself is sound, so this is a 4 and not a 3 — but nobody should be celebrating yet.

The three changed files are fine in isolation — the schema migration gap (no `046_change_sync_directory_default` migration present) is what deserves a hard stare before hitting merge.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: gitsync SyncDirectory toggle not be..."](https://github.com/getarcaneapp/arcane/commit/35e6fe1c6e6fab2d14c694e2653538346411d818) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27618342)</sub>

<!-- /greptile_comment -->