### PR TITLE
fix: project icons not loading when used with yaml/env aliases

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -561,7 +561,13 @@ func (s *ProjectService) GetProjectServices(ctx context.Context, projectID strin
 		return []ProjectServiceInfo{}, fmt.Errorf("no compose file found in project directory: %s", projectFromDb.Path)
 	}
 
-	meta, metaErr := projects.ParseArcaneComposeMetadata(ctx, composeFileFullPath)
+	projectsDirectory, projectsDirErr := s.getProjectsDirectoryInternal(ctx)
+	if projectsDirErr != nil {
+		slog.WarnContext(ctx, "failed to resolve projects directory for Arcane compose metadata", "path", composeFileFullPath, "error", projectsDirErr)
+	}
+	autoInjectEnv := s.settingsService.GetBoolSetting(ctx, "autoInjectEnv", false)
+
+	meta, metaErr := projects.ParseArcaneComposeMetadata(ctx, composeFileFullPath, projectsDirectory, autoInjectEnv)
 	if metaErr != nil {
 		slog.WarnContext(ctx, "failed to parse Arcane compose metadata", "path", composeFileFullPath, "error", metaErr)
 	}
@@ -3096,7 +3102,13 @@ func (s *ProjectService) getProjectMetadataForProject(ctx context.Context, p mod
 		return projects.ArcaneComposeMetadata{ServiceIcons: map[string]string{}}
 	}
 
-	meta, err := projects.ParseArcaneComposeMetadata(ctx, composeFile)
+	projectsDirectory, projectsDirErr := s.getProjectsDirectoryInternal(ctx)
+	if projectsDirErr != nil {
+		slog.WarnContext(ctx, "failed to resolve projects directory for Arcane compose metadata", "path", composeFile, "error", projectsDirErr)
+	}
+	autoInjectEnv := s.settingsService.GetBoolSetting(ctx, "autoInjectEnv", false)
+
+	meta, err := projects.ParseArcaneComposeMetadata(ctx, composeFile, projectsDirectory, autoInjectEnv)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to parse Arcane compose metadata", "path", composeFile, "error", err)
 		return projects.ArcaneComposeMetadata{ServiceIcons: map[string]string{}}

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -1786,6 +1786,54 @@ func TestProjectService_SyncProjectsFromFileSystem_DiscoversNestedProjectsAndRel
 	assert.Equal(t, "project2", items[1].DirName)
 }
 
