### PR TITLE
fix: validate and secure remote template registry fetching

### DIFF
--- a/backend/internal/common/errors.go
+++ b/backend/internal/common/errors.go
@@ -1013,7 +1013,7 @@ type RegistryFetchError struct {
 }
 
 func (e *RegistryFetchError) Error() string {
-	return fmt.Sprintf("Failed to fetch registry: %v", e.Err)
+	return "Failed to fetch registry"
 }
 
 type InvalidJSONResponseError struct {
@@ -1021,7 +1021,15 @@ type InvalidJSONResponseError struct {
 }
 
 func (e *InvalidJSONResponseError) Error() string {
-	return fmt.Sprintf("Invalid JSON response: %v", e.Err)
+	return "Invalid JSON response"
+}
+
+type UnsafeRemoteURLError struct {
+	Err error
+}
+
+func (e *UnsafeRemoteURLError) Error() string {
+	return fmt.Sprintf("Remote URL is not allowed: %v", e.Err)
 }
 
 type TemplateAlreadyLocalError struct{}

--- a/backend/internal/huma/handlers/templates.go
+++ b/backend/internal/huma/handlers/templates.go
@@ -185,6 +185,10 @@ func RegisterTemplates(api huma.API, templateService *services.TemplateService, 
 		Summary:     "Fetch remote registry",
 		Description: "Fetch templates from a remote registry URL",
 		Tags:        []string{"Templates"},
+		Security: []map[string][]string{
+			{"BearerAuth": {}},
+			{"ApiKeyAuth": {}},
+		},
 	}, h.FetchRegistry)
 
 	huma.Register(api, huma.Operation{

--- a/backend/internal/huma/handlers/templates_fetch_test.go
+++ b/backend/internal/huma/handlers/templates_fetch_test.go
@@ -1,0 +1,172 @@
+package handlers
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humagin"
+	"github.com/getarcaneapp/arcane/backend/internal/config"
+	"github.com/getarcaneapp/arcane/backend/internal/database"
+	humamiddleware "github.com/getarcaneapp/arcane/backend/internal/huma/middleware"
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/internal/services"
+	httputils "github.com/getarcaneapp/arcane/backend/pkg/utils/httpx"
+	"github.com/gin-gonic/gin"
+	glsqlite "github.com/glebarez/sqlite"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestFetchTemplateRegistryRequiresAuthentication(t *testing.T) {
+	router := newTemplateFetchTestRouter(t, http.DefaultClient, httputils.DefaultLookupIP)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/templates/fetch?url=http://example.com/registry.json", nil)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Contains(t, rec.Body.String(), "Unauthorized")
+}
+
+func TestFetchTemplateRegistryAuthenticatedSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"Registry","description":"Demo","version":"1.0.0","author":"Arcane","templates":[]}`))
+	}))
+	defer server.Close()
+
+	client, lookupIP, registryURL := makeTemplateFetchRemote(t, server)
+	router := newTemplateFetchTestRouter(t, client, lookupIP)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/templates/fetch?url="+url.QueryEscape(registryURL), nil)
+	req.Header.Set("Authorization", "Bearer "+makeTemplateFetchToken(t, "test-secret", "user-1", "alice"))
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"success":true`)
+	require.Contains(t, rec.Body.String(), `"name":"Registry"`)
+}
+
+func TestFetchTemplateRegistryAuthenticatedUnsafeTargetIsSanitized(t *testing.T) {
+	router := newTemplateFetchTestRouter(t, http.DefaultClient, httputils.DefaultLookupIP)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/templates/fetch?url="+url.QueryEscape("http://127.0.0.1:8080/registry.json"), nil)
+	req.Header.Set("Authorization", "Bearer "+makeTemplateFetchToken(t, "test-secret", "user-1", "alice"))
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Contains(t, rec.Body.String(), "Failed to fetch registry")
+	require.NotContains(t, rec.Body.String(), "127.0.0.1")
+	require.NotContains(t, rec.Body.String(), "connection refused")
+	require.NotContains(t, rec.Body.String(), "Invalid JSON response")
+}
+
+func newTemplateFetchTestRouter(t *testing.T, httpClient *http.Client, lookupIP httputils.LookupIPFunc) *gin.Engine {
+	t.Helper()
+
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(t.TempDir()))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalDir))
+	})
+
+	db, err := gorm.Open(glsqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}))
+
+	databaseDB := &database.DB{DB: db}
+	userService := services.NewUserService(databaseDB)
+	_, err = userService.CreateUser(context.Background(), &models.User{
+		BaseModel: models.BaseModel{ID: "user-1"},
+		Username:  "alice",
+		Roles:     models.StringSlice{"admin"},
+	})
+	require.NoError(t, err)
+
+	authService := services.NewAuthService(userService, nil, nil, "test-secret", &config.Config{})
+	templateService := services.NewTemplateService(context.Background(), nil, httpClient, nil).WithLookupIPResolver(lookupIP)
+
+	router := gin.New()
+	apiGroup := router.Group("/api")
+
+	humaConfig := huma.DefaultConfig("test", "1.0.0")
+	humaConfig.Components.SecuritySchemes = map[string]*huma.SecurityScheme{
+		"BearerAuth": {
+			Type:   "http",
+			Scheme: "bearer",
+		},
+		"ApiKeyAuth": {
+			Type: "apiKey",
+			In:   "header",
+			Name: "X-API-Key",
+		},
+	}
+
+	api := humagin.NewWithGroup(router, apiGroup, humaConfig)
+	api.UseMiddleware(humamiddleware.NewAuthBridge(api, authService, nil, &config.Config{}))
+	RegisterTemplates(api, templateService, nil)
+
+	return router
+}
+
+func makeTemplateFetchToken(t *testing.T, secret string, userID, username string) string {
+	t.Helper()
+
+	claims := services.UserClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        userID,
+			Subject:   "access",
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+		},
+		UserID:     userID,
+		Username:   username,
+		Roles:      []string{"admin"},
+		AppVersion: config.Version,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString([]byte(secret))
+	require.NoError(t, err)
+
+	return signed
+}
+
+func makeTemplateFetchRemote(t *testing.T, server *httptest.Server) (*http.Client, httputils.LookupIPFunc, string) {
+	t.Helper()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	listenerAddr := server.Listener.Addr().String()
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dialer := &net.Dialer{}
+		return dialer.DialContext(ctx, network, listenerAddr)
+	}
+
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   10 * time.Second,
+	}
+
+	lookupIP := func(ctx context.Context, host string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+
+	return client, lookupIP, "http://templates.example.test:" + parsedURL.Port() + "/registry.json"
+}

