### PR TITLE
fix: include files incorrectly identified as its own compose file and labeled as such

### DIFF
--- a/backend/pkg/projects/includes.go
+++ b/backend/pkg/projects/includes.go
@@ -119,6 +119,10 @@ func parseIncludeItemInternal(item any, baseDir string, envMap EnvMap) (IncludeF
 			relativePath = rel
 		}
 	}
+	relativePath = filepath.ToSlash(filepath.Clean(relativePath))
+	if relativePath == "." {
+		relativePath = filepath.Base(fullPath)
+	}
 
 	return IncludeFile{
 		Path:         fullPath,

--- a/backend/pkg/projects/includes_test.go
+++ b/backend/pkg/projects/includes_test.go
@@ -9,6 +9,36 @@ import (
 	pkgutils "github.com/getarcaneapp/arcane/backend/pkg/utils"
 )
 
+func TestParseIncludes_NormalizesRelativePaths(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	composePath := filepath.Join(projectDir, "compose.yaml")
+	includePath := filepath.Join(projectDir, "includes", "config.yaml")
+
+	requireNoError := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	requireNoError(os.MkdirAll(filepath.Dir(includePath), 0o755))
+	requireNoError(os.WriteFile(includePath, []byte("services: {}\n"), 0o600))
+	requireNoError(os.WriteFile(composePath, []byte("include:\n  - ./includes/config.yaml\n"), 0o600))
+
+	includes, err := ParseIncludes(composePath, nil)
+	requireNoError(err)
+
+	if len(includes) != 1 {
+		t.Fatalf("expected 1 include, got %d", len(includes))
+	}
+
+	if includes[0].RelativePath != "includes/config.yaml" {
+		t.Fatalf("unexpected relative path: got %q, want %q", includes[0].RelativePath, "includes/config.yaml")
+	}
+}
+
 func TestWriteIncludeFilePermissions(t *testing.T) {
 	// Save original perms
 	origFilePerm := pkgutils.FilePerm

--- a/backend/pkg/projects/load.go
+++ b/backend/pkg/projects/load.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/compose-spec/compose-go/v2/loader"
 	composetypes "github.com/compose-spec/compose-go/v2/types"
@@ -117,6 +118,10 @@ func loadComposeProjectInternal(
 		return nil, fmt.Errorf("load compose project: %w", err)
 	}
 
+	for _, configFile := range cfg.ConfigFiles {
+		project.ComposeFiles = append(project.ComposeFiles, configFile.Filename)
+	}
+
 	project = project.WithoutUnnecessaryResources()
 
 	// Resolve relative paths for bind mounts, secrets, and configs
@@ -129,26 +134,24 @@ func loadComposeProjectInternal(
 		}
 	}
 
-	injectServiceConfiguration(project, injectionVars, workdir, composeFile)
-
-	project.ComposeFiles = []string{composeFile}
+	injectServiceConfiguration(project, injectionVars)
 	return project, nil
 }
 
