### PR TITLE
fix: preserve webhook URL query params for generic notifications

### DIFF
--- a/backend/pkg/utils/notifications/generic_sender.go
+++ b/backend/pkg/utils/notifications/generic_sender.go
@@ -47,17 +47,20 @@ func BuildGenericURL(config models.GenericConfig) (string, error) {
 
 	// Start with the base URL.
 	// Preserve any query parameters from the original webhook URL by encoding
-	// them into the path. Shoutrrr's generic service uses the path to build the
-	// HTTP request URL, while its own query params are config-only.
-	path := webhookURL.Path
+	// the ? as %3F so it stays in the path component. Shoutrrr decodes the path
+	// when constructing the outbound HTTP request, recovering the original query
+	// string for the upstream service.
+	rawPath := webhookURL.Path
+	decodedPath := webhookURL.Path
 	if webhookURL.RawQuery != "" {
-		path = path + "?" + webhookURL.RawQuery
+		rawPath = webhookURL.Path + "%3F" + webhookURL.RawQuery
+		decodedPath = webhookURL.Path + "?" + webhookURL.RawQuery
 	}
 	shoutrrrURL := &url.URL{
 		Scheme:  scheme,
 		Host:    webhookURL.Host,
-		RawPath: path,
-		Path:    path,
+		RawPath: rawPath,
+		Path:    decodedPath,
 	}
 
 	// Build query parameters

--- a/backend/pkg/utils/notifications/generic_sender_test.go
+++ b/backend/pkg/utils/notifications/generic_sender_test.go
@@ -134,14 +134,14 @@ func TestBuildGenericURL(t *testing.T) {
 			config: models.GenericConfig{
 				WebhookURL: "http://www.pushplus.plus/send?token=abc123",
 			},
-			wantURL: "generic://www.pushplus.plus/send?token=abc123?disabletls=yes&template=json",
+			wantURL: "generic://www.pushplus.plus/send%3Ftoken=abc123?disabletls=yes&template=json",
 		},
 		{
 			name: "webhook URL with multiple query params preserved",
 			config: models.GenericConfig{
 				WebhookURL: "https://api.example.com/webhook?token=abc&channel=general",
 			},
-			wantURL: "generic://api.example.com/webhook?token=abc&channel=general?disabletls=no&template=json",
+			wantURL: "generic://api.example.com/webhook%3Ftoken=abc&channel=general?disabletls=no&template=json",
 		},
 		{
 			name: "empty webhook URL",


### PR DESCRIPTION
## Summary
- Query parameters from the original webhook URL (e.g. `?token=xxx` for PushPlus) were silently dropped when building the Shoutrrr URL, causing the target service to not authenticate the request
- The title param was set using the user-configured key name instead of Shoutrrr's standard `"title"` key, bypassing the `titlekey` mapping

## Changes
- `backend/pkg/utils/notifications/generic_sender.go`: Preserve original URL query params in the Shoutrrr URL path; use standard `"title"` param key
- `backend/pkg/utils/notifications/generic_sender_test.go`: Added test cases for URLs with query parameters

## Root cause
`BuildGenericURL` used only `webhookURL.Host` and `webhookURL.Path`, discarding `webhookURL.RawQuery`. For services like PushPlus where the token is passed as a URL query parameter (`?token=xxx`), the authentication was lost.

## Test plan
- [ ] Verify PushPlus notifications work with `http://www.pushplus.plus/send?token=YOUR_TOKEN`
- [ ] Verify generic webhooks without query params still work
- [ ] Verify custom title/message keys produce correct JSON structure

Fixes #2260

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two bugs in the generic webhook sender: silent loss of webhook URL query params (e.g. authentication tokens) and incorrect use of the user-configured key name instead of Shoutrrr's standard `"title"` param. The `titlekey` fix looks correct. However, the query-param preservation strategy embeds the upstream `?query` into the path as a literal `?`, producing a URL with two `?` characters — when any Go `url.Parse` call processes that output (including Shoutrrr internally), everything after the first `?` becomes the raw query string, silently absorbing Shoutrrr's own config params (`disabletls`, `template`, etc.) into the upstream param value. The upstream query params must be percent-encoded as `%3F` in the path segment to keep the Shoutrrr URL well-formed.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge — the fix introduces a malformed URL that silently breaks TLS and template configuration for all webhook URLs carrying query params.

One P1 logic bug: the double-`?` URL causes Shoutrrr config params like `disabletls` to be swallowed into the upstream token value, so TLS and template settings would be broken. Tests assert the wrong expected output, meaning CI will pass on broken behavior. The `titlekey` fix is correct and is a net improvement, but the core query-param approach needs to be reworked before merging.

Both `backend/pkg/utils/notifications/generic_sender.go` and `backend/pkg/utils/notifications/generic_sender_test.go` need to be updated to use percent-encoded `%3F` in the path rather than a literal `?`.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The PR handles authentication tokens passed as URL query params, and the existing code correctly propagates them through the URL; no secrets are logged or exposed. The malformed double-`?` URL could cause auth tokens to be silently dropped (service returns 401), but this is a reliability issue rather than a security vulnerability.
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Fpkg%2Futils%2Fnotifications%2Fgeneric_sender.go%3A52-61%0A**Double%20%60%3F%60%20produces%20malformed%20URL%20that%20silently%20drops%20Shoutrrr%20config%20params**%0A%0ASetting%20%60Path%60%20and%20%60RawPath%60%20to%20a%20string%20containing%20a%20literal%20%60%3F%60%20causes%20%60shoutrrrURL.String%28%29%60%20to%20emit%20a%20URL%20with%20two%20%60%3F%60%20characters.%20When%20Shoutrrr%20%28or%20any%20Go%20%60url.Parse%60%20caller%29%20later%20parses%20that%20string%2C%20the%20first%20%60%3F%60%20is%20the%20only%20recognized%20query%20delimiter%2C%20so%20%60RawQuery%60%20absorbs%20everything%20%E2%80%94%20including%20%60disabletls%3Dyes%26template%3Djson%60.%20%60url.ParseQuery%60%20on%20that%20combined%20string%20embeds%20%60disabletls%3Dyes%60%20into%20the%20upstream%20param's%20value%2C%20and%20Shoutrrr%20never%20sees%20it%20as%20a%20standalone%20config%20key.%20TLS%20configuration%20%28and%20any%20other%20Shoutrrr%20config%20param%29%20is%20silently%20broken%20for%20any%20webhook%20URL%20that%20carries%20query%20params.%0A%0AThe%20correct%20fix%20is%20to%20percent-encode%20the%20%60%3F%60%20separator%20as%20%60%253F%60%20so%20it%20lives%20inside%20the%20path%20segment%2C%20keeping%20Shoutrrr's%20own%20query%20string%20unambiguous%3A%0A%0A%60%60%60go%0Apath%20%3A%3D%20webhookURL.Path%0Aif%20webhookURL.RawQuery%20!%3D%20%22%22%20%7B%0A%20%20%20%20%2F%2F%20Use%20%253F%20so%20the%20%3F%20sits%20in%20the%20path%20component%2C%20not%20the%20query%20component.%0A%20%20%20%20%2F%2F%20Shoutrrr%20decodes%20the%20path%20when%20constructing%20the%20outbound%20HTTP%20request%2C%0A%20%20%20%20%2F%2F%20recovering%20the%20original%20query%20string%20for%20the%20upstream%20service.%0A%20%20%20%20path%20%3D%20path%20%2B%20%22%253F%22%20%2B%20webhookURL.RawQuery%0A%7D%0AshoutrrrURL%20%3A%3D%20%26url.URL%7B%0A%20%20%20%20Scheme%3A%20%20scheme%2C%0A%20%20%20%20Host%3A%20%20%20%20webhookURL.Host%2C%0A%20%20%20%20RawPath%3A%20path%2C%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20raw%2Fencoded%20form%0A%20%20%20%20Path%3A%20%20%20%20webhookURL.Path%20%2B%20%22%3F%22%20%2B%20webhookURL.RawQuery%2C%20%2F%2F%20decoded%20form%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Fpkg%2Futils%2Fnotifications%2Fgeneric_sender_test.go%3A133-145%0A**Test%20assertions%20validate%20the%20broken%20double-%60%3F%60%20URL%20format**%0A%0ABoth%20new%20test%20cases%20set%20%60wantURL%60%20to%20strings%20containing%20two%20%60%3F%60%20characters%20%28e.g.%20%60...%2Fsend%3F%3Cupstream-query%3E%3Fdisabletls%3Dyes%26template%3Djson%60%29.%20These%20tests%20will%20pass%20against%20the%20current%20broken%20implementation%2C%20but%20they%20are%20asserting%20malformed%20output.%20The%20expected%20values%20should%20instead%20reflect%20a%20well-formed%20URL%20where%20the%20upstream%20query%20params%20are%20percent-encoded%20%28%60%253F%60%29%20into%20the%20path%2C%20keeping%20Shoutrrr's%20own%20config%20params%20properly%20delimited%20after%20the%20single%20%60%3F%60.%0A%0A&repo=getarcaneapp%2Farcane"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/utils/notifications/generic_sender.go
Line: 52-61

Comment:
**Double `?` produces malformed URL that silently drops Shoutrrr config params**

Setting `Path` and `RawPath` to a string containing a literal `?` causes `shoutrrrURL.String()` to emit a URL with two `?` characters. When Shoutrrr (or any Go `url.Parse` caller) later parses that string, the first `?` is the only recognized query delimiter, so `RawQuery` absorbs everything — including `disabletls=yes&template=json`. `url.ParseQuery` on that combined string embeds `disabletls=yes` into the upstream param's value, and Shoutrrr never sees it as a standalone config key. TLS configuration (and any other Shoutrrr config param) is silently broken for any webhook URL that carries query params.

The correct fix is to percent-encode the `?` separator as `%3F` so it lives inside the path segment, keeping Shoutrrr's own query string unambiguous:

```go
path := webhookURL.Path
if webhookURL.RawQuery != "" {
    // Use %3F so the ? sits in the path component, not the query component.
    // Shoutrrr decodes the path when constructing the outbound HTTP request,
    // recovering the original query string for the upstream service.
    path = path + "%3F" + webhookURL.RawQuery
}
shoutrrrURL := &url.URL{
    Scheme:  scheme,
    Host:    webhookURL.Host,
    RawPath: path,                                         // raw/encoded form
    Path:    webhookURL.Path + "?" + webhookURL.RawQuery, // decoded form
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/utils/notifications/generic_sender_test.go
Line: 133-145

Comment:
**Test assertions validate the broken double-`?` URL format**

Both new test cases set `wantURL` to strings containing two `?` characters (e.g. `.../send?<upstream-query>?disabletls=yes&template=json`). These tests will pass against the current broken implementation, but they are asserting malformed output. The expected values should instead reflect a well-formed URL where the upstream query params are percent-encoded (`%3F`) into the path, keeping Shoutrrr's own config params properly delimited after the single `?`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve webhook URL query params a..."](https://github.com/getarcaneapp/arcane/commit/aef5eb48636854eb8da1b9bc123b50dbd3d4f483) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27694437)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->