--- a/backend/internal/services/template_service.go
+++ b/backend/internal/services/template_service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/pkg/projects"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils"
+	httputils "github.com/getarcaneapp/arcane/backend/pkg/utils/httpx"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils/mapper"
 	"github.com/getarcaneapp/arcane/types/env"
 	tmpl "github.com/getarcaneapp/arcane/types/template"
@@ -45,6 +46,8 @@ type registryFetchMeta struct {
 type TemplateService struct {
 	db              *database.DB
 	httpClient      *http.Client
+	safeHTTPClient  *http.Client
+	lookupIP        httputils.LookupIPFunc
 	settingsService *SettingsService
 
 	remoteMu    sync.RWMutex
@@ -81,13 +84,22 @@ func NewTemplateService(ctx context.Context, db *database.DB, httpClient *http.C
 		slog.WarnContext(ctx, "failed to ensure default templates", "error", err)
 	}
 
-	return &TemplateService{
+	service := &TemplateService{
 		db:                db,
 		httpClient:        httpClient,
+		lookupIP:          httputils.DefaultLookupIP,
 		settingsService:   settingsService,
 		remoteCache:       remoteCache{},
 		registryFetchMeta: make(map[string]*registryFetchMeta),
 	}
+	service.safeHTTPClient = service.newSafeHTTPClientInternal()
+	return service
+}
+
+func (s *TemplateService) WithLookupIPResolver(lookupIP httputils.LookupIPFunc) *TemplateService {
+	s.lookupIP = lookupIP
+	s.safeHTTPClient = s.newSafeHTTPClientInternal()
+	return s
 }
 
 func (s *TemplateService) ensureRemoteTemplatesLoaded(ctx context.Context) error {
@@ -554,11 +566,11 @@ func (s *TemplateService) FetchRaw(ctx context.Context, url string) ([]byte, err
 }
 
 func (s *TemplateService) doGET(ctx context.Context, url string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	client, req, err := s.newSafeRequestInternal(ctx, http.MethodGet, url)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request for %s: %w", url, err)
+		return nil, err
 	}
-	resp, err := s.httpClient.Do(req) //nolint:gosec // intentional request to configured template registry URL
+	resp, err := client.Do(req) //nolint:gosec // intentional request to configured template registry URL
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch %s: %w", url, err)
 	}
@@ -582,7 +594,7 @@ func (s *TemplateService) fetchRegistryTemplates(ctx context.Context, reg *model
 	fetchMeta := s.registryFetchMeta[reg.ID]
 	s.registryMu.RUnlock()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reg.URL, nil)
+	client, req, err := s.newSafeRequestInternal(ctx, http.MethodGet, reg.URL)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
@@ -590,7 +602,7 @@ func (s *TemplateService) fetchRegistryTemplates(ctx context.Context, reg *model
 		req.Header.Set("If-Modified-Since", fetchMeta.LastModified)
 	}
 
-	resp, err := s.httpClient.Do(req) //nolint:gosec // intentional request to configured template registry URL
+	resp, err := client.Do(req) //nolint:gosec // intentional request to configured template registry URL
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
@@ -735,6 +747,38 @@ func (s *TemplateService) fetchURL(ctx context.Context, url string) (string, err
 		return "", err
 	}
 	return string(body), nil
+}
+
+func (s *TemplateService) newSafeHTTPClientInternal() *http.Client {
+	client, err := httputils.NewSafeOutboundHTTPClient(s.httpClient, s.lookupIP)
+	if err != nil {
+		slog.Warn("failed to configure safe HTTP client", "error", err)
+		return nil
+	}
+	return client
+}
+
+func (s *TemplateService) newSafeRequestInternal(ctx context.Context, method, rawURL string) (*http.Client, *http.Request, error) {
+	parsedURL, err := httputils.ValidateSafeRemoteURL(ctx, rawURL, s.lookupIP)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client := s.safeHTTPClient
+	if client == nil {
+		client = s.newSafeHTTPClientInternal()
+		if client == nil {
+			return nil, nil, fmt.Errorf("failed to configure safe HTTP client")
+		}
+		s.safeHTTPClient = client
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, parsedURL.String(), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request for %s: %w", rawURL, err)
+	}
+
+	return client, req, nil
 }
 
 func (s *TemplateService) DownloadTemplate(ctx context.Context, remoteTemplate *models.ComposeTemplate) (*models.ComposeTemplate, error) {

--- a/backend/internal/services/template_service_test.go
+++ b/backend/internal/services/template_service_test.go
@@ -2,19 +2,25 @@ package services
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	glsqlite "github.com/glebarez/sqlite"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
+	"github.com/getarcaneapp/arcane/backend/internal/common"
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
+	httputils "github.com/getarcaneapp/arcane/backend/pkg/utils/httpx"
 )
 
 func setupTemplateServiceTestDB(t *testing.T) *database.DB {
@@ -37,6 +43,32 @@ func setTestWorkingDir(t *testing.T, dir string) {
 	t.Cleanup(func() {
 		require.NoError(t, os.Chdir(originalDir))
 	})
+}
+
+func makePublicTestClient(t *testing.T, server *httptest.Server) (*http.Client, httputils.LookupIPFunc, string) {
+	t.Helper()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	listenerAddr := server.Listener.Addr().String()
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dialer := &net.Dialer{}
+		return dialer.DialContext(ctx, network, listenerAddr)
+	}
+
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   10 * time.Second,
+	}
+
+	lookupIP := func(ctx context.Context, host string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+
+	baseURL := fmt.Sprintf("http://templates.example.test:%s", parsedURL.Port())
+	return client, lookupIP, baseURL
 }
 
 func TestResolveTemplateIconURL(t *testing.T) {
@@ -164,12 +196,14 @@ services:
 	}))
 	defer server.Close()
 