-func applyCustomLabelsInternal(projectName string, serviceName string, workingDirectory string, composeFile string) composetypes.Labels {
+func applyCustomLabelsInternal(projectName string, serviceName string, workingDirectory string, composeFiles []string) composetypes.Labels {
 	return composetypes.Labels{
 		api.ProjectLabel:     projectName,
 		api.ServiceLabel:     serviceName,
 		api.VersionLabel:     api.ComposeVersion,
 		api.OneoffLabel:      "False",
 		api.WorkingDirLabel:  workingDirectory,
-		api.ConfigFilesLabel: composeFile,
+		api.ConfigFilesLabel: strings.Join(composeFiles, ","),
 	}
 }
 
-func injectServiceConfiguration(project *composetypes.Project, injectionVars EnvMap, workdir, composeFile string) {
+func injectServiceConfiguration(project *composetypes.Project, injectionVars EnvMap) {
 	for i, s := range project.Services {
-		s.CustomLabels = applyCustomLabelsInternal(project.Name, s.Name, workdir, composeFile)
+		s.CustomLabels = applyCustomLabelsInternal(project.Name, s.Name, project.WorkingDir, project.ComposeFiles)
 
 		// Initialize environment if nil
 		if s.Environment == nil {

--- a/backend/pkg/projects/load_test.go
+++ b/backend/pkg/projects/load_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/docker/compose/v5/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -91,4 +93,37 @@ func TestLoadComposeProjectFromDir_EmptyProjectsDirectoryDoesNotCreateParentGlob
 
 	_, statErr := os.Stat(filepath.Join(projectsRoot, "nested", GlobalEnvFileName))
 	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestLoadComposeProject_UsesProjectLevelComposeLabelsForIncludedServices(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	includePath := filepath.Join(projectDir, "included.compose.yaml")
+	composePath := filepath.Join(projectDir, "compose.yaml")
+
+	require.NoError(t, os.WriteFile(includePath, []byte(`services:
+  included:
+    image: nginx:alpine
+`), 0o600))
+	require.NoError(t, os.WriteFile(composePath, []byte(`include:
+  - included.compose.yaml
+services:
+  root:
+    image: busybox:latest
+`), 0o600))
+
+	project, err := LoadComposeProject(context.Background(), composePath, "demo", projectDir, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, project)
+
+	rootService := project.Services["root"]
+	includedService := project.Services["included"]
+	expectedConfigFiles := strings.Join(project.ComposeFiles, ",")
+
+	require.Equal(t, []string{composePath}, project.ComposeFiles)
+	require.Equal(t, project.WorkingDir, rootService.CustomLabels[api.WorkingDirLabel])
+	require.Equal(t, expectedConfigFiles, rootService.CustomLabels[api.ConfigFilesLabel])
+	require.Equal(t, project.WorkingDir, includedService.CustomLabels[api.WorkingDirLabel])
+	require.Equal(t, expectedConfigFiles, includedService.CustomLabels[api.ConfigFilesLabel])
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related bugs: (1) `includes.go` now normalises `RelativePath` via `filepath.ToSlash(filepath.Clean(...))`, removing redundant `./` prefixes that caused include files to be mis-identified; (2) `load.go` stops overwriting `project.ComposeFiles` with a hardcoded single-file slice and instead derives compose-file labels from the project struct, so services from included compose files receive the same `ConfigFilesLabel` as root services.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all findings are minor style/robustness suggestions with no blocking correctness issues.

Both inline comments are P2: one flags a fragility in the append pattern for project.ComposeFiles (currently safe but could break if compose-go ever pre-populates the field), and one flags a pre-existing naming-convention violation on injectServiceConfiguration. Neither affects current correctness. The core logic of the fix is sound, and new tests cover both changed code paths.

backend/pkg/projects/load.go — the append-based project.ComposeFiles construction and the missing Internal suffix on injectServiceConfiguration.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Fpkg%2Fprojects%2Fload.go%3A121-123%0A**%60append%60%20onto%20potentially%20pre-populated%20%60project.ComposeFiles%60**%0A%0A%60loader.LoadWithContext%60%20may%20already%20populate%20%60project.ComposeFiles%60%20with%20all%20processed%20config%20files%20%28main%20%2B%20included%29.%20Using%20%60append%60%20rather%20than%20assignment%20means%20that%20if%20compose-go's%20loader%20ever%20fills%20this%20field%2C%20the%20loop%20adds%20%60composeFile%60%20again%2C%20producing%20duplicates.%20The%20original%20code%20used%20a%20direct%20assignment%20%28%60project.ComposeFiles%20%3D%20%5B%5Dstring%7BcomposeFile%7D%60%29%2C%20which%20was%20unconditionally%20safe.%20Consider%20resetting%20the%20slice%20first%20or%20using%20direct%20assignment%20from%20%60cfg.ConfigFiles%60%20to%20avoid%20this%20fragility%3A%0A%0A%60%60%60suggestion%0A%09project.ComposeFiles%20%3D%20make%28%5B%5Dstring%2C%200%2C%20len%28cfg.ConfigFiles%29%29%0A%09for%20_%2C%20configFile%20%3A%3D%20range%20cfg.ConfigFiles%20%7B%0A%09%09project.ComposeFiles%20%3D%20append%28project.ComposeFiles%2C%20configFile.Filename%29%0A%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Fpkg%2Fprojects%2Fload.go%3A152%0A**Missing%20%60Internal%60%20suffix%20on%20unexported%20function**%0A%0AThe%20project%20convention%20requires%20all%20unexported%20functions%20to%20end%20with%20%60Internal%60.%20%60injectServiceConfiguration%60%20is%20unexported%20but%20lacks%20the%20suffix%3B%20it's%20being%20modified%20in%20this%20PR%20and%20is%20a%20good%20opportunity%20to%20align%20it.%0A%0A%60%60%60suggestion%0Afunc%20injectServiceConfigurationInternal%28project%20*composetypes.Project%2C%20injectionVars%20EnvMap%29%20%7B%0A%60%60%60%0A%28The%20call-site%20on%20line%20137%20would%20need%20to%20be%20updated%20to%20%60injectServiceConfigurationInternal%60%20as%20well.%29%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A&repo=getarcaneapp%2Farcane"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/projects/load.go
Line: 121-123

Comment:
**`append` onto potentially pre-populated `project.ComposeFiles`**

`loader.LoadWithContext` may already populate `project.ComposeFiles` with all processed config files (main + included). Using `append` rather than assignment means that if compose-go's loader ever fills this field, the loop adds `composeFile` again, producing duplicates. The original code used a direct assignment (`project.ComposeFiles = []string{composeFile}`), which was unconditionally safe. Consider resetting the slice first or using direct assignment from `cfg.ConfigFiles` to avoid this fragility:

```suggestion
	project.ComposeFiles = make([]string, 0, len(cfg.ConfigFiles))
	for _, configFile := range cfg.ConfigFiles {
		project.ComposeFiles = append(project.ComposeFiles, configFile.Filename)
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/projects/load.go
Line: 152

Comment:
**Missing `Internal` suffix on unexported function**

The project convention requires all unexported functions to end with `Internal`. `injectServiceConfiguration` is unexported but lacks the suffix; it's being modified in this PR and is a good opportunity to align it.

```suggestion
func injectServiceConfigurationInternal(project *composetypes.Project, injectionVars EnvMap) {
```
(The call-site on line 137 would need to be updated to `injectServiceConfigurationInternal` as well.)

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: include files incorrectly identifie..."](https://github.com/getarcaneapp/arcane/commit/c1151d3b60336cc35e627884b064015604df673c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27663426)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->