### PR TITLE
fix: preserve editor state after save to prevent compose editor revert

### DIFF
--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -404,8 +404,7 @@
 
 				// Match the signature to data.project (the stale page-load value)
 				// so the $effect guard doesn't re-apply old content to the editor.
-				const currentPageProject = withLoadedProjectFileContent(data.project);
-				lastSeenProjectSignature = buildProjectSyncSignature(currentPageProject);
+				lastSeenProjectSignature = buildProjectSyncSignature(data.project);
 
 				toast.success(m.common_update_success({ resource: m.project() }));
 			}

--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -386,12 +386,27 @@
 					}
 				}
 
-				applyProjectDetailsToEditor(savedProject, 'saved');
-				// Pass the enriched project (with locally-preserved include file
-				// content) to the query cache so that any reactive re-read after
-				// save doesn't revert the editor to the lazy-loaded (content-less)
-				// server response.
-				await syncProjectQueries(withLoadedProjectFileContent(savedProject));
+				// Preserve the editor's current values as the new baseline rather
+				// than re-applying the server response via applyProjectDetailsToEditor,
+				// which triggers a reactive chain that reverts the editor content.
+				originalName = $inputs.name.value;
+				originalComposeContent = $inputs.composeContent.value;
+				originalEnvContent = $inputs.envContent.value;
+				originalIncludeFiles = { ...includeFilesState };
+
+				// Update the project object for runtime info (status, services, etc.)
+				// without touching the editor inputs.
+				const enriched = withLoadedProjectFileContent(savedProject);
+				project = enriched;
+				syncIncludeFileUiState(enriched);
+
+				await syncProjectQueries(enriched);
+
+				// Match the signature to data.project (the stale page-load value)
+				// so the $effect guard doesn't re-apply old content to the editor.
+				const currentPageProject = withLoadedProjectFileContent(data.project);
+				lastSeenProjectSignature = buildProjectSyncSignature(currentPageProject);
+
 				toast.success(m.common_update_success({ resource: m.project() }));
 			}
 		});


### PR DESCRIPTION
## Summary

After saving compose file changes on the project Configuration page, the editor reverts to the pre-edit content. A page refresh shows the correct saved content — the save itself succeeds, but the editor state is overwritten.

## Root cause

After a successful save, `applyProjectDetailsToEditor(savedProject, 'saved')` re-applies the server response to the editor, then `syncProjectQueries` updates the query cache. The `$effect` that watches `data.project` (the stale page-load value) then fires: it builds a signature from the old `data.project.composeContent`, sees it differs from `lastSeenProjectSignature` (set from the server response), passes the guard, and calls `applyProjectDetailsToEditor` again with the old content — reverting the editor.

## Fix

- Skip `applyProjectDetailsToEditor` after save entirely. Instead, set the editor's original-value baselines directly from the current editor inputs (so `hasChanges` resets to false).
- Update the `project` object for runtime info (status, services) without touching editor inputs.
- Set `lastSeenProjectSignature` from `data.project` (the stale page-load value) so the `$effect` guard sees no difference and doesn't re-apply old content.

## Files

- `frontend/src/routes/(app)/projects/[projectId]/+page.svelte`

## Test plan

- [ ] Edit root compose.yml on the project Configuration page, save — editor retains the edit
- [ ] Edit an include file, save — editor retains the edit
- [ ] Refresh the page after save — content matches what was saved
- [ ] Navigate away and back — page loads fresh data correctly

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an editor revert bug on the project Configuration page where, after a save, the compose editor would revert to the pre-edit content until a page refresh. The fix replaces the `applyProjectDetailsToEditor(savedProject, 'saved')` call with a direct baseline update from the current editor inputs and sets `lastSeenProjectSignature` to match the stale `data.project`, so the `$effect` guard comparing signatures sees no difference and skips the revert-causing re-apply.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix correctly breaks the reactive chain that caused the editor revert with no regressions in the analyzed paths.

The root cause analysis in the PR description is accurate, and the implementation handles all traced edge cases correctly: the buildProjectSyncSignature equality holds between data.project and withLoadedProjectFileContent(data.project) (content fields are never read by the signature function), lastAppliedProjectId is unchanged but remains correct since the project ID never changes on save, and the hasChanges = false invariant after the baseline update ensures any subsequent $effect re-fire from a query-invalidation refetch applies the saved content rather than reverting. No P0 or P1 findings.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["style: remove redundant withLoadedProjec..."](https://github.com/getarcaneapp/arcane/commit/0890179fe34f2d1a924d5fdbd05458be406e9a46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27970249)</sub>

<!-- /greptile_comment -->