### PR TITLE
refactor: remove intel gpu tools and rely on mounts pci entries

### DIFF
--- a/backend/internal/api/ws_handler.go
+++ b/backend/internal/api/ws_handler.go
@@ -40,8 +40,8 @@ const (
 	cgroupCacheTTL   = 30 * time.Second
 )
 
-// amdGPUSysfsPath is the base path for AMD GPU sysfs entries
-const amdGPUSysfsPath = "/sys/class/drm"
+// gpuDRMSysfsPath is the base path for Linux DRM sysfs entries.
+const gpuDRMSysfsPath = "/sys/class/drm"
 
 // ============================================================================
 // WebSocket Metrics
@@ -206,6 +206,8 @@ type WebSocketHandler struct {
 	detectionMutex       sync.Mutex
 	gpuMonitoringEnabled bool
 	gpuType              string
+	gpuSysfsPath         string
+	execLookPath         func(file string) (string, error)
 	projectLogStreamer   func(ctx context.Context, projectID string, logsChan chan<- string, follow bool, tail, since string, timestamps bool) error
 	containerLogStreamer func(ctx context.Context, containerID string, logsChan chan<- string, follow bool, tail, since string, timestamps bool) error
 	systemStatsCollector func(ctx context.Context) systemtypes.SystemStats
@@ -354,6 +356,8 @@ func NewWebSocketHandler(
 		logStreams:           make(map[string]*wsLogStream),
 		gpuMonitoringEnabled: cfg.GPUMonitoringEnabled,
 		gpuType:              cfg.GPUType,
+		gpuSysfsPath:         gpuDRMSysfsPath,
+		execLookPath:         exec.LookPath,
 		wsUpgrader: websocket.Upgrader{
 			CheckOrigin:       httputil.ValidateWebSocketOrigin(cfg.GetAppURL()),
 			ReadBufferSize:    32 * 1024,
@@ -1594,88 +1598,54 @@ func (h *WebSocketHandler) detectGPUs(ctx context.Context) error {
 	h.detectionMutex.Lock()
 	defer h.detectionMutex.Unlock()
 
+	gpuSysfsPath := h.getGPUSysfsPathInternal()
+
 	if h.gpuType != "" && h.gpuType != "auto" {
 		switch h.gpuType {
 		case "nvidia":
-			if path, err := exec.LookPath("nvidia-smi"); err == nil {
-				h.gpuDetectionCache.Lock()
-				h.gpuDetectionCache.detected = true
-				h.gpuDetectionCache.gpuType = "nvidia"
-				h.gpuDetectionCache.toolPath = path
-				h.gpuDetectionCache.timestamp = time.Now()
-				h.gpuDetectionCache.Unlock()
-				h.detectionDone = true
+			if path, err := h.execLookPathInternal("nvidia-smi"); err == nil {
+				h.cacheDetectedGPUInternal("nvidia", path)
 				slog.InfoContext(ctx, "Using configured GPU type", "type", "nvidia")
 				return nil
 			}
 			return fmt.Errorf("nvidia-smi not found but GPU_TYPE set to nvidia")
 
 		case "amd":
-			if hasAMDGPUInternal() {
-				h.gpuDetectionCache.Lock()
-				h.gpuDetectionCache.detected = true
-				h.gpuDetectionCache.gpuType = "amd"
-				h.gpuDetectionCache.toolPath = amdGPUSysfsPath
-				h.gpuDetectionCache.timestamp = time.Now()
-				h.gpuDetectionCache.Unlock()
-				h.detectionDone = true
+			if hasAMDGPUInternal(gpuSysfsPath) {
+				h.cacheDetectedGPUInternal("amd", gpuSysfsPath)
 				slog.InfoContext(ctx, "Using configured GPU type", "type", "amd")
 				return nil
 			}
 			return fmt.Errorf("AMD GPU not found in sysfs but GPU_TYPE set to amd")
 
 		case "intel":
-			if path, err := exec.LookPath("intel_gpu_top"); err == nil {
-				h.gpuDetectionCache.Lock()
-				h.gpuDetectionCache.detected = true
-				h.gpuDetectionCache.gpuType = "intel"
-				h.gpuDetectionCache.toolPath = path
-				h.gpuDetectionCache.timestamp = time.Now()
-				h.gpuDetectionCache.Unlock()
-				h.detectionDone = true
+			if path, ok := findIntelGPUPathInternal(gpuSysfsPath); ok {
+				h.cacheDetectedGPUInternal("intel", path)
 				slog.InfoContext(ctx, "Using configured GPU type", "type", "intel")
 				return nil
 			}
-			return fmt.Errorf("intel_gpu_top not found but GPU_TYPE set to intel")
+			slog.WarnContext(ctx, "Intel GPU not found in sysfs, falling back to auto-detection", "gpu_type", h.gpuType)
 
 		default:
 			slog.WarnContext(ctx, "Invalid GPU_TYPE specified, falling back to auto-detection", "gpu_type", h.gpuType)
 		}
 	}
 
-	if path, err := exec.LookPath("nvidia-smi"); err == nil {
-		h.gpuDetectionCache.Lock()
-		h.gpuDetectionCache.detected = true
-		h.gpuDetectionCache.gpuType = "nvidia"
-		h.gpuDetectionCache.toolPath = path
-		h.gpuDetectionCache.timestamp = time.Now()
-		h.gpuDetectionCache.Unlock()
-		h.detectionDone = true
+	if path, err := h.execLookPathInternal("nvidia-smi"); err == nil {
+		h.cacheDetectedGPUInternal("nvidia", path)
 		slog.InfoContext(ctx, "NVIDIA GPU detected", "tool", "nvidia-smi", "path", path)
 		return nil
 	}
 
-	if hasAMDGPUInternal() {
-		h.gpuDetectionCache.Lock()
-		h.gpuDetectionCache.detected = true
-		h.gpuDetectionCache.gpuType = "amd"
-		h.gpuDetectionCache.toolPath = amdGPUSysfsPath
-		h.gpuDetectionCache.timestamp = time.Now()
-		h.gpuDetectionCache.Unlock()
-		h.detectionDone = true
-		slog.InfoContext(ctx, "AMD GPU detected", "method", "sysfs", "path", amdGPUSysfsPath)
+	if hasAMDGPUInternal(gpuSysfsPath) {
+		h.cacheDetectedGPUInternal("amd", gpuSysfsPath)
+		slog.InfoContext(ctx, "AMD GPU detected", "method", "sysfs", "path", gpuSysfsPath)
 		return nil
 	}
 
-	if path, err := exec.LookPath("intel_gpu_top"); err == nil {
-		h.gpuDetectionCache.Lock()
-		h.gpuDetectionCache.detected = true
-		h.gpuDetectionCache.gpuType = "intel"
-		h.gpuDetectionCache.toolPath = path
-		h.gpuDetectionCache.timestamp = time.Now()
-		h.gpuDetectionCache.Unlock()
-		h.detectionDone = true
-		slog.InfoContext(ctx, "Intel GPU detected", "tool", "intel_gpu_top", "path", path)
+	if path, ok := findIntelGPUPathInternal(gpuSysfsPath); ok {
+		h.cacheDetectedGPUInternal("intel", path)
+		slog.InfoContext(ctx, "Intel GPU detected", "method", "sysfs", "path", path)
 		return nil
 	}
 
@@ -1753,8 +1723,10 @@ func (h *WebSocketHandler) getNvidiaStats(ctx context.Context) ([]systemtypes.GP
 func (h *WebSocketHandler) getAMDStats(ctx context.Context) ([]systemtypes.GPUStats, error) {
 	var stats []systemtypes.GPUStats
 
+	gpuSysfsPath := h.getGPUSysfsPathInternal()
+
 	// Find AMD GPU cards by looking for mem_info_vram_total in /sys/class/drm/card*/device/
-	entries, err := os.ReadDir(amdGPUSysfsPath)
+	entries, err := os.ReadDir(gpuSysfsPath)
 	if err != nil {
 		slog.WarnContext(ctx, "Failed to read DRM sysfs directory", "error", err)
 		return nil, fmt.Errorf("failed to read sysfs: %w", err)
@@ -1763,16 +1735,11 @@ func (h *WebSocketHandler) getAMDStats(ctx context.Context) ([]systemtypes.GPUSt
 	index := 0
 	for _, entry := range entries {
 		name := entry.Name()
-		// Only check card* entries (card0, card1, etc.) - skip renderD* and connector entries
-		if !strings.HasPrefix(name, "card") {
-			continue
-		}
-		// Skip connector entries like card0-DP-1, card0-HDMI-A-1
-		if strings.Contains(name, "-") {
+		if !isDRMCardEntryInternal(name) {
 			continue
 		}
 
-		devicePath := fmt.Sprintf("%s/%s/device", amdGPUSysfsPath, name)
+		devicePath := fmt.Sprintf("%s/%s/device", gpuSysfsPath, name)
 
 		// Check if this is an AMD GPU by looking for VRAM info files
 		memTotalPath := fmt.Sprintf("%s/mem_info_vram_total", devicePath)
@@ -1816,26 +1783,21 @@ func readSysfsValueInternal(path string) (uint64, error) {
 	return strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
 }
 
-// hasAMDGPUInternal checks if an AMD GPU is present by looking for VRAM info in sysfs
-func hasAMDGPUInternal() bool {
-	entries, err := os.ReadDir(amdGPUSysfsPath)
+// hasAMDGPUInternal checks if an AMD GPU is present by looking for VRAM info in sysfs.
+func hasAMDGPUInternal(sysfsPath string) bool {
+	entries, err := os.ReadDir(sysfsPath)
 	if err != nil {
 		return false
 	}
 
 	for _, entry := range entries {
 		name := entry.Name()
-		// Only check card* entries (card0, card1, etc.) - skip card0-DP-1 style entries
-		if !strings.HasPrefix(name, "card") {
-			continue
-		}
-		// Skip connector entries like card0-DP-1, card0-HDMI-A-1
-		if strings.Contains(name, "-") {
+		if !isDRMCardEntryInternal(name) {
 			continue
 		}
 
 		// Check if this card has AMD VRAM info
-		memTotalPath := fmt.Sprintf("%s/%s/device/mem_info_vram_total", amdGPUSysfsPath, name)
+		memTotalPath := fmt.Sprintf("%s/%s/device/mem_info_vram_total", sysfsPath, name)
 		if _, err := os.Stat(memTotalPath); err == nil {
 			return true
 		}
@@ -1844,7 +1806,73 @@ func hasAMDGPUInternal() bool {
 	return false
 }
 
-// getIntelStats collects Intel GPU statistics using intel_gpu_top
+func (h *WebSocketHandler) cacheDetectedGPUInternal(gpuType, toolPath string) {
+	h.gpuDetectionCache.Lock()
+	h.gpuDetectionCache.detected = true
+	h.gpuDetectionCache.gpuType = gpuType
+	h.gpuDetectionCache.toolPath = toolPath
+	h.gpuDetectionCache.timestamp = time.Now()
+	h.gpuDetectionCache.Unlock()
+	h.detectionDone = true
+}
+
+func (h *WebSocketHandler) getGPUSysfsPathInternal() string {
+	if h.gpuSysfsPath != "" {
+		return h.gpuSysfsPath
+	}
+	return gpuDRMSysfsPath
+}
+
+func (h *WebSocketHandler) execLookPathInternal(file string) (string, error) {
+	if h.execLookPath != nil {
+		return h.execLookPath(file)
+	}
+	return exec.LookPath(file)
+}
+
+func isDRMCardEntryInternal(name string) bool {
+	if !strings.HasPrefix(name, "card") {
+		return false
+	}
+	return !strings.Contains(name, "-")
+}
+
+func readSysfsStringInternal(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func findIntelGPUPathInternal(sysfsPath string) (string, bool) {
+	entries, err := os.ReadDir(sysfsPath)
+	if err != nil {
+		return "", false
+	}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if !isDRMCardEntryInternal(name) {
+			continue
+		}
+
+		devicePath := fmt.Sprintf("%s/%s/device", sysfsPath, name)
+		vendorPath := fmt.Sprintf("%s/vendor", devicePath)
+		vendor, err := readSysfsStringInternal(vendorPath)
+		if err != nil {
+			continue
+		}
+
+		if strings.EqualFold(vendor, "0x8086") {
+			return devicePath, true
+		}
+	}
+
+	return "", false
+}
+
+// getIntelStats collects Intel GPU statistics using sysfs detection.
 func (h *WebSocketHandler) getIntelStats(ctx context.Context) ([]systemtypes.GPUStats, error) {
 	stats := []systemtypes.GPUStats{
 		{

--- a/backend/internal/api/ws_handler_test.go
+++ b/backend/internal/api/ws_handler_test.go
@@ -6,6 +6,9 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -105,12 +108,151 @@ func newTestWSPairInternal(t *testing.T) (clientConn *websocket.Conn, serverConn
 
 func newTestWebSocketHandler() *WebSocketHandler {
 	return &WebSocketHandler{
-		wsMetrics:  NewWebSocketMetrics(),
-		logStreams: make(map[string]*wsLogStream),
+		wsMetrics:    NewWebSocketMetrics(),
+		logStreams:   make(map[string]*wsLogStream),
+		gpuSysfsPath: gpuDRMSysfsPath,
+		execLookPath: exec.LookPath,
 		wsUpgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool { return true },
 		},
 	}
+}
+
+func TestDetectGPUsInternal_IntelAutoDetectsFromSysfs(t *testing.T) {
+	t.Parallel()
+
+	sysfsPath := t.TempDir()
+	writeTestGPUFileInternal(t, filepath.Join(sysfsPath, "card0", "device", "vendor"), "0x8086\n")
+
+	handler := newTestWebSocketHandler()
+	handler.gpuSysfsPath = sysfsPath
+	handler.execLookPath = func(file string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+
+	err := handler.detectGPUs(t.Context())
+	require.NoError(t, err)
+
+	handler.gpuDetectionCache.RLock()
+	defer handler.gpuDetectionCache.RUnlock()
+	require.Equal(t, "intel", handler.gpuDetectionCache.gpuType)
+	require.Equal(t, filepath.Join(sysfsPath, "card0", "device"), handler.gpuDetectionCache.toolPath)
+}
+
+func TestFindIntelGPUPathInternal_IgnoresConnectorEntries(t *testing.T) {
+	t.Parallel()
+
+	sysfsPath := t.TempDir()
+	writeTestGPUFileInternal(t, filepath.Join(sysfsPath, "card0-DP-1", "device", "vendor"), "0x8086\n")
+
+	path, ok := findIntelGPUPathInternal(sysfsPath)
+	require.False(t, ok)
+	require.Empty(t, path)
+}
+
+func TestFindIntelGPUPathInternal_IgnoresNonIntelVendors(t *testing.T) {
+	t.Parallel()
+
+	sysfsPath := t.TempDir()
+	writeTestGPUFileInternal(t, filepath.Join(sysfsPath, "card0", "device", "vendor"), "0x1002\n")
+
+	path, ok := findIntelGPUPathInternal(sysfsPath)
+	require.False(t, ok)
+	require.Empty(t, path)
+}
+
+func TestDetectGPUsInternal_AMDWinsOverIntel(t *testing.T) {
+	t.Parallel()
+
+	sysfsPath := t.TempDir()
+	writeTestGPUFileInternal(t, filepath.Join(sysfsPath, "card0", "device", "vendor"), "0x8086\n")
+	writeTestGPUFileInternal(t, filepath.Join(sysfsPath, "card1", "device", "vendor"), "0x1002\n")
+	writeTestGPUFileInternal(t, filepath.Join(sysfsPath, "card1", "device", "mem_info_vram_total"), "1024\n")
+	writeTestGPUFileInternal(t, filepath.Join(sysfsPath, "card1", "device", "mem_info_vram_used"), "128\n")
+
+	handler := newTestWebSocketHandler()
+	handler.gpuSysfsPath = sysfsPath
+	handler.execLookPath = func(file string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+
+	err := handler.detectGPUs(t.Context())
+	require.NoError(t, err)
+
+	handler.gpuDetectionCache.RLock()
+	defer handler.gpuDetectionCache.RUnlock()
+	require.Equal(t, "amd", handler.gpuDetectionCache.gpuType)
+	require.Equal(t, sysfsPath, handler.gpuDetectionCache.toolPath)
+}
+
+func TestDetectGPUsInternal_NVIDIAWinsOverIntel(t *testing.T) {
+	t.Parallel()
+
+	sysfsPath := t.TempDir()
+	writeTestGPUFileInternal(t, filepath.Join(sysfsPath, "card0", "device", "vendor"), "0x8086\n")
+
+	handler := newTestWebSocketHandler()
+	handler.gpuSysfsPath = sysfsPath
+	handler.execLookPath = func(file string) (string, error) {
+		if file == "nvidia-smi" {
+			return "/usr/bin/nvidia-smi", nil
+		}
+		return "", exec.ErrNotFound
+	}
+
+	err := handler.detectGPUs(t.Context())
+	require.NoError(t, err)
+
+	handler.gpuDetectionCache.RLock()
+	defer handler.gpuDetectionCache.RUnlock()
+	require.Equal(t, "nvidia", handler.gpuDetectionCache.gpuType)
+	require.Equal(t, "/usr/bin/nvidia-smi", handler.gpuDetectionCache.toolPath)
+}
+
+func TestDetectGPUsInternal_GPUTypeIntelFallsBackToAuto(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestWebSocketHandler()
+	handler.gpuType = "intel"
+	handler.gpuSysfsPath = t.TempDir()
+	handler.execLookPath = func(file string) (string, error) {
+		if file == "nvidia-smi" {
+			return "/usr/bin/nvidia-smi", nil
+		}
+		return "", exec.ErrNotFound
+	}
+
+	err := handler.detectGPUs(t.Context())
+	require.NoError(t, err)
+
+	handler.gpuDetectionCache.RLock()
+	defer handler.gpuDetectionCache.RUnlock()
+	require.Equal(t, "nvidia", handler.gpuDetectionCache.gpuType)
+	require.Equal(t, "/usr/bin/nvidia-smi", handler.gpuDetectionCache.toolPath)
+}
+
+func TestGetIntelStatsInternal_RemainsPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestWebSocketHandler()
+
+	stats, err := handler.getIntelStats(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, []systemtypes.GPUStats{
+		{
+			Name:        "Intel GPU",
+			Index:       0,
+			MemoryUsed:  0,
+			MemoryTotal: 0,
+		},
+	}, stats)
+}
+
+func writeTestGPUFileInternal(t *testing.T, path string, contents string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
 }
 
 func dialWebSocket(t *testing.T, serverURL, path string) *websocket.Conn {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,9 +73,6 @@ ARG REVISION
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl tzdata tar gzip \
     vainfo clinfo libdrm2 libsystemd0 \
-    && if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get install -y --no-install-recommends intel-gpu-tools; \
-    fi \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV GIN_MODE=release
@@ -85,8 +82,7 @@ ENV NVIDIA_VISIBLE_DEVICES=all \
     NVIDIA_DRIVER_CAPABILITIES=compute,utility \
     ROCR_VISIBLE_DEVICES=all \
     HIP_VISIBLE_DEVICES=all \
-    ONEAPI_DEVICE_SELECTOR=level_zero:*,opencl:* \
-    LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/opt/rocm/lib:/opt/intel/oneapi/lib:/opt/intel/oneapi/lib/intel64:/usr/lib/x86_64-linux-gnu:/usr/lib/aarch64-linux-gnu:/usr/lib64:/usr/lib:/lib64:/lib
+    ONEAPI_DEVICE_SELECTOR=level_zero:*,opencl:*
 
 
 WORKDIR /app

--- a/docker/Dockerfile-agent
+++ b/docker/Dockerfile-agent
@@ -46,9 +46,6 @@ ARG TARGETARCH
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl tzdata tar gzip \
     vainfo clinfo libdrm2 libsystemd0 \
-    && if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get install -y --no-install-recommends intel-gpu-tools; \
-    fi \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -63,8 +60,7 @@ ENV NVIDIA_VISIBLE_DEVICES=all \
     NVIDIA_DRIVER_CAPABILITIES=compute,utility \
     ROCR_VISIBLE_DEVICES=all \
     HIP_VISIBLE_DEVICES=all \
-    ONEAPI_DEVICE_SELECTOR=level_zero:*,opencl:* \
-    LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/opt/rocm/lib:/opt/intel/oneapi/lib:/opt/intel/oneapi/lib/intel64:/usr/lib/x86_64-linux-gnu:/usr/lib/aarch64-linux-gnu:/usr/lib64:/usr/lib:/lib64:/lib
+    ONEAPI_DEVICE_SELECTOR=level_zero:*,opencl:*
 
 ENV ENVIRONMENT=production \
     AGENT_MODE=true \


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the `intel-gpu-tools` package dependency from both Docker images and replaces `intel_gpu_top`-based Intel GPU detection with DRM sysfs PCI vendor-ID lookup (`0x8086`), also improving testability by injecting `execLookPath` and `gpuSysfsPath` into the handler.

- **Intel GPU stats are a placeholder**: `getIntelStats` hard-codes `MemoryUsed: 0, MemoryTotal: 0` for all Intel GPUs — a regression from the previous `intel_gpu_top` metrics output. Users with Intel GPUs will see 0/0 in the UI until a follow-up implements sysfs-based stats collection.
- Prior review threads flagged `LD_LIBRARY_PATH` removal (NVIDIA/AMD paths lost) and the `GPU_TYPE=intel` silent fallthrough to auto-detection; both remain open.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge as-is — Intel GPU users will receive 0/0 memory stats, and prior P1 concerns about LD_LIBRARY_PATH and GPU_TYPE=intel silent fallthrough remain unresolved.

Three P1-level findings across this and prior review threads: (1) hardcoded zero Intel GPU stats, (2) LD_LIBRARY_PATH removal drops NVIDIA/AMD library paths, (3) GPU_TYPE=intel silently falls through to a different GPU vendor. All three affect current behavior for GPU-using deployments.

backend/internal/api/ws_handler.go (getIntelStats placeholder), docker/Dockerfile and docker/Dockerfile-agent (LD_LIBRARY_PATH removal)
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `backend/internal/api/ws_handler.go`, line 1875-1888 ([link](https://github.com/getarcaneapp/arcane/blob/850938c4b343c441b470b1526a41cb591364e69b/backend/internal/api/ws_handler.go#L1875-L1888)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`getIntelStats` returns zero memory values with no caller warning**

   The function returns placeholder stats (`MemoryUsed: 0, MemoryTotal: 0`) without any indication to the caller or in the log that the data is fabricated. Downstream consumers (e.g. the WebSocket client) will display 0 MB used out of 0 MB total for an Intel GPU, which is misleading. Consider returning an explicit sentinel or including a `MemoryTotal: -1` / distinct field, or at minimum upgrading the log level from `Debug` to `Warn` so operators know stats are unavailable.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/api/ws_handler.go
   Line: 1875-1888

   Comment:
   **`getIntelStats` returns zero memory values with no caller warning**

   The function returns placeholder stats (`MemoryUsed: 0, MemoryTotal: 0`) without any indication to the caller or in the log that the data is fabricated. Downstream consumers (e.g. the WebSocket client) will display 0 MB used out of 0 MB total for an Intel GPU, which is misleading. Consider returning an explicit sentinel or including a `MemoryTotal: -1` / distinct field, or at minimum upgrading the log level from `Debug` to `Warn` so operators know stats are unavailable.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fapi%2Fws_handler.go%0ALine%3A%201875-1888%0A%0AComment%3A%0A**%60getIntelStats%60%20returns%20zero%20memory%20values%20with%20no%20caller%20warning**%0A%0AThe%20function%20returns%20placeholder%20stats%20%28%60MemoryUsed%3A%200%2C%20MemoryTotal%3A%200%60%29%20without%20any%20indication%20to%20the%20caller%20or%20in%20the%20log%20that%20the%20data%20is%20fabricated.%20Downstream%20consumers%20%28e.g.%20the%20WebSocket%20client%29%20will%20display%200%20MB%20used%20out%20of%200%20MB%20total%20for%20an%20Intel%20GPU%2C%20which%20is%20misleading.%20Consider%20returning%20an%20explicit%20sentinel%20or%20including%20a%20%60MemoryTotal%3A%20-1%60%20%2F%20distinct%20field%2C%20or%20at%20minimum%20upgrading%20the%20log%20level%20from%20%60Debug%60%20to%20%60Warn%60%20so%20operators%20know%20stats%20are%20unavailable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `backend/internal/api/ws_handler.go`, line 1875-1888 ([link](https://github.com/getarcaneapp/arcane/blob/850938c4b343c441b470b1526a41cb591364e69b/backend/internal/api/ws_handler.go#L1875-L1888)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Intel GPU memory stats permanently return 0/0**

   `getIntelStats` always emits zero `MemoryUsed` and `MemoryTotal`, silently replacing the real metrics that `intel_gpu_top` previously produced. Any user whose container detects an Intel GPU — whether via explicit `GPU_TYPE=intel` or via auto-detection — will now see "0 MB / 0 MB" in the UI indefinitely. The owning test (`TestGetIntelStatsInternal_RemainsPlaceholder`) confirms this is a placeholder, but there is no follow-up issue or TODO linking to a real implementation. At minimum, consider reading `gt/gt_cur_freq_mhz` from the already-located `devicePath` that `findIntelGPUPathInternal` returns, or document a tracking issue for the sysfs-based stats work.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/api/ws_handler.go
   Line: 1875-1888

   Comment:
   **Intel GPU memory stats permanently return 0/0**

   `getIntelStats` always emits zero `MemoryUsed` and `MemoryTotal`, silently replacing the real metrics that `intel_gpu_top` previously produced. Any user whose container detects an Intel GPU — whether via explicit `GPU_TYPE=intel` or via auto-detection — will now see "0 MB / 0 MB" in the UI indefinitely. The owning test (`TestGetIntelStatsInternal_RemainsPlaceholder`) confirms this is a placeholder, but there is no follow-up issue or TODO linking to a real implementation. At minimum, consider reading `gt/gt_cur_freq_mhz` from the already-located `devicePath` that `findIntelGPUPathInternal` returns, or document a tracking issue for the sysfs-based stats work.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fapi%2Fws_handler.go%0ALine%3A%201875-1888%0A%0AComment%3A%0A**Intel%20GPU%20memory%20stats%20permanently%20return%200%2F0**%0A%0A%60getIntelStats%60%20always%20emits%20zero%20%60MemoryUsed%60%20and%20%60MemoryTotal%60%2C%20silently%20replacing%20the%20real%20metrics%20that%20%60intel_gpu_top%60%20previously%20produced.%20Any%20user%20whose%20container%20detects%20an%20Intel%20GPU%20%E2%80%94%20whether%20via%20explicit%20%60GPU_TYPE%3Dintel%60%20or%20via%20auto-detection%20%E2%80%94%20will%20now%20see%20%220%20MB%20%2F%200%20MB%22%20in%20the%20UI%20indefinitely.%20The%20owning%20test%20%28%60TestGetIntelStatsInternal_RemainsPlaceholder%60%29%20confirms%20this%20is%20a%20placeholder%2C%20but%20there%20is%20no%20follow-up%20issue%20or%20TODO%20linking%20to%20a%20real%20implementation.%20At%20minimum%2C%20consider%20reading%20%60gt%2Fgt_cur_freq_mhz%60%20from%20the%20already-located%20%60devicePath%60%20that%20%60findIntelGPUPathInternal%60%20returns%2C%20or%20document%20a%20tracking%20issue%20for%20the%20sysfs-based%20stats%20work.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Finternal%2Fapi%2Fws_handler.go%3A1875-1888%0A**Intel%20GPU%20memory%20stats%20permanently%20return%200%2F0**%0A%0A%60getIntelStats%60%20always%20emits%20zero%20%60MemoryUsed%60%20and%20%60MemoryTotal%60%2C%20silently%20replacing%20the%20real%20metrics%20that%20%60intel_gpu_top%60%20previously%20produced.%20Any%20user%20whose%20container%20detects%20an%20Intel%20GPU%20%E2%80%94%20whether%20via%20explicit%20%60GPU_TYPE%3Dintel%60%20or%20via%20auto-detection%20%E2%80%94%20will%20now%20see%20%220%20MB%20%2F%200%20MB%22%20in%20the%20UI%20indefinitely.%20The%20owning%20test%20%28%60TestGetIntelStatsInternal_RemainsPlaceholder%60%29%20confirms%20this%20is%20a%20placeholder%2C%20but%20there%20is%20no%20follow-up%20issue%20or%20TODO%20linking%20to%20a%20real%20implementation.%20At%20minimum%2C%20consider%20reading%20%60gt%2Fgt_cur_freq_mhz%60%20from%20the%20already-located%20%60devicePath%60%20that%20%60findIntelGPUPathInternal%60%20returns%2C%20or%20document%20a%20tracking%20issue%20for%20the%20sysfs-based%20stats%20work.%0A%0A%23%23%23%20Issue%202%20of%203%0Abackend%2Finternal%2Fapi%2Fws_handler.go%3A1876%0A**Missing%20%60Internal%60%20suffix%20on%20unexported%20method**%0A%0AThe%20team%20convention%20requires%20all%20unexported%20functions%20to%20carry%20an%20%60Internal%60%20suffix.%20The%20test%20for%20this%20function%20is%20already%20named%20%60TestGetIntelStatsInternal_RemainsPlaceholder%60%2C%20so%20this%20appears%20to%20be%20an%20accidental%20omission.%0A%0A%60%60%60suggestion%0Afunc%20%28h%20*WebSocketHandler%29%20getIntelStatsInternal%28ctx%20context.Context%29%20%28%5B%5Dsystemtypes.GPUStats%2C%20error%29%20%7B%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A%23%23%23%20Issue%203%20of%203%0Adocker%2FDockerfile%3A85%0A**%60ONEAPI_DEVICE_SELECTOR%60%20is%20now%20unused**%0A%0ANow%20that%20%60intel-gpu-tools%60%20is%20removed%20and%20GPU%20detection%20relies%20entirely%20on%20DRM%20sysfs%20entries%2C%20%60ONEAPI_DEVICE_SELECTOR%3Dlevel_zero%3A*%2Copencl%3A*%60%20%28an%20Intel%20oneAPI-specific%20env%20var%29%20no%20longer%20influences%20any%20code%20path%20in%20the%20application.%20It%20can%20be%20removed.%20The%20same%20stale%20variable%20remains%20in%20%60docker%2FDockerfile-agent%60.%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/api/ws_handler.go
Line: 1875-1888

Comment:
**Intel GPU memory stats permanently return 0/0**

`getIntelStats` always emits zero `MemoryUsed` and `MemoryTotal`, silently replacing the real metrics that `intel_gpu_top` previously produced. Any user whose container detects an Intel GPU — whether via explicit `GPU_TYPE=intel` or via auto-detection — will now see "0 MB / 0 MB" in the UI indefinitely. The owning test (`TestGetIntelStatsInternal_RemainsPlaceholder`) confirms this is a placeholder, but there is no follow-up issue or TODO linking to a real implementation. At minimum, consider reading `gt/gt_cur_freq_mhz` from the already-located `devicePath` that `findIntelGPUPathInternal` returns, or document a tracking issue for the sysfs-based stats work.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/api/ws_handler.go
Line: 1876

Comment:
**Missing `Internal` suffix on unexported method**

The team convention requires all unexported functions to carry an `Internal` suffix. The test for this function is already named `TestGetIntelStatsInternal_RemainsPlaceholder`, so this appears to be an accidental omission.

```suggestion
func (h *WebSocketHandler) getIntelStatsInternal(ctx context.Context) ([]systemtypes.GPUStats, error) {
```

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docker/Dockerfile
Line: 85

Comment:
**`ONEAPI_DEVICE_SELECTOR` is now unused**

Now that `intel-gpu-tools` is removed and GPU detection relies entirely on DRM sysfs entries, `ONEAPI_DEVICE_SELECTOR=level_zero:*,opencl:*` (an Intel oneAPI-specific env var) no longer influences any code path in the application. It can be removed. The same stale variable remains in `docker/Dockerfile-agent`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: remove intel gpu tools and rel..."](https://github.com/getarcaneapp/arcane/commit/850938c4b343c441b470b1526a41cb591364e69b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28061536)</sub>

<!-- /greptile_comment -->