-	registryURL := server.URL + "/registry.json"
-	okComposeURL = server.URL + "/ok.yml"
-	badComposeURL = server.URL + "/missing.yml"
+	client, lookupIP, baseURL := makePublicTestClient(t, server)
+	registryURL := baseURL + "/registry.json"
+	okComposeURL = baseURL + "/ok.yml"
+	badComposeURL = baseURL + "/missing.yml"
 
 	service := &TemplateService{
-		httpClient:        server.Client(),
+		httpClient:        client,
+		lookupIP:          lookupIP,
 		registryFetchMeta: make(map[string]*registryFetchMeta),
 	}
 	registry := &models.TemplateRegistry{
@@ -218,9 +252,12 @@ services:
 	}))
 	defer server.Close()
 
+	client, lookupIP, baseURL := makePublicTestClient(t, server)
+
 	service := &TemplateService{
 		db:                setupTemplateServiceTestDB(t),
-		httpClient:        server.Client(),
+		httpClient:        client,
+		lookupIP:          lookupIP,
 		registryFetchMeta: make(map[string]*registryFetchMeta),
 	}
 
@@ -232,8 +269,8 @@ services:
 		IsCustom:    false,
 		RegistryID:  stringPtr("reg-1"),
 		Metadata: &models.ComposeTemplateMetadata{
-			RemoteURL: stringPtr(server.URL + "/compose.yaml"),
-			EnvURL:    stringPtr(server.URL + "/template.env"),
+			RemoteURL: stringPtr(baseURL + "/compose.yaml"),
+			EnvURL:    stringPtr(baseURL + "/template.env"),
 			IconURL:   stringPtr("https://cdn.example/download.png"),
 		},
 	}
