### PR TITLE
fix: lazy-fetch include file content for container compose tab

### DIFF
--- a/frontend/src/routes/(app)/containers/[containerId]/+page.svelte
+++ b/frontend/src/routes/(app)/containers/[containerId]/+page.svelte
@@ -41,6 +41,8 @@
 	} from '$lib/icons';
 	import { parse as parseYaml } from 'yaml';
 	import type { IncludeFile } from '$lib/types/project.type';
+	import { projectService } from '$lib/services/project-service';
+	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	let { data } = $props();
 	let container = $derived(data?.container as ContainerDetailsDto);
 	let stats = $state(null as ContainerStatsType | null);
@@ -150,32 +152,73 @@
 	// Find which file (root compose or an include file) directly defines this service.
 	// Returns { includeFile: null } for root compose, { includeFile: <file> } for a sub-file,
 	// or null if the service isn't found anywhere (hides the tab).
-	const serviceComposeSource = $derived(
-		(() => {
-			if (!project || !composeServiceName || !composeInfo) return null;
+	//
+	// Include file content is lazy-loaded (PR #2259), so we fetch it on-demand here,
+	// stopping as soon as we find the file that defines the service.
+	let serviceComposeSource = $state(null as { includeFile: IncludeFile | null } | null);
 
-			const hasService = (content: string): boolean => {
+	const hasServiceInContent = (content: string, serviceName: string): boolean => {
+		try {
+			const parsed = parseYaml(content) as Record<string, unknown> | null;
+			return !!(parsed?.services && (parsed.services as Record<string, unknown>)[serviceName]);
+		} catch {
+			return false;
+		}
+	};
+
+	$effect(() => {
+		const proj = project;
+		const svcName = composeServiceName;
+		const info = composeInfo;
+		if (!proj || !svcName || !info) {
+			serviceComposeSource = null;
+			return;
+		}
+
+		// Check root compose first (content is always present)
+		if (proj.composeContent && hasServiceInContent(proj.composeContent, svcName)) {
+			serviceComposeSource = { includeFile: null };
+			return;
+		}
+
+		// Lazy-fetch include file contents one at a time until we find the service
+		const includes = proj.includeFiles ?? [];
+		if (includes.length === 0) {
+			serviceComposeSource = null;
+			return;
+		}
+
+		let cancelled = false;
+		(async () => {
+			const envId = await environmentStore.getCurrentEnvironmentId();
+			for (const f of includes) {
+				if (cancelled) return;
+
+				// If content was already present (non-lazy), use it directly
+				if (f.content) {
+					if (hasServiceInContent(f.content, svcName)) {
+						serviceComposeSource = { includeFile: f };
+						return;
+					}
+					continue;
+				}
+
 				try {
-					const parsed = parseYaml(content) as Record<string, unknown> | null;
-					return !!(parsed?.services && (parsed.services as Record<string, unknown>)[composeServiceName]);
+					const loaded = await projectService.getProjectFileForEnvironment(envId, proj.id, f.relativePath);
+					if (cancelled) return;
+					if (loaded?.content && hasServiceInContent(loaded.content, svcName)) {
+						serviceComposeSource = { includeFile: { ...f, content: loaded.content } };
+						return;
+					}
 				} catch {
-					return false;
-				}
-			};
-
-			if (project.composeContent && hasService(project.composeContent)) {
-				return { includeFile: null as IncludeFile | null };
-			}
-
-			for (const f of project.includeFiles ?? []) {
-				if (hasService(f.content)) {
-					return { includeFile: f };
+					// Skip files that fail to load
 				}
 			}
+			if (!cancelled) serviceComposeSource = null;
+		})();
 
-			return null;
-		})()
-	);
+		return () => { cancelled = true; };
+	});
 
 	const showComposeTab = $derived(!!composeInfo && !!serviceComposeSource);
 

--- a/frontend/src/routes/(app)/containers/[containerId]/+page.svelte
+++ b/frontend/src/routes/(app)/containers/[containerId]/+page.svelte
@@ -153,13 +153,8 @@
 	// Returns { includeFile: null } for root compose, { includeFile: <file> } for a sub-file,
 	// or null if the service isn't found anywhere (hides the tab).
 	//
-	// Include file content is lazy-loaded (PR #2259), so we fetch it on-demand here,
-	// stopping as soon as we find the file that defines the service.
-	// $state + $effect is used here instead of $derived because include file content
-	// is lazy-loaded via async API calls (PR #2259). $derived does not support async;
-	// revisit when Svelte's experimental.async $derived is stable.
-	let serviceComposeSource = $state(null as { includeFile: IncludeFile | null } | null);
-
+	// Include file content is lazy-loaded (PR #2259), so we fetch on-demand via
+	// getProjectFileForEnvironment, stopping as soon as the service is found.
 	const hasServiceInContent = (content: string, serviceName: string): boolean => {
 		try {
 			const parsed = parseYaml(content) as Record<string, unknown> | null;
@@ -169,63 +164,46 @@
 		}
 	};
 
-	$effect(() => {
-		const proj = project;
-		const svcName = composeServiceName;
-		const info = composeInfo;
-		if (!proj || !svcName || !info) {
-			serviceComposeSource = null;
-			return;
-		}
+	async function resolveServiceComposeSource(
+		proj: typeof project,
+		svcName: string,
+		info: typeof composeInfo
+	): Promise<{ includeFile: IncludeFile | null } | null> {
+		if (!proj || !svcName || !info) return null;
 
 		// Check root compose first (content is always present)
 		if (proj.composeContent && hasServiceInContent(proj.composeContent, svcName)) {
-			serviceComposeSource = { includeFile: null };
-			return;
+			return { includeFile: null };
 		}
 
 		// Lazy-fetch include file contents one at a time until we find the service
 		const includes = proj.includeFiles ?? [];
-		if (includes.length === 0) {
-			serviceComposeSource = null;
-			return;
-		}
+		if (includes.length === 0) return null;
 
-		serviceComposeSource = null;
-		let cancelled = false;
-		(async () => {
-			const envId = await environmentStore.getCurrentEnvironmentId().catch(() => null);
-			if (!envId || cancelled) return;
-			for (const f of includes) {
-				if (cancelled) return;
+		const envId = await environmentStore.getCurrentEnvironmentId().catch(() => null);
+		if (!envId) return null;
 
-				// If content was already present (non-lazy), use it directly
-				if (f.content) {
-					if (hasServiceInContent(f.content, svcName)) {
-						serviceComposeSource = { includeFile: f };
-						return;
-					}
-					continue;
-				}
-
-				try {
-					const loaded = await projectService.getProjectFileForEnvironment(envId, proj.id, f.relativePath);
-					if (cancelled) return;
-					if (loaded?.content && hasServiceInContent(loaded.content, svcName)) {
-						serviceComposeSource = { includeFile: { ...f, content: loaded.content } };
-						return;
-					}
-				} catch {
-					// Skip files that fail to load
-				}
+		for (const f of includes) {
+			if (f.content && hasServiceInContent(f.content, svcName)) {
+				return { includeFile: f };
 			}
-			if (!cancelled) serviceComposeSource = null;
-		})();
+			try {
+				const loaded = await projectService.getProjectFileForEnvironment(envId, proj.id, f.relativePath);
+				if (loaded?.content && hasServiceInContent(loaded.content, svcName)) {
+					return { includeFile: { ...f, content: loaded.content } };
+				}
+			} catch {
+				// Skip files that fail to load
+			}
+		}
+		return null;
+	}
 
-		return () => { cancelled = true; };
-	});
+	const serviceComposeSourcePromise = $derived(
+		resolveServiceComposeSource(project, composeServiceName, composeInfo)
+	);
 
-	const showComposeTab = $derived(!!composeInfo && !!serviceComposeSource);
+	const showComposeTab = $derived(!!composeInfo && !!project);
 
 	const tabItems = $derived<TabItem[]>([
 		{ value: 'overview', label: m.common_overview(), icon: ContainersIcon },
@@ -383,18 +361,20 @@
 				</Tabs.Content>
 			{/if}
 
-			{#if project && serviceComposeSource}
-				<Tabs.Content value="compose" class="h-full min-h-0">
-					{#key `${project?.id}-${serviceComposeSource?.includeFile?.relativePath ?? 'root'}`}
-						<ContainerComposePanel
-							{project}
-							serviceName={composeServiceName}
-							includeFile={serviceComposeSource.includeFile}
-							rootFilename={rootComposeFilename}
-						/>
-					{/key}
-				</Tabs.Content>
-			{/if}
+			{#await serviceComposeSourcePromise then serviceComposeSource}
+				{#if project && serviceComposeSource}
+					<Tabs.Content value="compose" class="h-full min-h-0">
+						{#key `${project?.id}-${serviceComposeSource?.includeFile?.relativePath ?? 'root'}`}
+							<ContainerComposePanel
+								{project}
+								serviceName={composeServiceName}
+								includeFile={serviceComposeSource.includeFile}
+								rootFilename={rootComposeFilename}
+							/>
+						{/key}
+					</Tabs.Content>
+				{/if}
+			{/await}
 		{/snippet}
 	</TabbedPageLayout>
 {:else}

--- a/frontend/src/routes/(app)/containers/[containerId]/+page.svelte
+++ b/frontend/src/routes/(app)/containers/[containerId]/+page.svelte
@@ -155,6 +155,9 @@
 	//
 	// Include file content is lazy-loaded (PR #2259), so we fetch it on-demand here,
 	// stopping as soon as we find the file that defines the service.
+	// $state + $effect is used here instead of $derived because include file content
+	// is lazy-loaded via async API calls (PR #2259). $derived does not support async;
+	// revisit when Svelte's experimental.async $derived is stable.
 	let serviceComposeSource = $state(null as { includeFile: IncludeFile | null } | null);
 
 	const hasServiceInContent = (content: string, serviceName: string): boolean => {
@@ -188,9 +191,11 @@
 			return;
 		}
 
+		serviceComposeSource = null;
 		let cancelled = false;
 		(async () => {
-			const envId = await environmentStore.getCurrentEnvironmentId();
+			const envId = await environmentStore.getCurrentEnvironmentId().catch(() => null);
+			if (!envId || cancelled) return;
 			for (const f of includes) {
 				if (cancelled) return;
 


### PR DESCRIPTION
## Summary

The Compose tab on the container detail view stopped appearing after v1.17.2 for containers defined in include files. This is a regression from #2259 (lazy load project file contents on demand).

## Root cause

#2259 changed `enrichWithIncludeFiles` to call `ParseIncludes(composeFile, envMap, false)`, which returns include file metadata without content. The `Content` field is tagged `omitempty`, so it's stripped from the JSON response entirely. The container detail page's `serviceComposeSource` derivation then calls `hasService(f.content)` on every include file — but `f.content` is `undefined`, so no match is found, `serviceComposeSource` stays `null`, and the Compose tab is hidden.

## Fix

Replace the synchronous `$derived` block with a `$effect` that lazy-fetches include file content on demand via `projectService.getProjectFileForEnvironment()` (the endpoint #2259 added for exactly this purpose). The fetch:

- Checks root compose content first (always present, no fetch needed)
- Iterates include files one at a time, fetching content only as needed
- Stops as soon as the service is found — no unnecessary API calls
- Supports cancellation on re-render so stale async doesn't clobber state
- Falls back gracefully if content was already present (non-lazy path)

## Files

- `frontend/src/routes/(app)/containers/[containerId]/+page.svelte`

## Test plan

- [ ] Container defined in root compose.yml: Compose tab appears immediately (no fetch needed)
- [ ] Container defined in an include file (e.g. `seerr` in a 26-service media stack with `include:` + `project_directory:`): Compose tab appears after brief load, shows correct include file content
- [ ] Container with no compose labels: no Compose tab (unchanged)
- [ ] Navigating between containers: previous async fetch is cancelled, new one runs cleanly

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a regression introduced in #2259 where the Compose tab disappeared for containers defined in Docker Compose `include` files. The root cause was that `ParseIncludes` returned include file metadata without content (stripped via `omitempty`), so `serviceComposeSource` could never match. The fix replaces the synchronous `$derived` with a `$state`+`$effect` combo that lazily fetches include file content on demand, stopping at the first match and supporting async cancellation on navigation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted regression fix with correct async cancellation semantics and no new P0/P1 issues.

The fix correctly addresses the regression: include file content is now fetched on demand, cancellation prevents stale async mutations, and the synchronous null-reset before the IIFE ensures no stale Compose tab during navigation. All remaining findings are P2. Prior review thread concerns (stale state, $effect/$state pattern, error handling for getCurrentEnvironmentId) are addressed in the implementation.

No files require special attention.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The lazy-fetch only reads project file content for files already listed in the project's include list, with the environment ID gated through `environmentStore.getCurrentEnvironmentId()`. No user-controlled input flows into path construction.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: guard getCurrentEnvironmentId again..."](https://github.com/getarcaneapp/arcane/commit/3eed2f29cc9905afb99f5647bca296566e2ecd75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27858623)</sub>

**Context used:**

- Rule used - What: Avoid updating `$state` inside `$effect` blo... ([source](https://app.greptile.com/review/custom-context?memory=8e0bee41-b073-4a49-a01c-2c2c8782b420))

<!-- /greptile_comment -->