### PR TITLE
fix: pass enriched project to query cache after save to prevent editor revert

### DIFF
--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -387,7 +387,11 @@
 				}
 
 				applyProjectDetailsToEditor(savedProject, 'saved');
-				await syncProjectQueries(savedProject);
+				// Pass the enriched project (with locally-preserved include file
+				// content) to the query cache so that any reactive re-read after
+				// save doesn't revert the editor to the lazy-loaded (content-less)
+				// server response.
+				await syncProjectQueries(withLoadedProjectFileContent(savedProject));
 				toast.success(m.common_update_success({ resource: m.project() }));
 			}
 		});


### PR DESCRIPTION
## Summary

After saving compose file changes on the project Configuration page, the editor reverts to the pre-edit content. A page refresh shows the correct saved content — the save itself succeeds, but the editor state is overwritten by stale data from the query cache.

## Root cause

`handleSaveChanges` calls `applyProjectDetailsToEditor(savedProject, 'saved')` which enriches the project with locally-preserved include file content and updates the editor. It then calls `syncProjectQueries(savedProject)` — but `savedProject` is the raw server response, which (since #2259's lazy load) has include files without content. Putting this content-less project into the query cache via `setQueryData` causes a reactive re-read that overwrites the editor with the stale version.

## Fix

Pass the enriched project (with locally-preserved content) to `syncProjectQueries` instead of the raw server response, so the query cache always has complete data.

## Files

- `frontend/src/routes/(app)/projects/[projectId]/+page.svelte`

## Test plan

- [ ] Edit root compose.yml on the project Configuration page, save — editor retains the edit
- [ ] Edit an include file, save — editor retains the edit
- [ ] Refresh the page after save — content matches what was saved

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a post-save editor revert bug where `syncProjectQueries` was receiving the raw server response (with lazily-loaded include files stripped of content) instead of the locally-enriched project, causing a reactive re-read to overwrite the editor state. The fix wraps the argument to `syncProjectQueries` with `withLoadedProjectFileContent`, which correctly fills in file content from the already-updated local state (`includeFilesState`, `originalIncludeFiles`, and `project`) that was just refreshed by the preceding `applyProjectDetailsToEditor` call.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — it fixes a real post-save editor revert bug with a minimal, well-reasoned one-line change.

The change is a single-call wrapping with a function already used in the same file for the same enrichment purpose. The ordering dependency (enrichment sources are updated before the second `withLoadedProjectFileContent` call) is satisfied by the preceding `applyProjectDetailsToEditor` call. No regressions are introduced and there are no P1/P0 findings.

No files require special attention.
</details>


<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/routes/(app)/containers/components/ContainerComposePanel.svelte`, line 42-47 ([link](https://github.com/getarcaneapp/arcane/blob/adc6a1fd6718b2f4b35a86ecb9ca96668636afcd/frontend/src/routes/(app)/containers/components/ContainerComposePanel.svelte#L42-L47)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`invalidateQueries` can hide the compose tab for include-file-defined services**

   After the save, `invalidateQueries` triggers a re-fetch that returns include files with `null` content (the lazy-load behaviour from #2259). Back in the container detail page, `serviceComposeSource` is `$derived` by calling `hasService(f.content)` on each include file — if `f.content` is `null`, `parseYaml(null)` returns `null`/throws, `hasService` returns `false`, and the whole `serviceComposeSource` expression resolves to `null`. This makes `showComposeTab = false` and the Compose tab disappears until the next hard navigation.

   The `+page.svelte` fix solved the same root cause with `setQueryData` (putting the *enriched* project into the cache) rather than `invalidateQueries` (triggering a re-fetch with content-less include files). `ContainerComposePanel` should follow the same pattern — either use `setQueryData` with the already-saved `composeContent`, or avoid the cache invalidation for the project detail query here and rely solely on the project page's own sync path.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/routes/(app)/containers/components/ContainerComposePanel.svelte
   Line: 42-47

   Comment:
   **`invalidateQueries` can hide the compose tab for include-file-defined services**

   After the save, `invalidateQueries` triggers a re-fetch that returns include files with `null` content (the lazy-load behaviour from #2259). Back in the container detail page, `serviceComposeSource` is `$derived` by calling `hasService(f.content)` on each include file — if `f.content` is `null`, `parseYaml(null)` returns `null`/throws, `hasService` returns `false`, and the whole `serviceComposeSource` expression resolves to `null`. This makes `showComposeTab = false` and the Compose tab disappears until the next hard navigation.

   The `+page.svelte` fix solved the same root cause with `setQueryData` (putting the *enriched* project into the cache) rather than `invalidateQueries` (triggering a re-fetch with content-less include files). `ContainerComposePanel` should follow the same pattern — either use `setQueryData` with the already-saved `composeContent`, or avoid the cache invalidation for the project detail query here and rely solely on the project page's own sync path.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20frontend%2Fsrc%2Froutes%2F%28app%29%2Fcontainers%2Fcomponents%2FContainerComposePanel.svelte%0ALine%3A%2042-47%0A%0AComment%3A%0A**%60invalidateQueries%60%20can%20hide%20the%20compose%20tab%20for%20include-file-defined%20services**%0A%0AAfter%20the%20save%2C%20%60invalidateQueries%60%20triggers%20a%20re-fetch%20that%20returns%20include%20files%20with%20%60null%60%20content%20%28the%20lazy-load%20behaviour%20from%20%232259%29.%20Back%20in%20the%20container%20detail%20page%2C%20%60serviceComposeSource%60%20is%20%60%24derived%60%20by%20calling%20%60hasService%28f.content%29%60%20on%20each%20include%20file%20%E2%80%94%20if%20%60f.content%60%20is%20%60null%60%2C%20%60parseYaml%28null%29%60%20returns%20%60null%60%2Fthrows%2C%20%60hasService%60%20returns%20%60false%60%2C%20and%20the%20whole%20%60serviceComposeSource%60%20expression%20resolves%20to%20%60null%60.%20This%20makes%20%60showComposeTab%20%3D%20false%60%20and%20the%20Compose%20tab%20disappears%20until%20the%20next%20hard%20navigation.%0A%0AThe%20%60%2Bpage.svelte%60%20fix%20solved%20the%20same%20root%20cause%20with%20%60setQueryData%60%20%28putting%20the%20*enriched*%20project%20into%20the%20cache%29%20rather%20than%20%60invalidateQueries%60%20%28triggering%20a%20re-fetch%20with%20content-less%20include%20files%29.%20%60ContainerComposePanel%60%20should%20follow%20the%20same%20pattern%20%E2%80%94%20either%20use%20%60setQueryData%60%20with%20the%20already-saved%20%60composeContent%60%2C%20or%20avoid%20the%20cache%20invalidation%20for%20the%20project%20detail%20query%20here%20and%20rely%20solely%20on%20the%20project%20page's%20own%20sync%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: pass enriched project to query cach..."](https://github.com/getarcaneapp/arcane/commit/adc6a1fd6718b2f4b35a86ecb9ca96668636afcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27884696)</sub>

<!-- /greptile_comment -->