@@ -251,6 +288,19 @@ services:
 	require.NotNil(t, stored.Metadata)
 	require.NotNil(t, stored.Metadata.IconURL)
 	require.Equal(t, "https://cdn.example/download.png", *stored.Metadata.IconURL)
+}
+
+func TestFetchRaw_BlocksUnsafeRemoteURL(t *testing.T) {
+	service := &TemplateService{
+		httpClient:        http.DefaultClient,
+		lookupIP:          httputils.DefaultLookupIP,
+		registryFetchMeta: make(map[string]*registryFetchMeta),
+	}
+
+	_, err := service.FetchRaw(context.Background(), "http://127.0.0.1:8080/registry.json")
+	require.Error(t, err)
+	var unsafeErr *common.UnsafeRemoteURLError
+	require.ErrorAs(t, err, &unsafeErr)
 }
 
 func TestSyncFilesystemTemplatesInternal_PopulatesIconURL(t *testing.T) {

--- a/backend/pkg/utils/httpx/safe_remote.go
+++ b/backend/pkg/utils/httpx/safe_remote.go
@@ -1,0 +1,232 @@
+package httpx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/getarcaneapp/arcane/backend/internal/common"
+)
+
+type LookupIPFunc func(ctx context.Context, host string) ([]net.IP, error)
+
+// blockedRemotePrefixes contains special-use ranges that should never be treated
+// as valid public registry destinations. We intentionally keep this list explicit
+// because Go exposes helpers for some classes (for example private, loopback, and
+// link-local) but does not provide one "publicly routable on the internet" check
+// that covers the full SSRF threat model. These prefixes complement the net.IP
+// helper checks in isBlockedIPInternal and make the policy reviewable in one place.
+var blockedRemotePrefixes = mustParsePrefixesInternal(
+	"0.0.0.0/8",
+	"100.64.0.0/10",
+	"127.0.0.0/8",
+	"169.254.0.0/16",
+	"192.0.0.0/24",
+	"192.0.2.0/24",
+	"198.18.0.0/15",
+	"198.51.100.0/24",
+	"203.0.113.0/24",
+	"224.0.0.0/4",
+	"240.0.0.0/4",
+	"::/128",
+	"::1/128",
+	"2001:db8::/32",
+	"fc00::/7",
+	"fe80::/10",
+	"ff00::/8",
+)
+
+func DefaultLookupIP(ctx context.Context, host string) ([]net.IP, error) {
+	return net.DefaultResolver.LookupIP(ctx, "ip", host)
+}
+
+func ValidateSafeRemoteURL(ctx context.Context, rawURL string, lookupIP LookupIPFunc) (*url.URL, error) {
+	if lookupIP == nil {
+		lookupIP = DefaultLookupIP
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, &common.UnsafeRemoteURLError{Err: err}
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return nil, &common.UnsafeRemoteURLError{Err: fmt.Errorf("scheme %q is not allowed", parsed.Scheme)}
+	}
+
+	if parsed.User != nil {
+		return nil, &common.UnsafeRemoteURLError{Err: errors.New("embedded credentials are not allowed")}
+	}
+
+	host := parsed.Hostname()
+	if host == "" || isBlockedHostnameInternal(host) {
+		return nil, &common.UnsafeRemoteURLError{Err: fmt.Errorf("host %q is not allowed", host)}
+	}
+
+	ips, err := resolveAllowedIPsInternal(ctx, host, lookupIP)
+	if err != nil || len(ips) == 0 {
+		if err == nil {
+			err = errors.New("host did not resolve to an allowed IP")
+		}
+		return nil, &common.UnsafeRemoteURLError{Err: err}
+	}
+
+	return parsed, nil
+}
+
+func NewSafeOutboundHTTPClient(base *http.Client, lookupIP LookupIPFunc) (*http.Client, error) {
+	if lookupIP == nil {
+		lookupIP = DefaultLookupIP
+	}
+	if base == nil {
+		base = http.DefaultClient
+	}
+
+	transport, err := cloneHTTPTransportInternal(base.Transport)
+	if err != nil {
+		return nil, err
+	}
+
+	baseDial := transport.DialContext
+	if baseDial == nil {
+		dialer := &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}
+		baseDial = dialer.DialContext
+	}
+
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, &common.UnsafeRemoteURLError{Err: err}
+		}
+
+		ips, err := resolveAllowedIPsInternal(ctx, host, lookupIP)
+		if err != nil {
+			return nil, err
+		}
+
+		var lastErr error
+		for _, ip := range ips {
+			conn, dialErr := baseDial(ctx, network, net.JoinHostPort(ip.String(), port))
+			if dialErr == nil {
+				return conn, nil
+			}
+			lastErr = dialErr
+		}
+
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, fmt.Errorf("failed to resolve remote host")
+	}
+
+	client := *base
+	client.Transport = transport
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		if _, err := ValidateSafeRemoteURL(req.Context(), req.URL.String(), lookupIP); err != nil {
+			return err
+		}
+		if base.CheckRedirect != nil {
+			return base.CheckRedirect(req, via)
+		}
+		return nil
+	}
+
+	return &client, nil
+}
+
+func cloneHTTPTransportInternal(base http.RoundTripper) (*http.Transport, error) {
+	switch t := base.(type) {
+	case nil:
+		return http.DefaultTransport.(*http.Transport).Clone(), nil
+	case *http.Transport:
+		return t.Clone(), nil
+	default:
+		return nil, fmt.Errorf("unsupported HTTP transport type %T", base)
+	}
+}
+
+func resolveAllowedIPsInternal(ctx context.Context, host string, lookupIP LookupIPFunc) ([]net.IP, error) {
+	if parsedIP := parseIPLiteralInternal(host); parsedIP != nil {
+		if isBlockedIPInternal(parsedIP) {
+			return nil, &common.UnsafeRemoteURLError{Err: fmt.Errorf("IP %s is not allowed", parsedIP.String())}
+		}
+		return []net.IP{parsedIP}, nil
+	}
+
+	ips, err := lookupIP(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+
+	allowed := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		if ip == nil {
+			continue
+		}
+		if isBlockedIPInternal(ip) {
+			return nil, &common.UnsafeRemoteURLError{Err: fmt.Errorf("IP %s is not allowed", ip.String())}
+		}
+		allowed = append(allowed, ip)
+	}
+
+	if len(allowed) == 0 {
+		return nil, &common.UnsafeRemoteURLError{Err: errors.New("host did not resolve to an allowed IP")}
+	}
+
+	return allowed, nil
+}
+
+func parseIPLiteralInternal(host string) net.IP {
+	host = strings.Trim(strings.TrimSpace(host), "[]")
+	if zoneIdx := strings.Index(host, "%"); zoneIdx != -1 {
+		host = host[:zoneIdx]
+	}
+	return net.ParseIP(host)
+}
+
+func isBlockedHostnameInternal(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "localhost" || strings.HasSuffix(host, ".localhost")
+}
+
+func isBlockedIPInternal(ip net.IP) bool {
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsMulticast() || ip.IsUnspecified() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return true
+	}
+
+	// net.IP helper methods do not cover every special-use range we want to keep
+	// off-limits for remote registry fetching, so we also check the explicit prefix list above.
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return true
+	}
+
+	for _, prefix := range blockedRemotePrefixes {
+		if prefix.Contains(addr.Unmap()) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func mustParsePrefixesInternal(raw ...string) []netip.Prefix {
+	prefixes := make([]netip.Prefix, 0, len(raw))
+	for _, cidr := range raw {
+		prefixes = append(prefixes, netip.MustParsePrefix(cidr))
+	}
+	return prefixes
+}

--- a/backend/pkg/utils/httpx/safe_remote_test.go
+++ b/backend/pkg/utils/httpx/safe_remote_test.go
@@ -1,0 +1,93 @@
+package httpx
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/getarcaneapp/arcane/backend/internal/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSafeRemoteURL(t *testing.T) {
+	lookupIP := func(ctx context.Context, host string) ([]net.IP, error) {
+		switch host {
+		case "registry.example.com":
+			return []net.IP{net.ParseIP("93.184.216.34")}, nil
+		case "internal.example.com":
+			return []net.IP{net.ParseIP("10.0.0.10")}, nil
+		default:
+			return nil, errors.New("unexpected host")
+		}
+	}
+
+	tests := []struct {
+		name    string
+		rawURL  string
+		wantErr bool
+	}{
+		{name: "allow public https", rawURL: "https://registry.example.com/templates.json"},
+		{name: "allow public http", rawURL: "http://registry.example.com/templates.json"},
+		{name: "reject missing host", rawURL: "https:///templates.json", wantErr: true},
+		{name: "reject unsupported scheme", rawURL: "ftp://registry.example.com/templates.json", wantErr: true},
+		{name: "reject schemeless", rawURL: "//registry.example.com/templates.json", wantErr: true},
+		{name: "reject credentials", rawURL: "https://user:pass@registry.example.com/templates.json", wantErr: true},
+		{name: "reject localhost", rawURL: "http://localhost:8080/templates.json", wantErr: true},
+		{name: "reject loopback literal", rawURL: "http://127.0.0.1:8080/templates.json", wantErr: true},
+		{name: "reject internal resolved host", rawURL: "https://internal.example.com/templates.json", wantErr: true},
+		{name: "reject file scheme", rawURL: "file:///etc/passwd", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := ValidateSafeRemoteURL(context.Background(), tt.rawURL, lookupIP)
+			if tt.wantErr {
+				require.Error(t, err)
+				var unsafeErr *common.UnsafeRemoteURLError
+				require.ErrorAs(t, err, &unsafeErr)
+				require.Nil(t, parsed)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, parsed)
+		})
+	}
+}
+
+func TestNewSafeOutboundHTTPClient_BlocksUnsafeRedirectTarget(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://127.0.0.1:8080/private", http.StatusFound)
+	}))
+	defer server.Close()
+
+	baseClient := newRedirectTestClient(server.Listener.Addr().String())
+	lookupIP := func(ctx context.Context, host string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+
+	client, err := NewSafeOutboundHTTPClient(baseClient, lookupIP)
+	require.NoError(t, err)
+
+	_, err = client.Get("http://registry.example.com/redirect")
+	require.Error(t, err)
+	var unsafeErr *common.UnsafeRemoteURLError
+	require.ErrorAs(t, err, &unsafeErr)
+}
+
+func newRedirectTestClient(listenerAddr string) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dialer := &net.Dialer{}
+		return dialer.DialContext(ctx, network, listenerAddr)
+	}
+
+	return &http.Client{
+		Transport: transport,
+		Timeout:   5 * time.Second,
+	}
+}

