### PR TITLE
fix: project max depth not working for filesystem discovery

### DIFF
--- a/backend/internal/bootstrap/jobs_bootstrap.go
+++ b/backend/internal/bootstrap/jobs_bootstrap.go
@@ -34,7 +34,7 @@ func registerJobs(appCtx context.Context, newScheduler *pkg_scheduler.JobSchedul
 	scheduledPruneJob := pkg_scheduler.NewScheduledPruneJob(appServices.System, appServices.Settings, appServices.Notification)
 	newScheduler.RegisterJob(scheduledPruneJob)
 
-	fsWatcherJob, err := pkg_scheduler.RegisterFilesystemWatcherJob(appCtx, appServices.Project, appServices.Template, appServices.Settings)
+	fsWatcherJob, err := pkg_scheduler.RegisterFilesystemWatcherJob(appCtx, appServices.Project, appServices.Template, appServices.Settings, appConfig.ProjectScanMaxDepth)
 	if err != nil {
 		slog.ErrorContext(appCtx, "Failed to register filesystem watcher job", "error", err)
 	}

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -903,7 +903,7 @@ func (s *ProjectService) SyncProjectsFromFileSystem(ctx context.Context) error {
 		return nil
 	}
 
-	discoveredProjects, discoveryErr := projects.DiscoverProjectDirectories(projectsDir, followProjectSymlinks)
+	discoveredProjects, discoveryErr := projects.DiscoverProjectDirectories(projectsDir, followProjectSymlinks, s.config.ProjectScanMaxDepth)
 	if discoveryErr != nil {
 		if os.IsNotExist(discoveryErr) {
 			return nil
@@ -1088,7 +1088,7 @@ func (s *ProjectService) countProjectFolders(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 
-	discoveredProjects, discoveryErr := projects.DiscoverProjectDirectories(projectsDir, followProjectSymlinks)
+	discoveredProjects, discoveryErr := projects.DiscoverProjectDirectories(projectsDir, followProjectSymlinks, s.config.ProjectScanMaxDepth)
 	if discoveryErr != nil {
 		return 0, fmt.Errorf("failed to discover project directories in %s: %w", projectsDir, discoveryErr)
 	}

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -1786,6 +1786,30 @@ func TestProjectService_SyncProjectsFromFileSystem_DiscoversNestedProjectsAndRel
 	assert.Equal(t, "project2", items[1].DirName)
 }
 
+func TestProjectService_SyncProjectsFromFileSystem_RespectsConfiguredScanMaxDepth(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectsRoot := t.TempDir()
+	topLevelPath := createComposeProjectDir(t, projectsRoot, "project1")
+	createComposeProjectDir(t, projectsRoot, filepath.Join("group", "project2"))
+
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
+	t.Setenv("PROJECT_SCAN_MAX_DEPTH", "1")
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, config.Load())
+	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
+
+	items, err := svc.ListAllProjects(ctx)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "project1", items[0].Name)
+	assert.Equal(t, topLevelPath, items[0].Path)
+}
+
 func TestProjectService_ListProjects_LoadsProjectIconFromGlobalEnvInIncludedMetadata(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()
@@ -1853,6 +1877,27 @@ func TestProjectService_CountProjectFolders_RecursivelyCountsNestedProjects(t *t
 	count, err := svc.countProjectFolders(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 3, count)
+}
+
+func TestProjectService_CountProjectFolders_RespectsConfiguredScanMaxDepth(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectsRoot := t.TempDir()
+	createComposeProjectDir(t, projectsRoot, "project1")
+	createComposeProjectDir(t, projectsRoot, filepath.Join("group", "project2"))
+
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
+	t.Setenv("PROJECT_SCAN_MAX_DEPTH", "1")
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, config.Load())
+
+	count, err := svc.countProjectFolders(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
 }
 
 func TestProjectService_SyncProjectsFromFileSystem_RemovesDeletedNestedProject(t *testing.T) {

--- a/backend/pkg/fswatch/watcher_test.go
+++ b/backend/pkg/fswatch/watcher_test.go
@@ -241,6 +241,72 @@ func TestWatcher_StartTriggersOnNestedProjectFileBeyondDepthOne(t *testing.T) {
 	}
 }
 
+func TestWatcher_StartDoesNotTriggerOnNestedProjectFileBeyondConfiguredDepth(t *testing.T) {
+	root := t.TempDir()
+	nestedDir := filepath.Join(root, "main-project", "sub-project1")
+	require.NoError(t, os.MkdirAll(nestedDir, 0o755))
+
+	changeCh := make(chan struct{}, 1)
+	ctx := t.Context()
+
+	watcher, err := NewWatcher(root, WatcherOptions{
+		Debounce: 25 * time.Millisecond,
+		MaxDepth: 1,
+		OnChange: func(context.Context) {
+			select {
+			case changeCh <- struct{}{}:
+			default:
+			}
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, watcher.Start(ctx))
+	defer func() {
+		require.NoError(t, watcher.Stop())
+	}()
+
+	require.NoError(t, os.WriteFile(filepath.Join(nestedDir, "compose.yaml"), []byte("services: {}\n"), 0o644))
+
+	select {
+	case <-changeCh:
+		t.Fatal("did not expect nested compose file beyond max depth to trigger watcher callback")
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+func TestWatcher_StartTriggersOnDirectChildProjectFileAtConfiguredDepth(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "main-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	changeCh := make(chan struct{}, 1)
+	ctx := t.Context()
+
+	watcher, err := NewWatcher(root, WatcherOptions{
+		Debounce: 25 * time.Millisecond,
+		MaxDepth: 1,
+		OnChange: func(context.Context) {
+			select {
+			case changeCh <- struct{}{}:
+			default:
+			}
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, watcher.Start(ctx))
+	defer func() {
+		require.NoError(t, watcher.Stop())
+	}()
+
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "compose.yaml"), []byte("services: {}\n"), 0o644))
+
+	select {
+	case <-changeCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected direct child compose file at max depth to trigger watcher callback")
+	}
+}
+
 func TestWatcher_StartIgnoresBareNestedDirectoryCreateAndRemove(t *testing.T) {
 	root := t.TempDir()
 

--- a/backend/pkg/projects/discovery.go
+++ b/backend/pkg/projects/discovery.go
@@ -60,7 +60,7 @@ func IsProjectDirectoryPath(path string, followSymlinks bool) (bool, error) {
 	return resolvedInfo.IsDir(), nil
 }
 
-func DiscoverProjectDirectories(root string, followSymlinks bool) ([]DiscoveredProjectDir, error) {
+func DiscoverProjectDirectories(root string, followSymlinks bool, maxDepth int) ([]DiscoveredProjectDir, error) {
 	root = filepath.Clean(root)
 
 	isDir, err := IsProjectDirectoryPath(root, followSymlinks)
@@ -74,7 +74,7 @@ func DiscoverProjectDirectories(root string, followSymlinks bool) ([]DiscoveredP
 	discovered := make([]DiscoveredProjectDir, 0)
 	ancestors := make(map[string]struct{})
 
-	if err := walkProjectDirectoriesInternal(root, true, followSymlinks, ancestors, &discovered); err != nil {
+	if err := walkProjectDirectoriesInternal(root, true, 0, maxDepth, followSymlinks, ancestors, &discovered); err != nil {
 		return nil, err
 	}
 
@@ -85,7 +85,7 @@ func DiscoverProjectDirectories(root string, followSymlinks bool) ([]DiscoveredP
 	return discovered, nil
 }
 
-func walkProjectDirectoriesInternal(path string, isRoot bool, followSymlinks bool, ancestors map[string]struct{}, discovered *[]DiscoveredProjectDir) error {
+func walkProjectDirectoriesInternal(path string, isRoot bool, currentDepth int, maxDepth int, followSymlinks bool, ancestors map[string]struct{}, discovered *[]DiscoveredProjectDir) error {
 	identity, err := ResolveDirectoryIdentityInternal(path)
 	if err != nil {
 		return err
@@ -115,6 +115,10 @@ func walkProjectDirectoriesInternal(path string, isRoot bool, followSymlinks boo
 		}
 	}
 
+	if maxDepth > 0 && currentDepth >= maxDepth {
+		return nil
+	}
+
 	entries, err := os.ReadDir(path)
 	if err != nil {
 		return err
@@ -126,7 +130,7 @@ func walkProjectDirectoriesInternal(path string, isRoot bool, followSymlinks boo
 			continue
 		}
 
-		if err := walkProjectDirectoriesInternal(childPath, false, followSymlinks, ancestors, discovered); err != nil {
+		if err := walkProjectDirectoriesInternal(childPath, false, currentDepth+1, maxDepth, followSymlinks, ancestors, discovered); err != nil {
 			return err
 		}
 	}

--- a/backend/pkg/projects/discovery_test.go
+++ b/backend/pkg/projects/discovery_test.go
@@ -8,15 +8,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// writeComposeFile creates an empty compose.yml at the given directory.
-func writeComposeFile(t *testing.T, dir string) {
+// writeComposeFileInternal creates an empty compose.yml at the given directory.
+func writeComposeFileInternal(t *testing.T, dir string) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "compose.yml"), []byte("services: {}\n"), 0o644))
 }
 
-// discoveredNames returns the DirName of each discovered project, preserving order.
-func discoveredNames(dirs []DiscoveredProjectDir) []string {
+// discoveredNamesInternal returns the DirName of each discovered project, preserving order.
+func discoveredNamesInternal(dirs []DiscoveredProjectDir) []string {
 	out := make([]string, 0, len(dirs))
 	for _, d := range dirs {
 		out = append(out, d.DirName)
@@ -35,14 +35,14 @@ func TestDiscoverProjectDirectories_StopsDescentAtCompose(t *testing.T) {
 	//   root/networking/compose.yml
 	//   root/networking/adguardhome/compose.yml
 	//   root/networking/nginx-proxy-manager/compose.yml
-	writeComposeFile(t, filepath.Join(root, "networking"))
-	writeComposeFile(t, filepath.Join(root, "networking", "adguardhome"))
-	writeComposeFile(t, filepath.Join(root, "networking", "nginx-proxy-manager"))
+	writeComposeFileInternal(t, filepath.Join(root, "networking"))
+	writeComposeFileInternal(t, filepath.Join(root, "networking", "adguardhome"))
+	writeComposeFileInternal(t, filepath.Join(root, "networking", "nginx-proxy-manager"))
 
-	discovered, err := DiscoverProjectDirectories(root, false)
+	discovered, err := DiscoverProjectDirectories(root, false, 0)
 	require.NoError(t, err)
 
-	names := discoveredNames(discovered)
+	names := discoveredNamesInternal(discovered)
 	require.Equal(t, []string{"networking"}, names,
 		"only the parent compose project should be discovered; children are assumed to be included")
 }
@@ -53,13 +53,13 @@ func TestDiscoverProjectDirectories_StopsDescentAtCompose(t *testing.T) {
 func TestDiscoverProjectDirectories_SiblingProjectsAtRoot(t *testing.T) {
 	root := t.TempDir()
 
-	writeComposeFile(t, filepath.Join(root, "app1"))
-	writeComposeFile(t, filepath.Join(root, "app2"))
+	writeComposeFileInternal(t, filepath.Join(root, "app1"))
+	writeComposeFileInternal(t, filepath.Join(root, "app2"))
 
-	discovered, err := DiscoverProjectDirectories(root, false)
+	discovered, err := DiscoverProjectDirectories(root, false, 0)
 	require.NoError(t, err)
 
-	names := discoveredNames(discovered)
+	names := discoveredNamesInternal(discovered)
 	require.ElementsMatch(t, []string{"app1", "app2"}, names)
 }
 
@@ -73,13 +73,13 @@ func TestDiscoverProjectDirectories_RootWithComposeAndSiblings(t *testing.T) {
 	// root/compose.yml (a root-level "project")
 	// root/app1/compose.yml
 	// root/app2/compose.yml
-	writeComposeFile(t, root)
-	writeComposeFile(t, filepath.Join(root, "app1"))
-	writeComposeFile(t, filepath.Join(root, "app2"))
+	writeComposeFileInternal(t, root)
+	writeComposeFileInternal(t, filepath.Join(root, "app1"))
+	writeComposeFileInternal(t, filepath.Join(root, "app2"))
 
-	discovered := DiscoveredProjectDirectories_call(t, root)
+	discovered := discoverProjectDirectoriesInternal(t, root)
 
-	names := discoveredNames(discovered)
+	names := discoveredNamesInternal(discovered)
 	require.Len(t, names, 3)
 	require.Contains(t, names, "app1")
 	require.Contains(t, names, "app2")
@@ -94,12 +94,12 @@ func TestDiscoverProjectDirectories_NestedStandaloneProject(t *testing.T) {
 	root := t.TempDir()
 
 	// root/sub/nested/compose.yml (no compose file at root/sub/)
-	writeComposeFile(t, filepath.Join(root, "sub", "nested"))
+	writeComposeFileInternal(t, filepath.Join(root, "sub", "nested"))
 
-	discovered, err := DiscoverProjectDirectories(root, false)
+	discovered, err := DiscoverProjectDirectories(root, false, 0)
 	require.NoError(t, err)
 
-	names := discoveredNames(discovered)
+	names := discoveredNamesInternal(discovered)
 	require.Equal(t, []string{"nested"}, names)
 }
 
@@ -109,18 +109,43 @@ func TestDiscoverProjectDirectories_SupportsCustomComposeFilename(t *testing.T) 
 	require.NoError(t, os.MkdirAll(projectDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "radarr.yaml"), []byte("services: {}\n"), 0o644))
 
-	discovered, err := DiscoverProjectDirectories(root, false)
+	discovered, err := DiscoverProjectDirectories(root, false, 0)
 	require.NoError(t, err)
 	require.Len(t, discovered, 1)
 	require.Equal(t, "Radarr-3", discovered[0].DirName)
 	require.Equal(t, projectDir, discovered[0].Path)
 }
 
-// DiscoveredProjectDirectories_call is a tiny helper so tests can share the
+// discoverProjectDirectoriesInternal is a tiny helper so tests can share the
 // err-check boilerplate.
-func DiscoveredProjectDirectories_call(t *testing.T, root string) []DiscoveredProjectDir {
+func discoverProjectDirectoriesInternal(t *testing.T, root string) []DiscoveredProjectDir {
 	t.Helper()
-	d, err := DiscoverProjectDirectories(root, false)
+	d, err := DiscoverProjectDirectories(root, false, 0)
 	require.NoError(t, err)
 	return d
+}
+
+func TestDiscoverProjectDirectories_RespectsMaxDepth(t *testing.T) {
+	root := t.TempDir()
+
+	writeComposeFileInternal(t, filepath.Join(root, "top-level"))
+	writeComposeFileInternal(t, filepath.Join(root, "group", "nested"))
+
+	discovered, err := DiscoverProjectDirectories(root, false, 1)
+	require.NoError(t, err)
+
+	names := discoveredNamesInternal(discovered)
+	require.Equal(t, []string{"top-level"}, names)
+}
+
+func TestDiscoverProjectDirectories_UnlimitedDepthStillFindsNestedProject(t *testing.T) {
+	root := t.TempDir()
+
+	writeComposeFileInternal(t, filepath.Join(root, "group", "nested"))
+
+	discovered, err := DiscoverProjectDirectories(root, false, 0)
+	require.NoError(t, err)
+
+	names := discoveredNamesInternal(discovered)
+	require.Equal(t, []string{"nested"}, names)
 }

--- a/backend/pkg/scheduler/filesystem_watcher_job.go
+++ b/backend/pkg/scheduler/filesystem_watcher_job.go
@@ -16,6 +16,7 @@ type FilesystemWatcherJob struct {
 	projectService   *services.ProjectService
 	templateService  *services.TemplateService
 	settingsService  *services.SettingsService
+	projectScanDepth int
 	projectsWatcher  *fswatch.Watcher
 	templatesWatcher *fswatch.Watcher
 	mu               sync.Mutex
@@ -25,16 +26,18 @@ func NewFilesystemWatcherJob(
 	projectService *services.ProjectService,
 	templateService *services.TemplateService,
 	settingsService *services.SettingsService,
+	projectScanDepth int,
 ) *FilesystemWatcherJob {
 	return &FilesystemWatcherJob{
-		projectService:  projectService,
-		templateService: templateService,
-		settingsService: settingsService,
+		projectService:   projectService,
+		templateService:  templateService,
+		settingsService:  settingsService,
+		projectScanDepth: projectScanDepth,
 	}
 }
 
-func RegisterFilesystemWatcherJob(ctx context.Context, projectService *services.ProjectService, templateService *services.TemplateService, settingsService *services.SettingsService) (*FilesystemWatcherJob, error) {
-	job := NewFilesystemWatcherJob(projectService, templateService, settingsService)
+func RegisterFilesystemWatcherJob(ctx context.Context, projectService *services.ProjectService, templateService *services.TemplateService, settingsService *services.SettingsService, projectScanDepth int) (*FilesystemWatcherJob, error) {
+	job := NewFilesystemWatcherJob(projectService, templateService, settingsService, projectScanDepth)
 
 	go func() {
 		if err := job.Start(ctx); err != nil {
@@ -58,12 +61,7 @@ func (j *FilesystemWatcherJob) Start(ctx context.Context) error {
 	followProjectSymlinks := settings.FollowProjectSymlinks.IsTrue()
 	j.logRecursiveProjectsWatchLimitWarningInternal(ctx, projectsDirectory)
 
-	sw, err := fswatch.NewWatcher(projectsDirectory, fswatch.WatcherOptions{
-		Debounce:          3 * time.Second, // Wait 3 seconds after last change before syncing
-		OnChange:          j.handleFilesystemChange,
-		MaxDepth:          0,
-		FollowSymlinkDirs: followProjectSymlinks,
-	})
+	sw, err := fswatch.NewWatcher(projectsDirectory, j.projectWatcherOptionsInternal(followProjectSymlinks))
 	if err != nil {
 		return err
 	}
@@ -193,12 +191,7 @@ func (j *FilesystemWatcherJob) RestartProjectsWatcher(ctx context.Context) error
 	j.logRecursiveProjectsWatchLimitWarningInternal(ctx, projectsDirectory)
 
 	// Create a new watcher with the updated path
-	sw, err := fswatch.NewWatcher(projectsDirectory, fswatch.WatcherOptions{
-		Debounce:          3 * time.Second,
-		OnChange:          j.handleFilesystemChange,
-		MaxDepth:          0,
-		FollowSymlinkDirs: followProjectSymlinks,
-	})
+	sw, err := fswatch.NewWatcher(projectsDirectory, j.projectWatcherOptionsInternal(followProjectSymlinks))
 	if err != nil {
 		return err
 	}
@@ -231,4 +224,13 @@ func (j *FilesystemWatcherJob) logRecursiveProjectsWatchLimitWarningInternal(ctx
 		"Projects filesystem watcher is monitoring directories recursively; very deep trees may require increasing fs.inotify.max_user_watches",
 		"path", projectsDirectory,
 		"sysctl", "fs.inotify.max_user_watches")
+}
+
+func (j *FilesystemWatcherJob) projectWatcherOptionsInternal(followProjectSymlinks bool) fswatch.WatcherOptions {
+	return fswatch.WatcherOptions{
+		Debounce:          3 * time.Second, // Wait 3 seconds after last change before syncing
+		OnChange:          j.handleFilesystemChange,
+		MaxDepth:          j.projectScanDepth,
+		FollowSymlinkDirs: followProjectSymlinks,
+	}
 }

--- a/backend/pkg/scheduler/filesystem_watcher_job_test.go
+++ b/backend/pkg/scheduler/filesystem_watcher_job_test.go
@@ -1,0 +1,18 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilesystemWatcherJob_ProjectWatcherOptions_UsesConfiguredMaxDepth(t *testing.T) {
+	job := &FilesystemWatcherJob{
+		projectScanDepth: 1,
+	}
+
+	opts := job.projectWatcherOptionsInternal(true)
+
+	assert.Equal(t, 1, opts.MaxDepth)
+	assert.True(t, opts.FollowSymlinkDirs)
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2323

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the \"project max depth not working\" bug by wiring `projectScanDepth` into the `FilesystemWatcherJob` (new field + `projectWatcherOptionsInternal` helper) and adding the `currentDepth >= maxDepth` guard in `walkProjectDirectoriesInternal` so discovery actually stops descending at the configured limit. Test coverage for the new depth semantics is solid.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the fix is correct and well-tested, with only minor naming-convention style findings remaining.

All findings are P2 style issues (missing Internal suffix on test helpers, non-idiomatic underscore name). The core logic is correct: depth enforcement in the walk function, proper propagation through the watcher job, and matching test coverage for both unlimited and bounded depth scenarios.

backend/pkg/projects/discovery_test.go — test helper naming conventions
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `backend/pkg/projects/discovery_test.go`, line 12-25 ([link](https://github.com/getarcaneapp/arcane/blob/3a3c12e7f3a0db8d533cd2260303283e1f9ce250/backend/pkg/projects/discovery_test.go#L12-L25)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unexported helpers missing "Internal" suffix**

   `writeComposeFile` and `discoveredNames` are unexported but don't carry the required `Internal` suffix. The existing precedent in the same test suite — `stopWatcherWithinTimeoutInternal` in `watcher_test.go` — shows the convention is applied to test helpers too.

   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/pkg/projects/discovery_test.go
   Line: 12-25
   
   Comment:
   **Unexported helpers missing "Internal" suffix**
   
   `writeComposeFile` and `discoveredNames` are unexported but don't carry the required `Internal` suffix. The existing precedent in the same test suite — `stopWatcherWithinTimeoutInternal` in `watcher_test.go` — shows the convention is applied to test helpers too.
   
   
   
   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Fprojects%2Fdiscovery_test.go%0ALine%3A%2012-25%0A%0AComment%3A%0A**Unexported%20helpers%20missing%20%22Internal%22%20suffix**%0A%0A%60writeComposeFile%60%20and%20%60discoveredNames%60%20are%20unexported%20but%20don't%20carry%20the%20required%20%60Internal%60%20suffix.%20The%20existing%20precedent%20in%20the%20same%20test%20suite%20%E2%80%94%20%60stopWatcherWithinTimeoutInternal%60%20in%20%60watcher_test.go%60%20%E2%80%94%20shows%20the%20convention%20is%20applied%20to%20test%20helpers%20too.%0A%0A%60%60%60suggestion%0Afunc%20writeComposeFileInternal%28t%20*testing.T%2C%20dir%20string%29%20%7B%0A%09t.Helper%28%29%0A%09require.NoError%28t%2C%20os.MkdirAll%28dir%2C%200o755%29%29%0A%09require.NoError%28t%2C%20os.WriteFile%28filepath.Join%28dir%2C%20%22compose.yml%22%29%2C%20%5B%5Dbyte%28%22services%3A%20%7B%7D%5Cn%22%29%2C%200o644%29%29%0A%7D%0A%0A%2F%2F%20discoveredNamesInternal%20returns%20the%20DirName%20of%20each%20discovered%20project%2C%20preserving%20order.%0Afunc%20discoveredNamesInternal%28dirs%20%5B%5DDiscoveredProjectDir%29%20%5B%5Dstring%20%7B%0A%09out%20%3A%3D%20make%28%5B%5Dstring%2C%200%2C%20len%28dirs%29%29%0A%09for%20_%2C%20d%20%3A%3D%20range%20dirs%20%7B%0A%09%09out%20%3D%20append%28out%2C%20d.DirName%29%0A%09%7D%0A%09return%20out%0A%7D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `backend/pkg/projects/discovery_test.go`, line 119-126 ([link](https://github.com/getarcaneapp/arcane/blob/3a3c12e7f3a0db8d533cd2260303283e1f9ce250/backend/pkg/projects/discovery_test.go#L119-L126)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Non-idiomatic helper name**

   `DiscoveredProjectDirectories_call` uses an underscore in the middle, which is not idiomatic Go. A more conventional name (still exported if that's the intent, or unexported with `Internal`) would read better — e.g. `discoverProjectDirectoriesInternal` — and would also satisfy the `Internal`-suffix convention for unexported helpers.

   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/pkg/projects/discovery_test.go
   Line: 119-126
   
   Comment:
   **Non-idiomatic helper name**
   
   `DiscoveredProjectDirectories_call` uses an underscore in the middle, which is not idiomatic Go. A more conventional name (still exported if that's the intent, or unexported with `Internal`) would read better — e.g. `discoverProjectDirectoriesInternal` — and would also satisfy the `Internal`-suffix convention for unexported helpers.
   
   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Fprojects%2Fdiscovery_test.go%0ALine%3A%20119-126%0A%0AComment%3A%0A**Non-idiomatic%20helper%20name**%0A%0A%60DiscoveredProjectDirectories_call%60%20uses%20an%20underscore%20in%20the%20middle%2C%20which%20is%20not%20idiomatic%20Go.%20A%20more%20conventional%20name%20%28still%20exported%20if%20that's%20the%20intent%2C%20or%20unexported%20with%20%60Internal%60%29%20would%20read%20better%20%E2%80%94%20e.g.%20%60discoverProjectDirectoriesInternal%60%20%E2%80%94%20and%20would%20also%20satisfy%20the%20%60Internal%60-suffix%20convention%20for%20unexported%20helpers.%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Fpkg%2Fprojects%2Fdiscovery_test.go%3A12-25%0A**Unexported%20helpers%20missing%20%22Internal%22%20suffix**%0A%0A%60writeComposeFile%60%20and%20%60discoveredNames%60%20are%20unexported%20but%20don't%20carry%20the%20required%20%60Internal%60%20suffix.%20The%20existing%20precedent%20in%20the%20same%20test%20suite%20%E2%80%94%20%60stopWatcherWithinTimeoutInternal%60%20in%20%60watcher_test.go%60%20%E2%80%94%20shows%20the%20convention%20is%20applied%20to%20test%20helpers%20too.%0A%0A%60%60%60suggestion%0Afunc%20writeComposeFileInternal%28t%20*testing.T%2C%20dir%20string%29%20%7B%0A%09t.Helper%28%29%0A%09require.NoError%28t%2C%20os.MkdirAll%28dir%2C%200o755%29%29%0A%09require.NoError%28t%2C%20os.WriteFile%28filepath.Join%28dir%2C%20%22compose.yml%22%29%2C%20%5B%5Dbyte%28%22services%3A%20%7B%7D%5Cn%22%29%2C%200o644%29%29%0A%7D%0A%0A%2F%2F%20discoveredNamesInternal%20returns%20the%20DirName%20of%20each%20discovered%20project%2C%20preserving%20order.%0Afunc%20discoveredNamesInternal%28dirs%20%5B%5DDiscoveredProjectDir%29%20%5B%5Dstring%20%7B%0A%09out%20%3A%3D%20make%28%5B%5Dstring%2C%200%2C%20len%28dirs%29%29%0A%09for%20_%2C%20d%20%3A%3D%20range%20dirs%20%7B%0A%09%09out%20%3D%20append%28out%2C%20d.DirName%29%0A%09%7D%0A%09return%20out%0A%7D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Fpkg%2Fprojects%2Fdiscovery_test.go%3A119-126%0A**Non-idiomatic%20helper%20name**%0A%0A%60DiscoveredProjectDirectories_call%60%20uses%20an%20underscore%20in%20the%20middle%2C%20which%20is%20not%20idiomatic%20Go.%20A%20more%20conventional%20name%20%28still%20exported%20if%20that's%20the%20intent%2C%20or%20unexported%20with%20%60Internal%60%29%20would%20read%20better%20%E2%80%94%20e.g.%20%60discoverProjectDirectoriesInternal%60%20%E2%80%94%20and%20would%20also%20satisfy%20the%20%60Internal%60-suffix%20convention%20for%20unexported%20helpers.%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/projects/discovery_test.go
Line: 12-25

Comment:
**Unexported helpers missing "Internal" suffix**

`writeComposeFile` and `discoveredNames` are unexported but don't carry the required `Internal` suffix. The existing precedent in the same test suite — `stopWatcherWithinTimeoutInternal` in `watcher_test.go` — shows the convention is applied to test helpers too.

```suggestion
func writeComposeFileInternal(t *testing.T, dir string) {
	t.Helper()
	require.NoError(t, os.MkdirAll(dir, 0o755))
	require.NoError(t, os.WriteFile(filepath.Join(dir, "compose.yml"), []byte("services: {}\n"), 0o644))
}

// discoveredNamesInternal returns the DirName of each discovered project, preserving order.
func discoveredNamesInternal(dirs []DiscoveredProjectDir) []string {
	out := make([]string, 0, len(dirs))
	for _, d := range dirs {
		out = append(out, d.DirName)
	}
	return out
}
```

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/projects/discovery_test.go
Line: 119-126

Comment:
**Non-idiomatic helper name**

`DiscoveredProjectDirectories_call` uses an underscore in the middle, which is not idiomatic Go. A more conventional name (still exported if that's the intent, or unexported with `Internal`) would read better — e.g. `discoverProjectDirectoriesInternal` — and would also satisfy the `Internal`-suffix convention for unexported helpers.

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: project max depth not working for f..."](https://github.com/getarcaneapp/arcane/commit/3a3c12e7f3a0db8d533cd2260303283e1f9ce250) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28020655)</sub>

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->