### PR TITLE
fix: prevent unnecessary container recreation when image is already up to date

### DIFF
--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -207,11 +207,8 @@ func (s *UpdaterService) ApplyPending(ctx context.Context, dryRun bool) (*update
 			item.Status = "skipped"
 			item.Error = "image already up to date"
 			out.Skipped++
-			// We skip checking for pull, but we still proceed to container update checks
-			// treating this as "successful" for the pipeline, but invalidating oldIDs
-			// because they represent the *current* image, not a stale one.
-			plans[i].pulled = true
-			plans[i].oldIDs = nil
+			// Image is already up to date — do NOT mark as pulled so that
+			// containers using this image are not scheduled for recreation.
 			skipPull = true
 
 			s.logAutoUpdate(ctx, s.severityFromStatus(item.Status), models.JSON{


### PR DESCRIPTION
## Summary
- When the digest pre-check determined an image was already up to date, the code incorrectly set `pulled = true` on the update plan
- This caused **all containers using that image to be scheduled for restart** even though no image update was available
- For compose-based projects, this triggered `docker compose up` with `RecreateDiverged`, recreating all services including **database containers**, causing **data loss**
- The fix removes the `pulled = true` / `oldIDs = nil` assignment when no update is needed, so only genuinely updated images trigger container restarts

## Changes
- `backend/internal/services/updater_service.go`: Removed incorrect `plans[i].pulled = true` and `plans[i].oldIDs = nil` when digest check shows image is already up to date

## Root cause
In the `ApplyPending` method (line ~206), when `CheckImageNeedsUpdate` returned `NeedsUpdate = false`, the code was:
```go
plans[i].pulled = true   // BUG: marks as pulled even though nothing was pulled
plans[i].oldIDs = nil     // clears old IDs but plan still enters restart path
```

Later at line ~261, all plans with `pulled == true` were added to `oldRefToNewRef`, causing containers to be matched for restart via `restartContainersUsingOldIDs`.

## Test plan
- [ ] Verify auto-update does NOT restart containers when no image update is available
- [ ] Verify auto-update still correctly restarts containers when a genuine image update is pulled
- [ ] Verify compose-based projects with database services are not recreated unnecessarily
- [ ] Verify the digest pre-check log still shows "image already up to date" status

Fixes #2264

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a critical bug in `ApplyPending` where a successful digest pre-check (image already up to date) incorrectly set `plans[i].pulled = true` and `plans[i].oldIDs = nil`. Because the downstream loop at line ~258 gates restart scheduling on `p.pulled == true`, this caused containers — including database containers in compose projects — to be restarted unnecessarily. The fix simply removes those two assignments so that only genuinely pulled images propagate into the `oldRefToNewRef`/`oldIDToNewRef` maps and trigger restarts.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is minimal, correct, and directly addresses a data-loss bug with no side effects.

The two removed lines were the sole cause of unintended container restarts. Removing them means the `pulled` flag stays `false` for the already-up-to-date path, so those plans are skipped by the restart-scheduling loop. The `skipPull = true` guard already prevented the actual pull; no other logic was relying on the now-removed assignments. No new code paths were introduced.

No files require special attention.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prevent unnecessary container recre..."](https://github.com/getarcaneapp/arcane/commit/31d1914753759735db7089157b7fec9b61481aa3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27690828)</sub>

<!-- /greptile_comment -->