--- a/frontend/src/routes/(app)/containers/[containerId]/+page.svelte
+++ b/frontend/src/routes/(app)/containers/[containerId]/+page.svelte
@@ -199,9 +199,7 @@
 		return null;
 	}
 
-	const serviceComposeSourcePromise = $derived(
-		resolveServiceComposeSource(project, composeServiceName, composeInfo)
-	);
+	const serviceComposeSourcePromise = $derived(resolveServiceComposeSource(project, composeServiceName, composeInfo));
 
 	const showComposeTab = $derived(!!composeInfo && !!project);
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -769,6 +769,7 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
@@ -992,6 +993,7 @@ go.etcd.io/etcd/server/v3 v3.5.6/go.mod h1:6/Gfe8XTGXQJgLYQ65oGKMfPivb2EASLUSMSW
 go.mongodb.org/mongo-driver v1.7.5 h1:ny3p0reEpgsR2cfA5cjgwFZg3Cv/ofFh/8jbhGtz9VI=
 go.mongodb.org/mongo-driver v1.7.5/go.mod h1:VXEWRZ6URJIkUq2SCAyapmhH0ZLRBP+FT4xhp5Zvxng=
 go.mongodb.org/mongo-driver v1.17.6 h1:87JUG1wZfWsr6rIz3ZmpH90rL5tea7O3IHuSwHUpsss=
