### PR TITLE
fix: resolve SSH known_hosts permission denied when using PUID/PGID

### DIFF
--- a/backend/pkg/gitutil/git.go
+++ b/backend/pkg/gitutil/git.go
@@ -163,7 +163,10 @@ func (c *Client) createAcceptNewHostKeyCallback() (gossh.HostKeyCallback, error)
 	}, nil
 }
 
-// getKnownHostsPath returns the path to the known_hosts file
+// getKnownHostsPath returns the path to the known_hosts file.
+// The returned path must be on a persistent volume so that host keys survive
+// container restarts; using a temporary directory would silently degrade
+// "accept_new" mode to effectively no verification.
 func getKnownHostsPath() string {
 	// Check environment variable first
 	if path := os.Getenv("SSH_KNOWN_HOSTS"); path != "" {
@@ -180,7 +183,17 @@ func getKnownHostsPath() string {
 		}
 	}
 
-	// Fall back to a temp-based location that is always writable
+	// Fall back to the persistent data directory. /app/data is mounted as a
+	// Docker volume in the standard Arcane deployment, so host keys are
+	// preserved across container restarts.
+	dataSSHDir := filepath.Join("data", ".ssh")
+	if ensureDirWritableInternal(dataSSHDir) {
+		return filepath.Join(dataSSHDir, "known_hosts")
+	}
+
+	// Last resort: log a warning because a temp path loses keys on restart.
+	fmt.Fprintln(os.Stderr, "Warning: no persistent path available for SSH known_hosts; "+
+		"host keys will be lost on restart. Set SSH_KNOWN_HOSTS to a persistent path.")
 	return filepath.Join(os.TempDir(), ".ssh", "known_hosts")
 }
 

