### PR TITLE
fix: truncate long image refs in container table (#1903)

### DIFF
--- a/frontend/src/routes/(app)/containers/container-table.svelte
+++ b/frontend/src/routes/(app)/containers/container-table.svelte
@@ -7,7 +7,7 @@
 	import type { SearchPaginationSortRequest } from '$lib/types/pagination.type';
 	import StatusBadge from '$lib/components/badges/status-badge.svelte';
 	import { format } from 'date-fns';
-	import { capitalizeFirstLetter } from '$lib/utils/string.utils';
+	import { capitalizeFirstLetter, truncateImageDigest } from '$lib/utils/string.utils';
 	import type { ContainerSummaryDto } from '$lib/types/container.type';
 	import type { ColumnSpec, BulkAction } from '$lib/components/arcane-table';
 	import { m } from '$lib/paraglide/messages';
@@ -228,7 +228,7 @@
 	const columns = $derived([
 		{ accessorKey: 'id', title: m.common_id(), cell: IdCell, hidden: true },
 		{ accessorKey: 'names', id: 'name', title: m.common_name(), sortable: !groupByProject, cell: NameCell },
-		{ accessorKey: 'image', title: m.common_image(), sortable: !groupByProject, cell: ImageCell },
+		{ accessorKey: 'image', title: m.common_image(), sortable: !groupByProject, cell: ImageCell, truncate: true },
 		{ accessorKey: 'state', title: m.common_state(), sortable: !groupByProject, cell: StateCell },
 		{
 			id: 'updates',
@@ -429,13 +429,13 @@
 
 {#snippet ImageCell({ item }: { item: ContainerSummaryDto })}
 	<ArcaneTooltip.Root>
-		<ArcaneTooltip.Trigger>
-			<span class="block w-full cursor-default truncate text-left">
-				{item.image}
+		<ArcaneTooltip.Trigger class="block w-full min-w-0">
+			<span class="block w-full cursor-default truncate text-left font-mono text-xs">
+				{truncateImageDigest(item.image)}
 			</span>
 		</ArcaneTooltip.Trigger>
 		<ArcaneTooltip.Content>
-			<p>{item.image}</p>
+			<p class="max-w-xl break-all">{item.image}</p>
 		</ArcaneTooltip.Content>
 	</ArcaneTooltip.Root>
 {/snippet}


### PR DESCRIPTION
## Summary

Fixes #1903. Containers running long image refs — typically digest-pinned ones like `ghcr.io/org/looooong-name@sha256:abcdef1234567890…` — stretched the Image column and pushed everything else (state, updates, cpu/mem, ports, created) off the right edge of the table. The column already had a \`truncate\` class on the inner \`<span>\`, but the surrounding \`<td>\` had no width constraint, so the span just grew to fit the text.

## Fix

Three small, isolated changes in the container table:

1. **Opt the image column into the arcane-table built-in truncation** via \`truncate: true\` on the column spec. The table already supports this — it applies \`max-w-0 truncate\` to the \`<td>\`, which is exactly what makes a flex-grow table cell actually clip instead of expand. No infrastructure changes needed.
2. **Collapse the sha256 digest** to 7 chars using the existing \`truncateImageDigest\` helper, so the visible text reads \`ghcr.io/org/name@sha256:abcdef1\` instead of showing a long hex string that the ellipsis immediately eats.
3. **Mono + xs font** in the cell so more characters fit before the ellipsis kicks in, and **\`break-all\`** in the tooltip so the full reference wraps nicely and is still copy-pasteable on hover.

Matches the UX the issue asked for (\"like the Volumes view\"): visibly short in the column, full content available on hover.

## Test plan

- [ ] Run a container with a long digest-pinned image (e.g. \`docker run --pull always -d nginx@sha256:<any-digest>\`) and confirm the Image cell no longer pushes other columns off-screen
- [ ] Hover the truncated cell → tooltip shows the full original image ref
- [ ] Short image refs (\`nginx:latest\`) still render unchanged
- [ ] Resize the browser — column clips at whatever width the table gives it
- [ ] Run \`pnpm svelte-check\` — no new errors from container-table.svelte

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes long image refs (especially digest-pinned ones like `ghcr.io/org/name@sha256:abc…`) stretching the Image column in the container table by adding `truncate: true` to the column spec, collapsing the sha256 digest to 7 chars via the existing `truncateImageDigest` helper, and improving tooltip display with `break-all`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is isolated to the container table's image cell and uses existing, proven infrastructure.

All three changes are correct and well-targeted: the column-level `truncate: true` is the core mechanism that actually constrains the cell, `truncateImageDigest` is an existing tested helper, and `image` is typed as `string` so the `.replace()` call is safe. No logic errors, no regressions identified.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: truncate long image refs in contain..."](https://github.com/getarcaneapp/arcane/commit/61b24a47d863907ae667c15083b8b81c44bf5795) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27967868)</sub>

<!-- /greptile_comment -->