### PR TITLE
fix: restore streaming remote proxy bodies and bound edge proxy uploads

### DIFF
--- a/backend/internal/common/errors.go
+++ b/backend/internal/common/errors.go
@@ -450,6 +450,21 @@ func (e *FileUploadReadError) Error() string {
 	return fmt.Sprintf("Failed to read upload: %v", e.Err)
 }
 
+type RequestBodyTooLargeError struct {
+	LimitBytes int64
+}
+
+func (e *RequestBodyTooLargeError) Error() string {
+	limitMB := e.LimitBytes / (1024 * 1024)
+	if e.LimitBytes%(1024*1024) != 0 {
+		limitMB++
+	}
+	if limitMB == 0 && e.LimitBytes > 0 {
+		limitMB = 1
+	}
+	return fmt.Sprintf("Request body exceeds maximum allowed size of %d MB", limitMB)
+}
+
 type NoFileUploadedError struct{}
 
 func (e *NoFileUploadedError) Error() string {

--- a/backend/internal/middleware/environment_middleware.go
+++ b/backend/internal/middleware/environment_middleware.go
@@ -1,10 +1,8 @@
 package middleware
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"path"
@@ -404,25 +402,14 @@ func (m *EnvironmentMiddleware) proxyHTTP(c *gin.Context, target string, accessT
 
 // createProxyRequest builds the HTTP request to forward to the remote environment.
 func (m *EnvironmentMiddleware) createProxyRequest(c *gin.Context, target string, accessToken *string) (*http.Request, error) {
-	var bodyBytes []byte
-	if c.Request.Body != nil {
-		var err error
-		bodyBytes, err = io.ReadAll(c.Request.Body)
-		_ = c.Request.Body.Close()
-		if err != nil {
-			return nil, fmt.Errorf("failed to read request body: %w", err)
-		}
-	}
+	slog.DebugContext(c.Request.Context(), "Creating proxy request",
+		"method", c.Request.Method,
+		"target", target,
+		"contentLength", c.Request.ContentLength,
+		"contentType", c.GetHeader("Content-Type"),
+	)
 
-	slog.DebugContext(c.Request.Context(), "Creating proxy request", "method", c.Request.Method, "target", target, "contentLength", c.Request.ContentLength, "contentType", c.GetHeader("Content-Type"), "bodyLength", len(bodyBytes), "body", string(bodyBytes))
-
-	// bytes.NewReader is preferred over bytes.NewBuffer: it implements io.ReadSeeker
-	// and avoids the internal grow-buffer logic that NewBuffer carries.
-	var body io.Reader
-	if len(bodyBytes) > 0 {
-		body = bytes.NewReader(bodyBytes)
-	}
-	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, target, body)
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, target, c.Request.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -433,9 +420,8 @@ func (m *EnvironmentMiddleware) createProxyRequest(c *gin.Context, target string
 	edge.SetAgentToken(req, accessToken)
 	edge.SetForwardedHeaders(req, c.ClientIP(), c.Request.Host)
 
-	// Set Content-Length based on actual body size
-	if len(bodyBytes) > 0 {
-		req.ContentLength = int64(len(bodyBytes))
+	if c.Request.ContentLength >= 0 {
+		req.ContentLength = c.Request.ContentLength
 	}
 
 	return req, nil

--- a/backend/internal/middleware/environment_middleware_test.go
+++ b/backend/internal/middleware/environment_middleware_test.go
@@ -1,24 +1,33 @@
 package middleware
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/edge"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestEnvironmentMiddleware() *EnvironmentMiddleware {
+	return newTestEnvironmentMiddlewareWithResolver(func(ctx context.Context, id string) (string, *string, bool, error) {
+		_ = ctx
+		return "edge://oracle-1", nil, true, nil
+	})
+}
+
+func newTestEnvironmentMiddlewareWithResolver(resolver EnvResolver) *EnvironmentMiddleware {
 	return &EnvironmentMiddleware{
 		localID:   "0",
 		paramName: "id",
-		resolver: func(ctx context.Context, id string) (string, *string, bool, error) {
-			_ = ctx
-			return "edge://oracle-1", nil, true, nil
-		},
+		resolver:  resolver,
 		authValidator: func(ctx context.Context, c *gin.Context) bool {
 			_ = ctx
 			_ = c
@@ -27,6 +36,89 @@ func newTestEnvironmentMiddleware() *EnvironmentMiddleware {
 		httpClient: &http.Client{Timeout: proxyTimeout},
 		registry:   edge.NewTunnelRegistry(),
 	}
+}
+
+func TestEnvironmentMiddleware_ProxyHTTPStreamsRequestBodyToRemote(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var (
+		receivedBody          string
+		receivedPath          string
+		receivedContentType   string
+		receivedContentLength int64
+	)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		receivedBody = string(body)
+		receivedPath = r.URL.Path
+		receivedContentType = r.Header.Get("Content-Type")
+		receivedContentLength = r.ContentLength
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"proxied":true}`))
+	}))
+	defer upstream.Close()
+
+	middleware := newTestEnvironmentMiddlewareWithResolver(func(ctx context.Context, id string) (string, *string, bool, error) {
+		_ = ctx
+		_ = id
+		return upstream.URL, nil, true, nil
+	})
+
+	router := gin.New()
+	api := router.Group("/api")
+	api.Use(middleware.Handle)
+
+	localHandlerHit := false
+	api.POST("/environments/:id/projects", func(c *gin.Context) {
+		localHandlerHit = true
+		c.JSON(http.StatusOK, gin.H{"success": true})
+	})
+
+	requestBody := `{"name":"remote project"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/environments/env-remote/projects?from=test", strings.NewReader(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusCreated, recorder.Code)
+	assert.Equal(t, `{"proxied":true}`, recorder.Body.String())
+	assert.Equal(t, "/api/environments/0/projects", receivedPath)
+	assert.Equal(t, "application/json", receivedContentType)
+	assert.Equal(t, int64(len(requestBody)), receivedContentLength)
+	assert.Equal(t, requestBody, receivedBody)
+	assert.False(t, localHandlerHit)
+}
+
+func TestEnvironmentMiddleware_CreateProxyRequestDoesNotLogRequestBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var logBuffer bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(originalLogger)
+
+	middleware := newTestEnvironmentMiddleware()
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+
+	secretBody := "super-secret-payload"
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/environments/env-remote/projects", strings.NewReader(secretBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	req, err := middleware.createProxyRequest(c, "https://example.com/api/environments/0/projects", nil)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+
+	output := logBuffer.String()
+	assert.Contains(t, output, "Creating proxy request")
+	assert.NotContains(t, output, secretBody)
+	assert.NotContains(t, output, " body=")
 }
 
 func TestEnvironmentMiddleware_ReturnsBadGatewayForEdgeResourcesWithoutTunnel(t *testing.T) {

--- a/backend/pkg/libarcane/edge/proxy.go
+++ b/backend/pkg/libarcane/edge/proxy.go
@@ -3,12 +3,14 @@ package edge
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"time"
 
+	"github.com/getarcaneapp/arcane/backend/internal/common"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
@@ -19,6 +21,15 @@ const (
 	// DefaultTunnelAcquirePollEvery is how frequently the manager checks for a
 	// newly activated edge tunnel while waiting for poll mode to connect.
 	DefaultTunnelAcquirePollEvery = 100 * time.Millisecond
+)
+
+var (
+	errProxyRequestBodyTooLarge = errors.New("proxy request body too large")
+
+	// maxBufferedProxyRequestBodyBytes caps manager-side buffering for edge tunnel
+	// requests. The tunnel protocol still forwards request bodies as []byte, so
+	// we fail fast once a request exceeds the compatibility ceiling.
+	maxBufferedProxyRequestBodyBytes int64 = 500 * 1024 * 1024
 )
 
 // DefaultTunnelAcquireTimeout returns a poll-aware wait timeout for acquiring
@@ -163,17 +174,10 @@ func ProxyHTTPRequest(c *gin.Context, tunnel *AgentTunnel, targetPath string) {
 	defer cancel()
 
 	// Read request body
-	var body []byte
-	if c.Request.Body != nil {
-		var err error
-		body, err = io.ReadAll(c.Request.Body)
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed to read request body for tunnel proxy", "error", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read request body"})
-			return
-		}
-		// Restore body for potential retry
-		c.Request.Body = io.NopCloser(bytes.NewReader(body))
+	body, err := readBufferedProxyRequestBody(c.Request, maxBufferedProxyRequestBodyBytes)
+	if err != nil {
+		writeProxyRequestBodyError(c, ctx, err)
+		return
 	}
 
 	// Build headers map, stripping hop-by-hop and browser-security headers.
@@ -223,6 +227,42 @@ func ProxyHTTPRequest(c *gin.Context, tunnel *AgentTunnel, targetPath string) {
 
 	// Write response
 	c.Data(status, respHeaders["Content-Type"], respBody)
+}
+
+func readBufferedProxyRequestBody(req *http.Request, maxBytes int64) ([]byte, error) {
+	if req == nil || req.Body == nil {
+		return nil, nil
+	}
+	if maxBytes > 0 && req.ContentLength > maxBytes {
+		return nil, errProxyRequestBodyTooLarge
+	}
+
+	body, err := io.ReadAll(io.LimitReader(req.Body, maxBytes+1))
+	_ = req.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, errProxyRequestBodyTooLarge
+	}
+
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.ContentLength = int64(len(body))
+
+	return body, nil
+}
+
+func writeProxyRequestBodyError(c *gin.Context, ctx context.Context, err error) {
+	if errors.Is(err, errProxyRequestBodyTooLarge) {
+		slog.WarnContext(ctx, "Rejected oversized request body for edge tunnel proxy", "contentLength", c.Request.ContentLength, "limitBytes", maxBufferedProxyRequestBodyBytes)
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": (&common.RequestBodyTooLargeError{
+			LimitBytes: maxBufferedProxyRequestBodyBytes,
+		}).Error()})
+		return
+	}
+
+	slog.ErrorContext(ctx, "Failed to read request body for tunnel proxy", "error", err)
+	c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read request body"})
 }
 
 // isHopByHopHeader returns true if the header should not be forwarded