--- a/backend/pkg/gitutil/git_test.go
+++ b/backend/pkg/gitutil/git_test.go
@@ -46,7 +46,7 @@ func TestGetKnownHostsPath(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to temp when home is not writable", func(t *testing.T) {
+	t.Run("falls back to data dir when home is not writable", func(t *testing.T) {
 		if os.Getuid() == 0 {
 			t.Skip("running as root; /root is writable, fallback path not exercised")
 		}
@@ -54,9 +54,9 @@ func TestGetKnownHostsPath(t *testing.T) {
 		t.Setenv("HOME", "/root")
 
 		result := getKnownHostsPath()
-		expected := filepath.Join(os.TempDir(), ".ssh", "known_hosts")
-		if result != expected {
-			t.Errorf("expected %s, got %s", expected, result)
+		// Should fall back to data/.ssh/known_hosts (persistent) or temp (last resort)
+		if result == filepath.Join("/root", ".ssh", "known_hosts") {
+			t.Errorf("should not use inaccessible /root/.ssh, got %s", result)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- When running with `PUID`/`PGID` (e.g. UID 1000), `os.UserHomeDir()` returns `/root` which is not writable by the runtime user
- This caused **all git sync operations to fail** with `mkdir /root/.ssh: permission denied`
- The fix verifies the home `.ssh` directory is actually writable before using it, falling back to a temp-based path otherwise

## Changes
- `backend/pkg/gitutil/git.go`: Added `isDirWritable()` helper and updated `getKnownHostsPath()` to check writability before using the home directory path
- `backend/pkg/gitutil/git_test.go`: Updated tests to cover both writable and non-writable home directory scenarios

## Test plan
- [ ] Verify git sync works with `PUID=1000` / `PGID=1000` set
- [ ] Verify git sync works without `PUID`/`PGID` (runs as root)
- [ ] Verify `SSH_KNOWN_HOSTS` env var still takes precedence
- [ ] Verify host keys are persisted across syncs (accept_new mode)

Fixes #2238

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes SSH `known_hosts` path resolution when running with a non-root `PUID`/`PGID`: instead of blindly using `os.UserHomeDir()` (which may return `/root` even for non-root runtime users), it now probes the `.ssh` directory for writability and falls back to a temp path if it is not accessible. The logic is sound; the remaining findings are style and test-coverage quality issues.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after addressing the naming convention and the vacuous test; no correctness or security blockers.

All findings are P2 style/quality issues. The core bug fix is correct. Score is 4 rather than 5 because the naming convention violation is a project policy requirement and the test's silent vacuousness under root means CI may give false confidence in the fallback path.

backend/pkg/gitutil/git.go (naming convention), backend/pkg/gitutil/git_test.go (vacuous test branch when run as root)
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The probe-file approach for writability testing is safe (temp file is created and immediately removed). The fallback to `os.TempDir()` is acceptable for a known_hosts file in a container context.
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Fpkg%2Fgitutil%2Fgit.go%3A188-205%0A**Naming%20convention%3A%20missing%20%22Internal%22%20suffix%20on%20unexported%20function**%0A%0APer%20the%20project's%20Go%20naming%20rules%2C%20all%20unexported%20functions%20must%20carry%20the%20%60Internal%60%20suffix.%20%60isDirWritable%60%20should%20be%20renamed%20to%20%60isDirWritableInternal%60%20%28and%20its%20call-sites%20updated%20accordingly%29.%0A%0A%60%60%60suggestion%0A%2F%2F%20isDirWritableInternal%20checks%20whether%20dir%20exists%20and%20is%20writable%2C%20or%20can%20be%20created.%0Afunc%20isDirWritableInternal%28dir%20string%29%20bool%20%7B%0A%09info%2C%20err%20%3A%3D%20os.Stat%28dir%29%0A%09if%20err%20%3D%3D%20nil%20%26%26%20info.IsDir%28%29%20%7B%0A%09%09%2F%2F%20Directory%20exists%20%E2%80%94%20try%20creating%20a%20temp%20file%20to%20verify%20write%20access%0A%09%09f%2C%20err%20%3A%3D%20os.CreateTemp%28dir%2C%20%22.probe-*%22%29%0A%09%09if%20err%20!%3D%20nil%20%7B%0A%09%09%09return%20false%0A%09%09%7D%0A%09%09_%20%3D%20f.Close%28%29%0A%09%09_%20%3D%20os.Remove%28f.Name%28%29%29%0A%09%09return%20true%0A%09%7D%0A%09%2F%2F%20Directory%20doesn't%20exist%20%E2%80%94%20try%20to%20create%20it%0A%09if%20err%20%3A%3D%20os.MkdirAll%28dir%2C%200o700%29%3B%20err%20!%3D%20nil%20%7B%0A%09%09return%20false%0A%09%7D%0A%09return%20true%0A%7D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A%23%23%23%20Issue%202%20of%203%0Abackend%2Fpkg%2Fgitutil%2Fgit.go%3A188-205%0A**%60isDirWritable%60%20creates%20directories%20as%20a%20side%20effect**%0A%0AWhen%20the%20directory%20does%20not%20yet%20exist%2C%20this%20function%20calls%20%60os.MkdirAll%60%20and%20returns%20%60true%60%20%E2%80%94%20it%20is%20not%20a%20pure%20read%20check%20but%20also%20a%20mutating%20one.%20If%20a%20caller%20only%20wants%20to%20test%20writability%20without%20creating%20the%20directory%2C%20this%20will%20silently%20create%20it.%20The%20%60createAcceptNewHostKeyCallback%60%20path%20later%20calls%20%60os.MkdirAll%60%20again%20%28harmless%20but%20redundant%29.%20Consider%20splitting%20the%20concern%3A%20a%20dedicated%20%22ensure%20dir%22%20helper%20is%20clearer%20than%20a%20boolean%20probe%20that%20creates%20state%20as%20a%20side%20effect.%0A%0A%23%23%23%20Issue%203%20of%203%0Abackend%2Fpkg%2Fgitutil%2Fgit_test.go%3A50-63%0A**Test%20is%20silently%20vacuous%20when%20running%20as%20root**%0A%0AWhen%20the%20test%20suite%20runs%20as%20root%20%28common%20in%20CI%20containers%29%2C%20%60isDirWritable%28%22%2Froot%2F.ssh%22%29%60%20returns%20%60true%60%2C%20so%20the%20inner%20%60if%20!isDirWritable%28...%29%60%20block%20is%20never%20entered%20and%20the%20test%20makes%20zero%20assertions%20%E2%80%94%20it%20passes%20trivially%20without%20verifying%20any%20fallback%20behavior.%20The%20test%20should%20either%20always%20assert%20something%2C%20or%20be%20skipped%20when%20running%20as%20root%3A%0A%0A%60%60%60go%0At.Run%28%22falls%20back%20to%20temp%20when%20home%20is%20not%20writable%22%2C%20func%28t%20*testing.T%29%20%7B%0A%20%20%20%20if%20os.Getuid%28%29%20%3D%3D%200%20%7B%0A%20%20%20%20%20%20%20%20t.Skip%28%22running%20as%20root%3B%20%2Froot%20is%20writable%2C%20fallback%20path%20not%20exercised%22%29%0A%20%20%20%20%7D%0A%20%20%20%20t.Setenv%28%22SSH_KNOWN_HOSTS%22%2C%20%22%22%29%0A%20%20%20%20t.Setenv%28%22HOME%22%2C%20%22%2Froot%22%29%0A%0A%20%20%20%20result%20%3A%3D%20getKnownHostsPath%28%29%0A%20%20%20%20expected%20%3A%3D%20filepath.Join%28os.TempDir%28%29%2C%20%22.ssh%22%2C%20%22known_hosts%22%29%0A%20%20%20%20if%20result%20!%3D%20expected%20%7B%0A%20%20%20%20%20%20%20%20t.Errorf%28%22expected%20%25s%2C%20got%20%25s%22%2C%20expected%2C%20result%29%0A%20%20%20%20%7D%0A%7D%29%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/gitutil/git.go
Line: 188-205

Comment:
**Naming convention: missing "Internal" suffix on unexported function**

Per the project's Go naming rules, all unexported functions must carry the `Internal` suffix. `isDirWritable` should be renamed to `isDirWritableInternal` (and its call-sites updated accordingly).

```suggestion
// isDirWritableInternal checks whether dir exists and is writable, or can be created.
func isDirWritableInternal(dir string) bool {
	info, err := os.Stat(dir)
	if err == nil && info.IsDir() {
		// Directory exists — try creating a temp file to verify write access
		f, err := os.CreateTemp(dir, ".probe-*")
		if err != nil {
			return false
		}
		_ = f.Close()
		_ = os.Remove(f.Name())
		return true
	}
	// Directory doesn't exist — try to create it
	if err := os.MkdirAll(dir, 0o700); err != nil {
		return false
	}
	return true
}
```

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/gitutil/git.go
Line: 188-205

Comment:
**`isDirWritable` creates directories as a side effect**

When the directory does not yet exist, this function calls `os.MkdirAll` and returns `true` — it is not a pure read check but also a mutating one. If a caller only wants to test writability without creating the directory, this will silently create it. The `createAcceptNewHostKeyCallback` path later calls `os.MkdirAll` again (harmless but redundant). Consider splitting the concern: a dedicated "ensure dir" helper is clearer than a boolean probe that creates state as a side effect.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/gitutil/git_test.go
Line: 50-63

Comment:
**Test is silently vacuous when running as root**

When the test suite runs as root (common in CI containers), `isDirWritable("/root/.ssh")` returns `true`, so the inner `if !isDirWritable(...)` block is never entered and the test makes zero assertions — it passes trivially without verifying any fallback behavior. The test should either always assert something, or be skipped when running as root:

```go
t.Run("falls back to temp when home is not writable", func(t *testing.T) {
    if os.Getuid() == 0 {
        t.Skip("running as root; /root is writable, fallback path not exercised")
    }
    t.Setenv("SSH_KNOWN_HOSTS", "")
    t.Setenv("HOME", "/root")

    result := getKnownHostsPath()
    expected := filepath.Join(os.TempDir(), ".ssh", "known_hosts")
    if result != expected {
        t.Errorf("expected %s, got %s", expected, result)
    }
})
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use writable fallback path for SSH ..."](https://github.com/getarcaneapp/arcane/commit/16701400bfdfb740879d6cf8c5fa5af97af8c645) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27690744)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->