+func TestProjectService_ListProjects_LoadsProjectIconFromGlobalEnvInIncludedMetadata(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectsRoot := t.TempDir()
+	projectPath := filepath.Join(projectsRoot, "demo")
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectsRoot, projects.GlobalEnvFileName),
+		[]byte("ICON_CDN_URL=https://cdn.jsdelivr.net/gh/selfhst/icons@main\n"),
+		0o600,
+	))
+
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte(`include:
+  - metadata.yaml
+services:
+  watchtower:
+    image: nickfedor/watchtower:latest
+`), 0o600))
+
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "metadata.yaml"), []byte(`x-watchtower-icon: &watchtower-icon "${ICON_CDN_URL:+${ICON_CDN_URL}/svg/watchtower.svg}"
+x-arcane:
+  icon: *watchtower-icon
+services:
+  watchtower:
+    labels:
+      com.getarcaneapp.arcane.icon: *watchtower-icon
+`), 0o600))
+
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, config.Load())
+	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
+
+	items, page, err := svc.ListProjects(ctx, pagination.QueryParams{
+		SortParams:       pagination.SortParams{Sort: "path", Order: pagination.SortAsc},
+		PaginationParams: pagination.PaginationParams{Limit: -1},
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, page.TotalItems)
+	require.Len(t, items, 1)
+	assert.Equal(t, "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/watchtower.svg", items[0].IconURL)
+}
+
 func TestProjectService_CountProjectFolders_RecursivelyCountsNestedProjects(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()

--- a/backend/pkg/projects/custom_labels.go
+++ b/backend/pkg/projects/custom_labels.go
@@ -36,9 +36,24 @@ type ArcaneComposeMetadata struct {
 }
 
 // ParseArcaneComposeMetadata reads a Docker Compose file and extracts Arcane-specific metadata.
-func ParseArcaneComposeMetadata(ctx context.Context, composeFilePath string) (ArcaneComposeMetadata, error) {
+// When projectsDirectory is set, Arcane's project env loading is used so .env.global is available.
+func ParseArcaneComposeMetadata(ctx context.Context, composeFilePath, projectsDirectory string, autoInjectEnv bool) (ArcaneComposeMetadata, error) {
+	if composeFilePath == "" {
+		return ArcaneComposeMetadata{ServiceIcons: map[string]string{}}, nil
+	}
+
 	workdir := filepath.Dir(composeFilePath)
-	envMap := loadComposeEnvironment(workdir)
+	if strings.TrimSpace(projectsDirectory) == "" {
+		envMap := loadComposeEnvironment(workdir)
+		return ParseArcaneComposeMetadataWithEnv(ctx, composeFilePath, envMap)
+	}
+
+	envLoader := NewEnvLoader(projectsDirectory, workdir, autoInjectEnv)
+	envMap, _, err := envLoader.LoadEnvironment(ctx)
+	if err != nil {
+		return ArcaneComposeMetadata{ServiceIcons: map[string]string{}}, fmt.Errorf("load project environment: %w", err)
+	}
+
 	return ParseArcaneComposeMetadataWithEnv(ctx, composeFilePath, envMap)
 }
 

--- a/backend/pkg/projects/custom_labels_test.go
+++ b/backend/pkg/projects/custom_labels_test.go
@@ -28,7 +28,7 @@ x-arcane:
 	composePath := filepath.Join(tempDir, "compose.yaml")
 	require.NoError(t, os.WriteFile(composePath, []byte(composeContent), 0o600))
 
-	meta, err := ParseArcaneComposeMetadata(context.Background(), composePath)
+	meta, err := ParseArcaneComposeMetadata(context.Background(), composePath, tempDir, false)
 	require.NoError(t, err)
 	require.Equal(t, "https://cdn.jsdelivr.net/gh/homarr-labs/webp/raspberry-pi.webp", meta.ProjectIconURL)
 	require.Equal(t, []string{"https://www.example.com"}, meta.ProjectURLS)
@@ -53,8 +53,64 @@ services:
 `
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "meta.yaml"), []byte(metaContent), 0o600))
 
-	meta, err := ParseArcaneComposeMetadata(context.Background(), composePath)
+	meta, err := ParseArcaneComposeMetadata(context.Background(), composePath, tempDir, false)
 	require.NoError(t, err)
 	require.Equal(t, "https://example.com/icon.png", meta.ProjectIconURL)
 	require.Equal(t, []string{"https://example.com/docs"}, meta.ProjectURLS)
+}
+
+func TestParseArcaneComposeMetadata_LoadsGlobalEnvForIncludedMetadata(t *testing.T) {
+	projectsRoot := t.TempDir()
+	projectDir := filepath.Join(projectsRoot, "demo")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectsRoot, GlobalEnvFileName),
+		[]byte("ICON_CDN_URL=https://cdn.jsdelivr.net/gh/selfhst/icons@main\n"),
+		0o600,
+	))
+
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "compose.yaml"), []byte(`include:
+  - metadata.yaml
+services:
+  watchtower:
+    image: nickfedor/watchtower:latest
+`), 0o600))
+
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "metadata.yaml"), []byte(`x-watchtower-icon: &watchtower-icon "${ICON_CDN_URL:+${ICON_CDN_URL}/svg/watchtower.svg}"
+x-arcane:
+  icon: *watchtower-icon
+`), 0o600))
+
+	meta, err := ParseArcaneComposeMetadata(context.Background(), filepath.Join(projectDir, "compose.yaml"), projectsRoot, false)
+	require.NoError(t, err)
+	require.Equal(t, "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/watchtower.svg", meta.ProjectIconURL)
+}
+
+func TestParseArcaneComposeMetadata_LoadsGlobalEnvForNestedProjects(t *testing.T) {
+	projectsRoot := t.TempDir()
+	projectDir := filepath.Join(projectsRoot, "group", "demo")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectsRoot, GlobalEnvFileName),
+		[]byte("ICON_CDN_URL=https://cdn.jsdelivr.net/gh/selfhst/icons@main\n"),
+		0o600,
+	))
+
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "compose.yaml"), []byte(`include:
+  - metadata.yaml
+services:
+  watchtower:
+    image: nickfedor/watchtower:latest
+`), 0o600))
+
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "metadata.yaml"), []byte(`x-watchtower-icon: &watchtower-icon "${ICON_CDN_URL:+${ICON_CDN_URL}/svg/watchtower.svg}"
+x-arcane:
+  icon: *watchtower-icon
+`), 0o600))
+
+	meta, err := ParseArcaneComposeMetadata(context.Background(), filepath.Join(projectDir, "compose.yaml"), projectsRoot, false)
+	require.NoError(t, err)
+	require.Equal(t, "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/watchtower.svg", meta.ProjectIconURL)
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2322

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes project icons failing to load when Docker Compose files use YAML aliases referencing variables from `.env.global` (the projects-root global env file). The fix threads `projectsDirectory` and `autoInjectEnv` into `ParseArcaneComposeMetadata`, so the full `EnvLoader` path (which reads `.env.global`) is used instead of the narrower `loadComposeEnvironment` fallback that only reads the project-local `.env`. Both changed call sites in `project_service.go` fall back gracefully to the old behavior when the projects directory cannot be resolved.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is well-scoped, degrades gracefully on error, and is covered by new unit and integration-style tests.

The change is minimal and correctness-focused: a wider env loader replaces a narrower one, the old path is preserved as a fallback when projectsDirectory is empty or fails, error handling is consistent with existing patterns, and three new tests verify the happy path. No new unexported functions are introduced, so naming-convention rules are not affected.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: project icons not loading when used..."](https://github.com/getarcaneapp/arcane/commit/e0ea61cb9f27d026f222c57ff3ca7fec43ab4116) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28018534)</sub>

<!-- /greptile_comment -->