### PR TITLE
fix: surface actual compose load error instead of generic 'no compose file found'

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -558,7 +558,7 @@ func (s *ProjectService) GetProjectServices(ctx context.Context, projectID strin
 
 	composeProject, composeFileFullPath, derr := s.loadComposeProjectForProjectInternal(ctx, projectFromDb)
 	if derr != nil {
-		return []ProjectServiceInfo{}, fmt.Errorf("no compose file found in project directory: %s", projectFromDb.Path)
+		return []ProjectServiceInfo{}, fmt.Errorf("failed to load compose project in %s: %w", projectFromDb.Path, derr)
 	}
 
 	meta, metaErr := projects.ParseArcaneComposeMetadata(ctx, composeFileFullPath)
@@ -1184,7 +1184,7 @@ func (s *ProjectService) DeployProject(ctx context.Context, projectID string, us
 
 	project, _, derr := s.loadComposeProjectForProjectInternal(ctx, projectFromDb)
 	if derr != nil {
-		return fmt.Errorf("no compose file found in project directory: %s", projectFromDb.Path)
+		return fmt.Errorf("failed to load compose project in %s: %w", projectFromDb.Path, derr)
 	}
 
 	if err := s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusDeploying); err != nil {
@@ -1424,7 +1424,7 @@ func (s *ProjectService) BuildProjectServices(ctx context.Context, projectID str
 
 	project, _, derr := s.loadComposeProjectForProjectInternal(ctx, projectFromDb)
 	if derr != nil {
-		return fmt.Errorf("no compose file found in project directory: %s", projectFromDb.Path)
+		return fmt.Errorf("failed to load compose project in %s: %w", projectFromDb.Path, derr)
 	}
 
 	return s.buildProjectServicesInternal(ctx, projectID, project, options, progressWriter, user)


### PR DESCRIPTION
## Summary

When `DeployProject`, `GetProjectServices`, or `BuildProjectServices` fails to load a compose project, the real error is discarded and replaced with a misleading `no compose file found in project directory` message. This hides the actual cause — which could be a validation error (e.g. undefined volume reference), env var expansion failure, or YAML parse error.

## Example

A penpot compose file referencing an undefined volume `penpot_postgres_v15` displays:
```
Failed to redeploy project: no compose file found in project directory: /home/abstract/docker/utilities
```

The actual error (visible only in server logs) is:
```
service "penpot-postgres" refers to undefined volume penpot_postgres_v15: invalid compose project
```

## Fix

Wrap the original error with `%w` in all three call sites so users see the real cause in the UI.

## Files

- `backend/internal/services/project_service.go` (3 lines changed)

## Test plan

- [ ] Project with an invalid compose file (e.g. undefined volume) shows the actual validation error in the UI toast, not "no compose file found"
- [ ] Project with a missing compose file still shows a clear error

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes three call sites in `project_service.go` where errors from `loadComposeProjectForProjectInternal` were discarded and replaced with a generic `"no compose file found in project directory"` message. The fix wraps the original error with `%w` so the actual cause (e.g. undefined volume reference, YAML parse error) propagates to the UI.

The change is consistent with how all other call sites in the same file already handle this error, and correctly follows Go's idiomatic error-wrapping pattern.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted fix that improves error surfacing with no behavioral risk.

All three changed sites now correctly wrap the underlying error with `%w`, consistent with every other call site for `loadComposeProjectForProjectInternal` in the file. No logic is altered, only error message propagation. No P0 or P1 findings.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: surface actual compose load error i..."](https://github.com/getarcaneapp/arcane/commit/d6670a3dc41fea97d97bbb6799adedadd8fe1240) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28027063)</sub>

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/review/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Rule used - # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

<!-- /greptile_comment -->