--- a/backend/pkg/libarcane/edge/proxy_test.go
+++ b/backend/pkg/libarcane/edge/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -20,6 +21,27 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
+
+type repeatedByteReader struct {
+	remaining int
+}
+
+func (r *repeatedByteReader) Read(p []byte) (int, error) {
+	if r.remaining == 0 {
+		return 0, io.EOF
+	}
+
+	n := len(p)
+	if n > r.remaining {
+		n = r.remaining
+	}
+	for i := range n {
+		p[i] = 'x'
+	}
+	r.remaining -= n
+
+	return n, nil
+}
 
 // setupMockAgentServer creates a WS server that acts as an agent
 // It receives requests and sends back responses
@@ -235,6 +257,40 @@ func TestProxyHTTPRequest_GRPCTunnel(t *testing.T) {
 	assert.Equal(t, `{"success":true}`, w.Body.String())
 
 	require.NoError(t, <-agentErrCh)
+}
+
+func TestProxyHTTPRequest_RejectsOversizedBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	originalLimit := maxBufferedProxyRequestBodyBytes
+	maxBufferedProxyRequestBodyBytes = 8
+	defer func() {
+		maxBufferedProxyRequestBodyBytes = originalLimit
+	}()
+
+	requestForwarded := false
+	server, tunnel := setupMockAgentServer(t, func(msg *TunnelMessage) *TunnelMessage {
+		requestForwarded = true
+		return &TunnelMessage{
+			ID:     msg.ID,
+			Type:   MessageTypeResponse,
+			Status: http.StatusOK,
+			Body:   []byte("ok"),
+		}
+	})
+	defer server.Close()
+	defer func() { _ = tunnel.Close() }()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/test", &repeatedByteReader{remaining: 9})
+	c.Request.ContentLength = -1
+
+	ProxyHTTPRequest(c, tunnel, "/target/path")
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+	assert.Contains(t, w.Body.String(), "Request body exceeds maximum allowed size of 1 MB")
+	assert.False(t, requestForwarded)
 }
 
 func TestDoRequest(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->