+go.mongodb.org/mongo-driver v1.17.6/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/detectors/gcp v1.38.0 h1:ZoYbqX7OaA/TAikspPl3ozPI6iY6LiIY9I8cUfm+pJs=
 go.opentelemetry.io/contrib/detectors/gcp v1.38.0/go.mod h1:SU+iU7nu5ud4oCb3LQOhIZ3nRLj6FNVrKgtflbaf2ts=


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds SSRF protection to the remote template registry fetching endpoint by introducing a `safe_remote.go` utility that validates URLs against blocked IP ranges, rejects private/loopback addresses (including DNS rebinding via per-connection re-resolution), and wraps an HTTP client to enforce safe redirects. The endpoint is also now gated behind authentication. Error messages are sanitized to avoid leaking internal details to clients.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the SSRF fix is structurally sound and all remaining findings are style/P2.

The core security fix (URL validation, IP range blocking, redirect re-validation, auth enforcement, error sanitization) is correct and well-tested. All open findings are P2: naming convention violations and one misleading test assertion. None affect correctness or security.

backend/pkg/utils/httpx/safe_remote.go (naming convention), backend/internal/services/template_service.go (client reuse)
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/pkg/utils/httpx/safe_remote.go`, line 144-225 ([link](https://github.com/getarcaneapp/arcane/blob/72ca909afa1e959a856c20729c662540f0732053/backend/pkg/utils/httpx/safe_remote.go#L144-L225)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unexported functions missing "Internal" suffix**

   Per the team's naming convention, all unexported functions must have the `Internal` suffix. The new `safe_remote.go` file introduces six unexported functions that don't follow this rule: `cloneHTTPTransport`, `resolveAllowedIPs`, `parseIPLiteral`, `isBlockedHostname`, `isBlockedIP`, and `mustParsePrefixes`. The same issue applies to `newSafeRequest` added in `template_service.go`.

   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/pkg/utils/httpx/safe_remote.go
   Line: 144-225
   
   Comment:
   **Unexported functions missing "Internal" suffix**
   
   Per the team's naming convention, all unexported functions must have the `Internal` suffix. The new `safe_remote.go` file introduces six unexported functions that don't follow this rule: `cloneHTTPTransport`, `resolveAllowedIPs`, `parseIPLiteral`, `isBlockedHostname`, `isBlockedIP`, and `mustParsePrefixes`. The same issue applies to `newSafeRequest` added in `template_service.go`.
   
   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Futils%2Fhttpx%2Fsafe_remote.go%0ALine%3A%20144-225%0A%0AComment%3A%0A**Unexported%20functions%20missing%20%22Internal%22%20suffix**%0A%0APer%20the%20team's%20naming%20convention%2C%20all%20unexported%20functions%20must%20have%20the%20%60Internal%60%20suffix.%20The%20new%20%60safe_remote.go%60%20file%20introduces%20six%20unexported%20functions%20that%20don't%20follow%20this%20rule%3A%20%60cloneHTTPTransport%60%2C%20%60resolveAllowedIPs%60%2C%20%60parseIPLiteral%60%2C%20%60isBlockedHostname%60%2C%20%60isBlockedIP%60%2C%20and%20%60mustParsePrefixes%60.%20The%20same%20issue%20applies%20to%20%60newSafeRequest%60%20added%20in%20%60template_service.go%60.%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Fpkg%2Futils%2Fhttpx%2Fsafe_remote.go%3A144-225%0A**Unexported%20functions%20missing%20%22Internal%22%20suffix**%0A%0APer%20the%20team's%20naming%20convention%2C%20all%20unexported%20functions%20must%20have%20the%20%60Internal%60%20suffix.%20The%20new%20%60safe_remote.go%60%20file%20introduces%20six%20unexported%20functions%20that%20don't%20follow%20this%20rule%3A%20%60cloneHTTPTransport%60%2C%20%60resolveAllowedIPs%60%2C%20%60parseIPLiteral%60%2C%20%60isBlockedHostname%60%2C%20%60isBlockedIP%60%2C%20and%20%60mustParsePrefixes%60.%20The%20same%20issue%20applies%20to%20%60newSafeRequest%60%20added%20in%20%60template_service.go%60.%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A%23%23%23%20Issue%202%20of%203%0Abackend%2Finternal%2Fhuma%2Fhandlers%2Ftemplates_fetch_test.go%3A74%0A**Misleading%20test%20assertion%20%E2%80%94%20colon%20never%20appears**%0A%0AThe%20assertion%20checks%20that%20%60%22Invalid%20JSON%20response%3A%22%60%20%28with%20a%20colon%29%20is%20absent%20from%20the%20response%20body.%20However%2C%20%60InvalidJSONResponseError.Error%28%29%60%20was%20changed%20in%20this%20PR%20to%20return%20%60%22Invalid%20JSON%20response%22%60%20%28no%20colon%29%2C%20so%20this%20assertion%20is%20always%20trivially%20true%20and%20doesn't%20actually%20verify%20that%20the%20old%20leaky%20format%20is%20gone.%20Changing%20the%20assertion%20to%20check%20for%20the%20colon-less%20form%20would%20make%20the%20intent%20clear.%0A%0A%60%60%60suggestion%0A%09require.NotContains%28t%2C%20rec.Body.String%28%29%2C%20%22Invalid%20JSON%20response%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Abackend%2Finternal%2Fservices%2Ftemplate_service.go%3A748-765%0A**New%20safe%20HTTP%20client%20constructed%20on%20every%20request**%0A%0A%60NewSafeOutboundHTTPClient%60%20clones%20the%20transport%20and%20allocates%20a%20new%20%60http.Client%60%20wrapper%20on%20each%20call%20to%20%60newSafeRequest%60.%20Because%20Go's%20%60http.Client%60%20is%20designed%20to%20be%20reused%20%28it%20maintains%20an%20internal%20connection%20pool%20via%20%60Transport%60%29%2C%20creating%20a%20fresh%20clone%20per%20request%20bypasses%20connection%20keep-alive%20and%20can%20exhaust%20file%20descriptors%20under%20load.%20Consider%20building%20the%20safe%20client%20once%20%28e.g.%2C%20during%20%60TemplateService%60%20construction%29%20and%20reusing%20it%20across%20calls.%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/utils/httpx/safe_remote.go
Line: 144-225

Comment:
**Unexported functions missing "Internal" suffix**

Per the team's naming convention, all unexported functions must have the `Internal` suffix. The new `safe_remote.go` file introduces six unexported functions that don't follow this rule: `cloneHTTPTransport`, `resolveAllowedIPs`, `parseIPLiteral`, `isBlockedHostname`, `isBlockedIP`, and `mustParsePrefixes`. The same issue applies to `newSafeRequest` added in `template_service.go`.

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/huma/handlers/templates_fetch_test.go
Line: 74

Comment:
**Misleading test assertion — colon never appears**

The assertion checks that `"Invalid JSON response:"` (with a colon) is absent from the response body. However, `InvalidJSONResponseError.Error()` was changed in this PR to return `"Invalid JSON response"` (no colon), so this assertion is always trivially true and doesn't actually verify that the old leaky format is gone. Changing the assertion to check for the colon-less form would make the intent clear.

```suggestion
	require.NotContains(t, rec.Body.String(), "Invalid JSON response")
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/services/template_service.go
Line: 748-765

Comment:
**New safe HTTP client constructed on every request**

`NewSafeOutboundHTTPClient` clones the transport and allocates a new `http.Client` wrapper on each call to `newSafeRequest`. Because Go's `http.Client` is designed to be reused (it maintains an internal connection pool via `Transport`), creating a fresh clone per request bypasses connection keep-alive and can exhaust file descriptors under load. Consider building the safe client once (e.g., during `TemplateService` construction) and reusing it across calls.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: validate and secure remote template..."](https://github.com/getarcaneapp/arcane/commit/72ca909afa1e959a856c20729c662540f0732053) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27949028)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->