### PR TITLE
fix: invalidate project query cache after compose save from container view

### DIFF
--- a/frontend/src/routes/(app)/containers/components/ContainerComposePanel.svelte
+++ b/frontend/src/routes/(app)/containers/components/ContainerComposePanel.svelte
@@ -2,7 +2,12 @@
 	import { ComposeEditorWrapper } from '$lib/components/compose';
 	import CodePanel from '../../projects/components/CodePanel.svelte';
 	import { projectService } from '$lib/services/project-service';
+	import { useQueryClient } from '@tanstack/svelte-query';
+	import { queryKeys } from '$lib/query/query-keys';
+	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import type { Project, IncludeFile } from '$lib/types/project.type';
+
+	const queryClient = useQueryClient();
 
 	let {
 		project,
@@ -32,6 +37,13 @@
 			await projectService.updateProjectIncludeFile(project.id, includeFile.relativePath, composeContent);
 		} else {
 			await projectService.updateProject(project.id, undefined, composeContent);
+		}
+
+		// Invalidate cached project details so the editor reflects the saved content
+		// without requiring a full page refresh.
+		const envId = await environmentStore.getCurrentEnvironmentId().catch(() => null);
+		if (envId) {
+			await queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(envId, project.id) });
 		}
 	}
 </script>


### PR DESCRIPTION
## Summary

After saving compose file changes from the container detail Compose tab, the editor reverts to the old content. A full page refresh shows the correct saved content. This happens because the save handler in `ContainerComposePanel` doesn't invalidate the project detail query cache after a successful write.

## Root cause

`ContainerComposePanel.save()` calls `updateProjectIncludeFile` or `updateProject` but never invalidates the `queryKeys.projects.detail` cache entry. The parent page loaded the project via `queryClient.fetchQuery` — after save, the stale cached version is returned on the next render cycle.

The project detail page (`projects/[projectId]/+page.svelte`) already handles this correctly via `queryClient.setQueryData` + `invalidateQueries` after save — the container compose panel was missing the equivalent.

## Fix

After a successful save, invalidate the project detail query cache so the next access re-fetches from the backend with the updated content.

## Files

- `frontend/src/routes/(app)/containers/components/ContainerComposePanel.svelte`

## Test plan

- [ ] Edit a compose file from the container detail Compose tab, save — content stays as edited without requiring page refresh
- [ ] Edit from the project detail page — still works as before (unchanged code path)

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a stale-cache bug in `ContainerComposePanel` where the compose editor would revert to the pre-save content after writing changes from the container detail view. The fix adds `invalidateQueries` for the project detail cache key after a successful save, mirroring the pattern already used on the project detail page.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the fix is minimal, targeted, and correct.

The only finding is a P2 style suggestion to use the synchronous `environmentStore.selected?.id` instead of the async `getCurrentEnvironmentId()`. The fix itself is logically correct — invalidation happens after a successful write, the query key matches the parent's cached entry, and error propagation is preserved. No blocking issues.

No files require special attention.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fcontainers%2Fcomponents%2FContainerComposePanel.svelte%3A44-47%0A**Simpler%20synchronous%20env%20ID%20access%20available**%0A%0A%60environmentStore.getCurrentEnvironmentId%28%29%60%20is%20async%20solely%20because%20it%20awaits%20the%20ready%20promise%2C%20but%20by%20the%20time%20a%20user%20can%20interact%20with%20this%20component%20the%20store%20is%20already%20initialized.%20The%20project%20detail%20page%20accesses%20the%20same%20value%20synchronously%20via%20%60environmentStore.selected%3F.id%60.%20Using%20the%20synchronous%20accessor%20removes%20the%20async%20overhead%2C%20the%20%60.catch%28%28%29%20%3D%3E%20null%29%60%20defensive%20branch%2C%20and%20keeps%20the%20pattern%20consistent%20with%20the%20rest%20of%20the%20codebase.%0A%0A&repo=getarcaneapp%2Farcane"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/routes/(app)/containers/components/ContainerComposePanel.svelte
Line: 44-47

Comment:
**Simpler synchronous env ID access available**

`environmentStore.getCurrentEnvironmentId()` is async solely because it awaits the ready promise, but by the time a user can interact with this component the store is already initialized. The project detail page accesses the same value synchronously via `environmentStore.selected?.id`. Using the synchronous accessor removes the async overhead, the `.catch(() => null)` defensive branch, and keeps the pattern consistent with the rest of the codebase.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: invalidate project query cache afte..."](https://github.com/getarcaneapp/arcane/commit/b0afce959e5a8b93cefee2addda1932c83c0289b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27880050)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->