### PR TITLE
fix(projects): preserve include project_directory in service labels (#2264)

### DIFF
--- a/backend/pkg/projects/includes.go
+++ b/backend/pkg/projects/includes.go
@@ -13,7 +13,7 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
-// buildServiceOriginMap walks `include:` directives in composeFilePath and
+// buildServiceOriginMapInternal walks `include:` directives in composeFilePath and
 // returns a map of service name -> origin (working dir + compose file) for
 // every service contributed by an include. Services defined directly in the
 // top-level compose file are NOT in the map; callers should fall back to
@@ -26,7 +26,7 @@ import (
 // caused #2264, where included services' bind mounts were re-rooted at the
 // top-level project's directory and Postgres ran initdb on what it thought
 // were empty data directories.
-func buildServiceOriginMap(ctx context.Context, composeFilePath string, envMap EnvMap) map[string]serviceOrigin {
+func buildServiceOriginMapInternal(ctx context.Context, composeFilePath string, envMap EnvMap) map[string]serviceOrigin {
 	out := map[string]serviceOrigin{}
 	visited := map[string]bool{}
 	collectServiceOriginsInternal(ctx, composeFilePath, envMap, out, visited)
@@ -50,7 +50,7 @@ func collectServiceOriginsInternal(ctx context.Context, composeFilePath string, 
 	}
 	var data map[string]any
 	if err := yaml.Unmarshal(content, &data); err != nil {
-		slog.DebugContext(ctx, "buildServiceOriginMap: failed to parse compose file", "path", abs, "error", err)
+		slog.DebugContext(ctx, "buildServiceOriginMapInternal: failed to parse compose file", "path", abs, "error", err)
 		return
 	}
 

--- a/backend/pkg/projects/includes_test.go
+++ b/backend/pkg/projects/includes_test.go
@@ -52,7 +52,7 @@ services:
       - ./config:/config
 `)
 
-	originMap := buildServiceOriginMap(context.Background(), topCompose, EnvMap{})
+	originMap := buildServiceOriginMapInternal(context.Background(), topCompose, EnvMap{})
 
 	origin, ok := originMap["seerr"]
 	if !ok {
@@ -93,7 +93,7 @@ services:
     image: alpine
 `)
 
-	originMap := buildServiceOriginMap(context.Background(), topCompose, EnvMap{})
+	originMap := buildServiceOriginMapInternal(context.Background(), topCompose, EnvMap{})
 
 	origin, ok := originMap["shared_svc"]
 	if !ok {
@@ -136,7 +136,7 @@ services:
     image: alpine
 `)
 
-	originMap := buildServiceOriginMap(context.Background(), a, EnvMap{})
+	originMap := buildServiceOriginMapInternal(context.Background(), a, EnvMap{})
 
 	if origin := originMap["b_svc"]; origin.WorkingDir != bDir {
 		t.Errorf("b_svc WorkingDir = %q, want %q", origin.WorkingDir, bDir)

--- a/backend/pkg/projects/load.go
+++ b/backend/pkg/projects/load.go
@@ -146,7 +146,7 @@ func loadComposeProjectInternal(
 	// Build a per-service origin map by walking `include:` directives, so
 	// services pulled in via includes are labeled with the include's own
 	// working_dir/compose_file rather than the top-level compose file's.
-	originMap := buildServiceOriginMap(ctx, composeFile, fullEnvMap)
+	originMap := buildServiceOriginMapInternal(ctx, composeFile, fullEnvMap)
 
 	injectServiceConfiguration(project, injectionVars, workdir, composeFile, originMap)
 


### PR DESCRIPTION
## Summary
- Fixes #2264: auto-update no longer mis-resolves bind-mount paths for services pulled in via `include:` with a `project_directory`.
- Walks `include:` directives recursively to map each service to its true `working_dir` + compose file, then uses those when stamping compose labels.

## Root cause
`injectServiceConfiguration` in `backend/pkg/projects/load.go` stamped **every** service's `com.docker.compose.project.working_dir` and `.config_files` labels with the **top-level** compose file's directory — even for services that came from an `include:` with its own `project_directory`.

On reconcile/recreate, compose used those wrong labels as the base for relative bind-mount paths:

- Expected: `/home/abstract/docker/media/seerr/config`
- Actual: `/media/seerr/config` (empty)

Postgres entrypoints saw the "empty" data directory and ran `initdb`, destroying databases. ~80 containers were affected on v1.17.1.

The same incorrect labels are also why per-container redeploy stopped picking up image changes — compose was identifying included services against the wrong project context.

## Fix
New helper `buildServiceOriginMap` in `backend/pkg/projects/includes.go` walks `include:` directives recursively, capturing each include's effective working directory per the Docker Compose spec:

- `project_directory` if explicitly set (absolute or resolved against the parent compose dir)
- otherwise, the directory of the first listed include path

It enumerates each include's `services:` keys, recurses into nested includes, and guards against cycles. The resulting map is consulted in `injectServiceConfiguration` so included services get labeled with **their own** working dir and compose file. Services defined directly in the top-level compose file fall through to the existing default.

## Test plan

- [x] `go test ./pkg/projects/... -run BuildServiceOriginMap -v` — 3 new tests pass:
  - `TestBuildServiceOriginMap_PreservesIncludeProjectDirectory` (regression for #2264)
  - `TestBuildServiceOriginMap_DefaultsToIncludeFileDirectory` (spec default)
  - `TestBuildServiceOriginMap_NestedIncludes` (recursion + cycle guard)
- [ ] Manual: on a stack using `include: { path, project_directory }`, trigger an auto-update and verify the container's `com.docker.compose.project.working_dir` label matches the include's `project_directory`:

      docker inspect <container> --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}'

- [ ] Manual: per-container redeploy on an included service picks up an image change.

## Notes
- Pre-existing path-separator failures in `fs_util_test.go` / `path_mapper_test.go` on Windows are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a serious regression (#2264) where `include:` directives with an explicit `project_directory` had their working directory silently discarded by `injectServiceConfiguration`, causing Docker Compose to re-root relative bind-mount paths at the top-level compose directory — and triggering `initdb` on live Postgres data volumes. The fix introduces `buildServiceOriginMap`, which walks `include:` entries recursively to build a per-service origin map, ensuring each service is stamped with accurate `com.docker.compose.project.working_dir` and `com.docker.compose.project.config_files` labels.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the fix is correct, well-tested, and the only finding is a minor naming convention violation.

All findings are P2 (style/convention). The core logic correctly implements the Docker Compose spec for include project_directory resolution, includes a cycle guard, and is covered by three targeted regression tests.

No files require special attention beyond the optional rename of `buildServiceOriginMap` to `buildServiceOriginMapInternal`.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fpkg%2Fprojects%2Fincludes.go%3A29%0A**Missing%20%22Internal%22%20suffix%20on%20unexported%20function**%0A%0A%60buildServiceOriginMap%60%20is%20unexported%20but%20doesn't%20follow%20the%20project's%20%60*Internal%60%20naming%20convention%20used%20by%20every%20other%20unexported%20helper%20in%20this%20file%20%28%60collectServiceOriginsInternal%60%2C%20%60expandEnvVarsInternal%60%2C%20%60parseIncludeItemInternal%60%29.%20Rename%20to%20%60buildServiceOriginMapInternal%60%20and%20update%20the%20call%20site%20in%20%60load.go%3A149%60%20and%20the%20test%20references%20in%20%60includes_test.go%60.%0A%0A%60%60%60suggestion%0Afunc%20buildServiceOriginMapInternal%28ctx%20context.Context%2C%20composeFilePath%20string%2C%20envMap%20EnvMap%29%20map%5Bstring%5DserviceOrigin%20%7B%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A&repo=getarcaneapp%2Farcane"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/projects/includes.go
Line: 29

Comment:
**Missing "Internal" suffix on unexported function**

`buildServiceOriginMap` is unexported but doesn't follow the project's `*Internal` naming convention used by every other unexported helper in this file (`collectServiceOriginsInternal`, `expandEnvVarsInternal`, `parseIncludeItemInternal`). Rename to `buildServiceOriginMapInternal` and update the call site in `load.go:149` and the test references in `includes_test.go`.

```suggestion
func buildServiceOriginMapInternal(ctx context.Context, composeFilePath string, envMap EnvMap) map[string]serviceOrigin {
```

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(projects): preserve include project\_..."](https://github.com/getarcaneapp/arcane/commit/ee03e7f86b9cf3cb123a1f894599223193f49939) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27656818)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->