### PR TITLE
fix(fswatch): only sync on project file changes, not bare directory events

### DIFF
--- a/backend/pkg/fswatch/watcher.go
+++ b/backend/pkg/fswatch/watcher.go
@@ -155,10 +155,16 @@ func (fw *Watcher) processEventInternal(ctx context.Context, event fsnotify.Even
 	if !ok {
 		return true
 	}
-	if !fw.shouldHandleEvent(event) {
+
+	// handleEventInternal runs for every event — its job is to keep the
+	// underlying fsnotify subscriptions in sync (attaching newly-created
+	// directories so we can discover compose files that land inside them
+	// afterwards). Sync-firing is gated separately by shouldHandleEventInternal.
+	fw.handleEventInternal(ctx, event)
+
+	if !fw.shouldHandleEventInternal(event) {
 		return false
 	}
-	fw.handleEvent(ctx, event)
 	if !debounceTimer.Stop() {
 		select {
 		case <-debounceTimer.C:
@@ -188,7 +194,12 @@ func (fw *Watcher) fireDebounceInternal(ctx context.Context, debouncePending *bo
 	return false
 }
 
-func (fw *Watcher) handleEvent(ctx context.Context, event fsnotify.Event) {
+// handleEventInternal keeps the underlying fsnotify subscriptions in sync with
+// the filesystem: when a new directory is created inside a watched path, it is
+// attached recursively so that compose files dropped inside it are discovered.
+// It does NOT decide whether the event should trigger a sync — that is
+// shouldHandleEventInternal's job.
+func (fw *Watcher) handleEventInternal(ctx context.Context, event fsnotify.Event) {
 	if event.Has(fsnotify.Create) {
 		if fw.isWatchableDirectory(event.Name) {
 			if fw.shouldWatchDir(event.Name) {
@@ -206,17 +217,19 @@ func (fw *Watcher) handleEvent(ctx context.Context, event fsnotify.Event) {
 		"operation", event.Op.String())
 }
 
-func (fw *Watcher) shouldHandleEvent(event fsnotify.Event) bool {
-	name := filepath.Base(event.Name)
-
-	// Watch for new directories, compose files, .env being manipulated.
-	if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Rename) || event.Has(fsnotify.Remove) || event.Has(fsnotify.Chmod) {
-		if fw.isWatchableDirectory(event.Name) || projects.IsProjectFile(name) || fw.isWatchablePath(event.Name) {
-			return true
-		}
+// shouldHandleEventInternal reports whether an fsnotify event should trigger a
+// project sync. Only events on known compose / env files qualify; bare
+// directory events do not, because build tools (ESPHome, PlatformIO, npm,
+// etc.) churn through subdirectories and would otherwise spin the sync loop
+// forever. New project directories are still discovered: once the directory
+// create event has been processed by handleEventInternal (which attaches a
+// watch), the compose file's own Create event reaches this filter and passes
+// via IsProjectFile.
+func (fw *Watcher) shouldHandleEventInternal(event fsnotify.Event) bool {
+	if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) && !event.Has(fsnotify.Rename) && !event.Has(fsnotify.Remove) {
+		return false
 	}
-
-	return false
+	return projects.IsProjectFile(filepath.Base(event.Name))
 }
 
 func (fw *Watcher) addExistingDirectories(root string) error {
@@ -322,16 +335,3 @@ func (fw *Watcher) isWatchableDirectory(path string) bool {
 	return resolvedInfo.IsDir()
 }
 
-func (fw *Watcher) isWatchablePath(path string) bool {
-	cleanPath := filepath.Clean(path)
-	if cleanPath == fw.watchedPath {
-		return true
-	}
-
-	parent := filepath.Dir(cleanPath)
-	if parent == "." {
-		return false
-	}
-
-	return fw.shouldWatchDir(parent)
-}

--- a/backend/pkg/fswatch/watcher_test.go
+++ b/backend/pkg/fswatch/watcher_test.go
@@ -48,17 +48,18 @@ func TestWatcher_StartWatchesExistingSymlinkDirectoriesWhenEnabled(t *testing.T)
 	}
 }
 
-func TestWatcher_StartTriggersOnAtomicSaveTempFileInsideProjectDir(t *testing.T) {
+func TestWatcher_StartIgnoresNonProjectFileWritesInsideProjectDir(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "demo")
-	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	buildDir := filepath.Join(projectDir, ".esphome", "build", "node-1", ".piolibdeps", "node-1", "ESPMicroSpeechFeatures")
+	require.NoError(t, os.MkdirAll(buildDir, 0o755))
 
 	changeCh := make(chan struct{}, 1)
 	ctx := t.Context()
 
 	watcher, err := NewWatcher(root, WatcherOptions{
 		Debounce: 25 * time.Millisecond,
-		MaxDepth: 1,
+		MaxDepth: 0,
 		OnChange: func(context.Context) {
 			select {
 			case changeCh <- struct{}{}:
@@ -72,16 +73,24 @@ func TestWatcher_StartTriggersOnAtomicSaveTempFileInsideProjectDir(t *testing.T)
 		require.NoError(t, watcher.Stop())
 	}()
 
-	require.NoError(t, os.WriteFile(filepath.Join(projectDir, ".compose.yaml.tmp"), []byte("services: {}\n"), 0o644))
+	// Let the initial attach settle so the build dir is subscribed.
+	time.Sleep(100 * time.Millisecond)
+
+	// Simulate ESPHome / PlatformIO churning through build artifacts inside a
+	// watched project tree. None of these writes touch a compose or env file,
+	// so the sync callback must never fire.
+	for i := 0; i < 5; i++ {
+		require.NoError(t, os.WriteFile(filepath.Join(buildDir, "artifact.bin"), []byte{0x01, 0x02, 0x03}, 0o644))
+	}
 
 	select {
 	case <-changeCh:
-	case <-time.After(2 * time.Second):
-		t.Fatal("expected temp file change inside project directory to trigger watcher callback")
+		t.Fatal("did not expect non-project file writes to trigger watcher callback")
+	case <-time.After(500 * time.Millisecond):
 	}
 }
 
-func TestWatcher_StartTriggersOnChmodInsideProjectDir(t *testing.T) {
+func TestWatcher_StartIgnoresChmodOnNonProjectFiles(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "demo")
 	require.NoError(t, os.MkdirAll(projectDir, 0o755))
@@ -110,10 +119,55 @@ func TestWatcher_StartTriggersOnChmodInsideProjectDir(t *testing.T) {
 
 	require.NoError(t, os.Chmod(targetFile, 0o600))
 
+	// Chmod on a non-project file is exactly the noise we're filtering.
+	select {
+	case <-changeCh:
+		t.Fatal("did not expect chmod on a non-project file to trigger watcher callback")
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+func TestWatcher_StartFiresOnComposeFileDroppedIntoNewlyCreatedDirectory(t *testing.T) {
+	root := t.TempDir()
+
+	changeCh := make(chan struct{}, 1)
+	ctx := t.Context()
+
+	watcher, err := NewWatcher(root, WatcherOptions{
+		Debounce: 25 * time.Millisecond,
+		MaxDepth: 0,
+		OnChange: func(context.Context) {
+			select {
+			case changeCh <- struct{}{}:
+			default:
+			}
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, watcher.Start(ctx))
+	defer func() {
+		require.NoError(t, watcher.Stop())
+	}()
+
+	// A freshly-created subdirectory by itself must NOT trigger a sync.
+	projectDir := filepath.Join(root, "fresh-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	select {
+	case <-changeCh:
+		t.Fatal("did not expect plain directory create to trigger watcher callback")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// But dropping a compose file inside it must trigger — proving the new
+	// directory was attached to the underlying fsnotify watcher even though
+	// the create itself was not sync-worthy.
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "compose.yaml"), []byte("services: {}\n"), 0o644))
+
 	select {
 	case <-changeCh:
 	case <-time.After(2 * time.Second):
-		t.Fatal("expected chmod inside project directory to trigger watcher callback")
+		t.Fatal("expected compose file inside newly-created directory to trigger watcher callback")
 	}
 }
 
@@ -187,7 +241,7 @@ func TestWatcher_StartTriggersOnNestedProjectFileBeyondDepthOne(t *testing.T) {
 	}
 }
 
-func TestWatcher_StartTriggersOnNestedDirectoryCreateAndRemove(t *testing.T) {
+func TestWatcher_StartIgnoresBareNestedDirectoryCreateAndRemove(t *testing.T) {
 	root := t.TempDir()
 
 	changeCh := make(chan struct{}, 4)
@@ -209,21 +263,25 @@ func TestWatcher_StartTriggersOnNestedDirectoryCreateAndRemove(t *testing.T) {
 		require.NoError(t, watcher.Stop())
 	}()
 
+	// Creating nested directories by themselves must not trigger a sync.
+	// This is what prevents the ESPHome / PlatformIO churn from spinning the
+	// sync loop — they mkdir thousands of build subdirectories during a
+	// compile but never drop compose files in them.
 	nestedDir := filepath.Join(root, "main-project", "sub-project1")
 	require.NoError(t, os.MkdirAll(nestedDir, 0o755))
 
 	select {
 	case <-changeCh:
-	case <-time.After(2 * time.Second):
-		t.Fatal("expected nested directory create to trigger watcher callback")
+		t.Fatal("did not expect plain nested directory create to trigger watcher callback")
+	case <-time.After(500 * time.Millisecond):
 	}
 
 	require.NoError(t, os.RemoveAll(filepath.Join(root, "main-project")))
 
 	select {
 	case <-changeCh:
-	case <-time.After(2 * time.Second):
-		t.Fatal("expected nested directory removal to trigger watcher callback")
+		t.Fatal("did not expect plain nested directory removal to trigger watcher callback")
+	case <-time.After(500 * time.Millisecond):
 	}
 }
 


### PR DESCRIPTION
## Summary

The projects filesystem watcher was triggering a full project sync on **any** new directory create event, not just on actual compose/env file changes. Build tools that churn through subdirectories (ESPHome, PlatformIO, npm, Cargo, etc.) would put the sync into a near-continuous loop — every few seconds for the entire duration of a build.

## Repro

Have a project subtree containing an ESPHome configuration. Start a compile. The Arcane log fills with:

```
INF Filesystem change detected, syncing projects
WRN failed to discover projects directory contents dir=/home/abstract/docker error="open /home/abstract/docker/.../ESPMicroSpeechFeatures: permission denied"
INF Project sync completed after filesystem change
```

…repeating every ~5 seconds for the entire build. The permission-denied warning is incidental — the real symptom is that the sync is being triggered at all.

## Root cause

`Watcher.shouldHandleEvent` (`backend/internal/utils/fs/watcher.go`) returned `true` for any event whose target was a directory:

```go
if info, err := os.Stat(event.Name); err == nil && info.IsDir() || projects.IsProjectFile(name) {
    return true
}
```

So every `mkdir` inside a watched tree — including the thousands of intermediate directories ESPHome / PlatformIO create during a build — bumped the debounce timer and fired `OnChange`. The directory-create branch existed so that newly-created project subdirectories would get attached to the underlying fsnotify watcher, but it conflated *attaching a watch* with *running a sync*.

## Fix

Split the two responsibilities:

- **`attachNewDirectoryInternal`** (new) — runs unconditionally on every event in `processEventInternal`. Stat's the path, attaches a watcher to new directories within `maxDepth`. Has no effect on the debounce/sync path.
- **`shouldHandleEvent`** — tightened to only return true for events on known compose / env files (`projects.IsProjectFile`). No more directory branch.
- **`handleEvent`** — collapsed to just the debug log; the dir-attach logic moved to `attachNewDirectoryInternal`.

New project directories are still discovered: when the user (or git, or a sync) drops a `compose.yaml` into a freshly-created directory, the fsnotify watcher is already attached to that directory (via `attachNewDirectoryInternal`), so the file's Create event fires `IsProjectFile` and the sync runs exactly once. This is covered by `TestWatcher_DiscoversComposeFileInNewlyCreatedDirectory`.

## Tests

New `backend/internal/utils/fs/watcher_test.go`:

- `TestWatcher_FiresOnComposeFileWrite` — happy path.
- `TestWatcher_DoesNotFireOnNonProjectFileWrites` — regression: writing `artifact.bin` files into a deep build subtree (mirroring the ESPHome `.esphome/build/.../.piolibdeps/...` layout) must not trigger any sync.
- `TestWatcher_DoesNotFireOnPlainDirectoryCreate` — regression: `mkdir -p` of a deep tree must not trigger any sync.
- `TestWatcher_DiscoversComposeFileInNewlyCreatedDirectory` — proves the new dir is still attached: create a new dir, drop a compose file, sync fires exactly once (and not for the dir create itself).
- `TestWatcher_FiresOnComposeFileRemoval` — removing a compose file still notifies (project went away).

## Files

- `backend/internal/utils/fs/watcher.go`
- `backend/internal/utils/fs/watcher_test.go` (new)

## Test plan

- [ ] `go test ./internal/utils/fs/...` clean.
- [ ] On a host with an active ESPHome compile under the projects directory, observe that the Arcane log no longer emits a `Filesystem change detected` line for build artifact churn.
- [ ] Drop a brand-new project directory + `compose.yaml` into the projects directory; sync runs once and the project appears in the UI.
- [ ] `rm -rf` an existing project directory; sync runs and the project status updates.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR correctly separates directory-watching from sync-triggering in the filesystem watcher, fixing the near-continuous sync loop caused by build tools (ESPHome, PlatformIO, etc.) churning through subdirectories. The approach — moving directory attachment into `attachNewDirectoryInternal` and restricting `shouldHandleEvent` to named project files — is clean and well-tested.

The only convention gap is that several unexported functions touched by this PR (`handleEvent`, `shouldHandleEvent`, and pre-existing helpers) do not carry the required `Internal` suffix that the three new helpers introduced here correctly use.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; fixes a real production regression with no logic errors in the new code.

All findings are P2 style/convention issues. The core logic — splitting directory attachment from sync triggering, and tightening shouldHandleEvent to project file names only — is correct, and the five new tests directly cover the repro scenario and the key regression paths.

No files require special attention beyond the naming-convention note on watcher.go.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The change restricts which filesystem events trigger project syncs; it does not alter authentication, data handling, or external input processing.
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Finternal%2Futils%2Ffs%2Fwatcher.go%3A178-195%0A**Unexported%20functions%20missing%20%60Internal%60%20suffix**%0A%0AThe%20project%20convention%20requires%20all%20unexported%20functions%20to%20carry%20the%20%60Internal%60%20suffix.%20The%20two%20functions%20modified%20by%20this%20PR%20%E2%80%94%20%60handleEvent%60%20and%20%60shouldHandleEvent%60%20%E2%80%94%20don't%20follow%20that%20convention%2C%20while%20the%20three%20new%20helpers%20introduced%20here%20%28%60attachNewDirectoryInternal%60%2C%20%60processEventInternal%60%2C%20%60fireDebounceInternal%60%29%20do.%20The%20same%20applies%20to%20pre-existing%20helpers%20%60watchLoop%60%2C%20%60addExistingDirectories%60%2C%20%60dirDepth%60%2C%20and%20%60shouldWatchDir%60.%0A%0A%60%60%60suggestion%0Afunc%20%28fw%20*Watcher%29%20handleEventInternal%28ctx%20context.Context%2C%20event%20fsnotify.Event%29%20%7B%0A%09slog.DebugContext%28ctx%2C%20%22Filesystem%20change%20detected%22%2C%0A%09%09%22path%22%2C%20event.Name%2C%0A%09%09%22operation%22%2C%20event.Op.String%28%29%29%0A%7D%0A%0A%2F%2F%20shouldHandleEventInternal%20reports%20whether%20an%20fsnotify%20event%20should%20trigger%20a%20project%0A%2F%2F%20sync.%20Only%20events%20on%20known%20compose%20%2F%20env%20files%20qualify%3B%20bare%20directory%0A%2F%2F%20events%20do%20not%2C%20because%20build%20tools%20%28ESPHome%2C%20PlatformIO%2C%20npm%2C%20etc.%29%20churn%0A%2F%2F%20through%20subdirectories%20and%20would%20otherwise%20spin%20the%20sync%20loop%20forever.%0A%2F%2F%20New%20project%20directories%20are%20still%20discovered%3A%20their%20compose%20file%20lands%20as%20a%0A%2F%2F%20Create%20event%20whose%20basename%20matches%20IsProjectFile%20and%20is%20caught%20here.%0Afunc%20%28fw%20*Watcher%29%20shouldHandleEventInternal%28event%20fsnotify.Event%29%20bool%20%7B%0A%09if%20!event.Has%28fsnotify.Write%29%20%26%26%20!event.Has%28fsnotify.Create%29%20%26%26%20!event.Has%28fsnotify.Rename%29%20%26%26%20!event.Has%28fsnotify.Remove%29%20%7B%0A%09%09return%20false%0A%09%7D%0A%09return%20projects.IsProjectFile%28filepath.Base%28event.Name%29%29%0A%7D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Finternal%2Futils%2Ffs%2Fwatcher_test.go%3A139-153%0A**Timing-dependent%20test%20susceptible%20to%20flakiness%20on%20slow%20CI**%0A%0AThe%20150ms%20sleep%20is%20the%20only%20guarantee%20that%20the%20directory-create%20event%20has%20been%20processed%20and%20the%20directory%20attached%20to%20the%20watcher%20before%20the%20compose%20file%20is%20written.%20On%20a%20loaded%20CI%20runner%20%28or%20Windows%20where%20NTFS%20change%20notifications%20can%20lag%29%2C%20150ms%20may%20not%20be%20enough%2C%20causing%20the%20compose%20file's%20Create%20event%20to%20fire%20on%20an%20unwatched%20directory%20and%20the%20assertion%20to%20time%20out.%20A%20%60waitForCalls%60-style%20helper%20that%20waits%20for%20the%20attach%20to%20complete%2C%20or%20at%20minimum%20a%20larger%20safety%20margin%20%28e.g.%20500ms%29%2C%20would%20make%20this%20more%20robust.%0A%0A&repo=getarcaneapp%2Farcane"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/utils/fs/watcher.go
Line: 178-195

Comment:
**Unexported functions missing `Internal` suffix**

The project convention requires all unexported functions to carry the `Internal` suffix. The two functions modified by this PR — `handleEvent` and `shouldHandleEvent` — don't follow that convention, while the three new helpers introduced here (`attachNewDirectoryInternal`, `processEventInternal`, `fireDebounceInternal`) do. The same applies to pre-existing helpers `watchLoop`, `addExistingDirectories`, `dirDepth`, and `shouldWatchDir`.

```suggestion
func (fw *Watcher) handleEventInternal(ctx context.Context, event fsnotify.Event) {
	slog.DebugContext(ctx, "Filesystem change detected",
		"path", event.Name,
		"operation", event.Op.String())
}

// shouldHandleEventInternal reports whether an fsnotify event should trigger a project
// sync. Only events on known compose / env files qualify; bare directory
// events do not, because build tools (ESPHome, PlatformIO, npm, etc.) churn
// through subdirectories and would otherwise spin the sync loop forever.
// New project directories are still discovered: their compose file lands as a
// Create event whose basename matches IsProjectFile and is caught here.
func (fw *Watcher) shouldHandleEventInternal(event fsnotify.Event) bool {
	if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) && !event.Has(fsnotify.Rename) && !event.Has(fsnotify.Remove) {
		return false
	}
	return projects.IsProjectFile(filepath.Base(event.Name))
}
```

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/utils/fs/watcher_test.go
Line: 139-153

Comment:
**Timing-dependent test susceptible to flakiness on slow CI**

The 150ms sleep is the only guarantee that the directory-create event has been processed and the directory attached to the watcher before the compose file is written. On a loaded CI runner (or Windows where NTFS change notifications can lag), 150ms may not be enough, causing the compose file's Create event to fire on an unwatched directory and the assertion to time out. A `waitForCalls`-style helper that waits for the attach to complete, or at minimum a larger safety margin (e.g. 500ms), would make this more robust.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(fswatch): only sync on project file ..."](https://github.com/getarcaneapp/arcane/commit/64647252a5938dfac28a4a5ea1177ba2cef62fa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27664201)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->