### PR TITLE
fix: show custom device path for type=none volumes

### DIFF
--- a/frontend/src/routes/(app)/volumes/[volumeName]/+page.svelte
+++ b/frontend/src/routes/(app)/volumes/[volumeName]/+page.svelte
@@ -29,13 +29,6 @@
 	let isLoading = $state({ remove: false });
 	const createdDate = $derived(volume.createdAt ? format(new Date(volume.createdAt), 'PP p') : m.common_unknown());
 
-	const effectiveMountpoint = $derived.by(() => {
-		if (volume.options?.type === 'none' && volume.options?.device) {
-			return volume.options.device;
-		}
-		return volume.mountpoint;
-	});
-
 	let selectedTab = $state('overview');
 
 	const tabItems = $derived([
@@ -212,7 +205,7 @@
 									<div class="min-w-0 flex-1">
 										<p class="text-muted-foreground text-sm font-medium">{m.common_mountpoint()}</p>
 										<div class="bg-muted/50 mt-2 cursor-pointer rounded-lg border p-3 select-all" title="Click to select">
-											<code class="font-mono text-sm break-all">{effectiveMountpoint}</code>
+											<code class="font-mono text-sm break-all">{volume.mountpoint}</code>
 										</div>
 									</div>
 								</div>

--- a/frontend/src/routes/(app)/volumes/[volumeName]/+page.svelte
+++ b/frontend/src/routes/(app)/volumes/[volumeName]/+page.svelte
@@ -29,6 +29,13 @@
 	let isLoading = $state({ remove: false });
 	const createdDate = $derived(volume.createdAt ? format(new Date(volume.createdAt), 'PP p') : m.common_unknown());
 
+	const effectiveMountpoint = $derived.by(() => {
+		if (volume.options?.type === 'none' && volume.options?.device) {
+			return volume.options.device;
+		}
+		return volume.mountpoint;
+	});
+
 	let selectedTab = $state('overview');
 
 	const tabItems = $derived([
@@ -205,7 +212,7 @@
 									<div class="min-w-0 flex-1">
 										<p class="text-muted-foreground text-sm font-medium">{m.common_mountpoint()}</p>
 										<div class="bg-muted/50 mt-2 cursor-pointer rounded-lg border p-3 select-all" title="Click to select">
-											<code class="font-mono text-sm break-all">{volume.mountpoint}</code>
+											<code class="font-mono text-sm break-all">{effectiveMountpoint}</code>
 										</div>
 									</div>
 								</div>

--- a/types/volume/volume.go
+++ b/types/volume/volume.go
@@ -124,11 +124,16 @@ type Create struct {
 //
 // InUse is set to true if the volume's UsageData.RefCount is >= 1, false otherwise.
 func NewSummary(v volume.Volume) Volume {
+	mountpoint := v.Mountpoint
+	if v.Options["type"] == "none" && v.Options["device"] != "" {
+		mountpoint = v.Options["device"]
+	}
+
 	dto := Volume{
 		ID:         v.Name,
 		Name:       v.Name,
 		Driver:     v.Driver,
-		Mountpoint: v.Mountpoint,
+		Mountpoint: mountpoint,
 		Scope:      v.Scope,
 		Options:    v.Options,
 		Labels:     v.Labels,


### PR DESCRIPTION
## Summary
- When a Docker volume uses `type=none` with a custom `device` path, the mountpoint displayed was Docker's internal path (`/var/lib/docker/volumes/<name>/_data`) instead of the actual device path
- Updated `NewSummary()` in the backend to resolve the effective mountpoint from volume driver options when `type=none` and `device` is set
- Added `effectiveMountpoint` derived state in the frontend volume detail page as a fallback

## Test plan
- [ ] Create a volume with `type=none`, `device=/some/host/path`, `o=bind`
- [ ] Navigate to the volume detail page
- [ ] Verify the mountpoint shows the custom device path instead of Docker's internal path
- [ ] Verify the file browser tab works correctly
- [ ] Verify normal volumes (without custom device) still show the correct mountpoint

Fixes #2284

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the display of mountpoints for Docker volumes created with `type=none` and a custom `device` path. The backend `NewSummary()` now substitutes the Docker-internal path (`/var/lib/docker/volumes/<name>/_data`) with the actual `device` option value, and the frontend adds a `$derived.by()` fallback that applies the same substitution client-side.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is minimal, correct, and carries no risk of regression for normal volumes.

Both changes are focused and correct. Go nil-map reads are safe, so the backend logic cannot panic. The frontend uses the idiomatic $derived.by() pattern. The only finding is a P2 style note about the frontend logic duplicating backend behavior. No P0/P1 issues were found.

No files require special attention.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The `device` path was already present in the `Options` field sent to the client; surfacing it in `Mountpoint` does not expose any new information.
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fvolumes%2F%5BvolumeName%5D%2F%2Bpage.svelte%3A32-37%0A**Redundant%20frontend%20logic%20may%20diverge%20from%20backend**%0A%0AThe%20backend%20already%20sets%20%60Mountpoint%60%20to%20%60device%60%20for%20%60type%3Dnone%60%20volumes%20in%20%60NewSummary%28%29%60%2C%20so%20%60volume.mountpoint%60%20arriving%20at%20the%20frontend%20is%20already%20the%20device%20path.%20This%20derived%20re-implements%20the%20same%20logic%2C%20which%20means%20any%20future%20changes%20to%20how%20the%20backend%20resolves%20the%20mountpoint%20%28e.g.%20path%20normalization%2C%20symlink%20resolution%29%20would%20cause%20the%20displayed%20value%20to%20differ%20from%20what%20the%20backend%20actually%20uses%20for%20file-browser%20operations.%0A%0AIf%20the%20intent%20is%20backward%20compatibility%20with%20pre-fix%20cached%2FAPI%20responses%2C%20a%20comment%20to%20that%20effect%20would%20make%20the%20purpose%20clear.%20Otherwise%2C%20the%20simpler%20approach%20is%20to%20drop%20the%20derived%20and%20just%20use%20%60volume.mountpoint%60%20directly.%0A%0A&repo=getarcaneapp%2Farcane"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/routes/(app)/volumes/[volumeName]/+page.svelte
Line: 32-37

Comment:
**Redundant frontend logic may diverge from backend**

The backend already sets `Mountpoint` to `device` for `type=none` volumes in `NewSummary()`, so `volume.mountpoint` arriving at the frontend is already the device path. This derived re-implements the same logic, which means any future changes to how the backend resolves the mountpoint (e.g. path normalization, symlink resolution) would cause the displayed value to differ from what the backend actually uses for file-browser operations.

If the intent is backward compatibility with pre-fix cached/API responses, a comment to that effect would make the purpose clear. Otherwise, the simpler approach is to drop the derived and just use `volume.mountpoint` directly.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: show custom device path for type=no..."](https://github.com/getarcaneapp/arcane/commit/1eb07b46d172b9b7a067a030b1383b70d01735f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27830149)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->