### PR TITLE
fix: svelte reactivity issues in project editors

### DIFF
--- a/frontend/src/routes/(app)/customize/templates/components/RegistryManager.svelte
+++ b/frontend/src/routes/(app)/customize/templates/components/RegistryManager.svelte
@@ -77,7 +77,7 @@
 								<p class="text-muted-foreground mt-1 text-sm">{registry.description}</p>
 							{/if}
 							{#if registry.lastFetchError}
-								<div class="mt-2 flex items-start gap-1.5 rounded-md border border-destructive/30 bg-destructive/10 px-2 py-1.5">
+								<div class="border-destructive/30 bg-destructive/10 mt-2 flex items-start gap-1.5 rounded-md border px-2 py-1.5">
 									<AlertTriangleIcon class="text-destructive mt-0.5 size-3.5 shrink-0" />
 									<p class="text-destructive text-xs break-all">{registry.lastFetchError}</p>
 								</div>

--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -37,11 +37,10 @@
 	import { queryKeys } from '$lib/query/query-keys';
 	import { RefreshIcon } from '$lib/icons';
 	import IconImage from '$lib/components/icon-image.svelte';
-	import { useQueryClient } from '@tanstack/svelte-query';
+	import { createQuery, useQueryClient } from '@tanstack/svelte-query';
 
 	let { data } = $props();
 	let projectId = $derived(data.projectId);
-	let project = $state(untrack(() => data.project));
 	const queryClient = useQueryClient();
 	const isTablet = new IsTablet();
 
@@ -58,17 +57,22 @@
 		syncing: false
 	});
 
-	const envId = $derived(environmentStore.selected?.id);
+	const envId = $derived(environmentStore.selected?.id || '0');
 
-	let originalName = $state(untrack(() => data.editorState.originalName));
-	let originalComposeContent = $state(untrack(() => data.editorState.originalComposeContent));
-	let originalEnvContent = $state(untrack(() => data.editorState.originalEnvContent || ''));
 	let includeFilesState = $state<Record<string, string>>({});
-	let originalIncludeFiles = $state<Record<string, string>>({});
+	let loadedIncludeFileContents = $state<Record<string, string>>({});
+	let loadedDirectoryFileContents = $state<Record<string, string>>({});
 	let projectFilePromises: Record<string, Promise<IncludeFile> | undefined> = {};
 	const globalVariableMap = $derived.by(() =>
 		Object.fromEntries((data.globalVariables ?? []).map((item) => [item.key, item.value]))
 	);
+
+	const projectDetailQuery = createQuery(() => ({
+		queryKey: queryKeys.projects.detail(envId, projectId),
+		queryFn: () => projectService.getProjectForEnvironment(envId, projectId),
+		initialData: data.project,
+		refetchOnMount: false
+	}));
 
 	const formSchema = z.object({
 		name: z
@@ -87,11 +91,39 @@
 
 	const { inputs, ...form } = createForm<typeof formSchema>(formSchema, initialFormData);
 
+	function withLoadedProjectFileContent(details: Project | null | undefined): Project | null {
+		if (!details) return null;
+
+		return {
+			...details,
+			includeFiles: (details.includeFiles ?? []).map((file) => ({
+				...file,
+				content: file.content ?? loadedIncludeFileContents[file.relativePath]
+			})),
+			directoryFiles: (details.directoryFiles ?? []).map((file) => ({
+				...file,
+				content: file.content ?? loadedDirectoryFileContents[file.relativePath]
+			}))
+		};
+	}
+
+	const project = $derived.by(() => withLoadedProjectFileContent(projectDetailQuery.data ?? data.project));
+	const serverName = $derived(project?.name ?? '');
+	const serverComposeContent = $derived(project?.composeContent ?? '');
+	const serverEnvContent = $derived(project?.envContent ?? '');
+	const serverIncludeFiles = $derived.by(() =>
+		Object.fromEntries(
+			(project?.includeFiles ?? []).flatMap((file) =>
+				file.content === undefined ? [] : [[file.relativePath, file.content] as const]
+			)
+		)
+	);
+
 	let hasChanges = $derived(
-		$inputs.name.value !== originalName ||
-			$inputs.composeContent.value !== originalComposeContent ||
-			$inputs.envContent.value !== originalEnvContent ||
-			JSON.stringify(includeFilesState) !== JSON.stringify(originalIncludeFiles)
+		$inputs.name.value !== serverName ||
+			$inputs.composeContent.value !== serverComposeContent ||
+			$inputs.envContent.value !== serverEnvContent ||
+			Object.entries(includeFilesState).some(([relativePath, content]) => content !== serverIncludeFiles[relativePath])
 	);
 
 	let isGitOpsManaged = $derived(!!project?.gitOpsManagedBy);
@@ -109,9 +141,9 @@
 	let composeOpen = $state(true);
 	let envOpen = $state(true);
 	let includeFilesPanelStates = $state<Record<string, boolean>>({});
-	let selectedFile = $state<'compose' | 'env' | string>('compose');
+	let selectedFilePreference = $state<'compose' | 'env' | string>('compose');
 	let layoutMode = $state<'classic' | 'tree'>('classic');
-	let selectedIncludeTab = $state<string | null>(null);
+	let selectedIncludeTabPreference = $state<string | null>(null);
 	let treePaneWidth = $state(320);
 	let composeSplitWidth = $state<number | null>(null);
 	const minTreePaneWidth = 200;
@@ -125,12 +157,24 @@
 	let composeValidationReady = $state(false);
 	let envValidationReady = $state(false);
 	let includeFilesValidationReady = $state<Record<string, boolean>>({});
-	let composeHasChanges = $derived($inputs.composeContent.value !== originalComposeContent);
-	let envHasChanges = $derived($inputs.envContent.value !== originalEnvContent);
+	const includeFilePaths = $derived.by(() => new Set((project?.includeFiles ?? []).map((file) => file.relativePath)));
+	const directoryFilePaths = $derived.by(() => new Set((project?.directoryFiles ?? []).map((file) => file.relativePath)));
+	const selectedFile = $derived.by(() => {
+		const current = selectedFilePreference;
+		if (current === 'compose' || current === 'env') return current;
+		if (current.startsWith('dir:')) {
+			return directoryFilePaths.has(current.slice(4)) ? current : 'compose';
+		}
+		return includeFilePaths.has(current) ? current : 'compose';
+	});
+	const selectedIncludeTab = $derived.by(() => {
+		if (!selectedIncludeTabPreference) return null;
+		return includeFilePaths.has(selectedIncludeTabPreference) ? selectedIncludeTabPreference : null;
+	});
+	let composeHasChanges = $derived($inputs.composeContent.value !== serverComposeContent);
+	let envHasChanges = $derived($inputs.envContent.value !== serverEnvContent);
 	let changedIncludeFilePaths = $derived.by(() =>
-		Object.keys(includeFilesState).filter(
-			(relativePath) => includeFilesState[relativePath] !== originalIncludeFiles[relativePath]
-		)
+		Object.keys(includeFilesState).filter((relativePath) => includeFilesState[relativePath] !== serverIncludeFiles[relativePath])
 	);
 
 	let hasAnyErrors = $derived(
@@ -184,112 +228,41 @@
 	};
 
 	let prefs: PersistedState<ComposeUIPrefs> | null = null;
-	let lastAppliedProjectId = $state<string | null>(null);
-	let lastSeenProjectSignature = $state<string | null>(null);
 	let lastPrefsProjectId = $state<string | null>(null);
 
-	type ApplyProjectMode = 'initialize' | 'saved' | 'refresh';
-
-	function buildProjectSyncSignature(details: Project): string {
-		return JSON.stringify({
-			id: details.id,
-			name: details.name,
-			status: details.status,
-			statusReason: details.statusReason,
-			runningCount: details.runningCount,
-			serviceCount: details.serviceCount,
-			updatedAt: details.updatedAt,
-			composeContent: details.composeContent ?? '',
-			envContent: details.envContent ?? '',
-			includeFiles: (details.includeFiles ?? []).map((file) => ({
-				relativePath: file.relativePath
-			})),
-			directoryFiles: (details.directoryFiles ?? []).map((file) => ({
-				relativePath: file.relativePath
-			})),
-			runtimeServices: (details.runtimeServices ?? []).map((service) => ({
-				name: service.name,
-				status: service.status,
-				containerId: service.containerId,
-				containerName: service.containerName
-			})),
-			composeFileName: details.composeFileName ?? ''
-		});
-	}
-
-	function buildIncludeFilesMap(details: Project): Record<string, string> {
-		return Object.fromEntries((details.includeFiles ?? []).map((file) => [file.relativePath, file.content ?? '']));
-	}
-
-	function withLoadedProjectFileContent(details: Project): Project {
-		const existingIncludeFiles = project?.includeFiles ?? [];
-		const existingDirectoryFiles = project?.directoryFiles ?? [];
-
-		return {
-			...details,
-			includeFiles: (details.includeFiles ?? []).map((file) => ({
-				...file,
-				content:
-					file.content ??
-					includeFilesState[file.relativePath] ??
-					originalIncludeFiles[file.relativePath] ??
-					existingIncludeFiles.find((existingFile) => existingFile.relativePath === file.relativePath)?.content
-			})),
-			directoryFiles: (details.directoryFiles ?? []).map((file) => ({
-				...file,
-				content:
-					file.content ?? existingDirectoryFiles.find((existingFile) => existingFile.relativePath === file.relativePath)?.content
-			}))
-		};
-	}
-
-	function syncIncludeFileUiState(details: Project) {
-		const nextPanelStates: Record<string, boolean> = {};
-		const nextErrors: Record<string, boolean> = {};
-		const nextValidationReady: Record<string, boolean> = {};
-
-		for (const file of details.includeFiles ?? []) {
-			nextPanelStates[file.relativePath] = includeFilesPanelStates[file.relativePath] ?? true;
-			nextErrors[file.relativePath] = includeFilesHasErrors[file.relativePath] ?? false;
-			nextValidationReady[file.relativePath] = includeFilesValidationReady[file.relativePath] ?? true;
+	function ensureIncludeFileUiState(relativePath: string) {
+		if (includeFilesPanelStates[relativePath] === undefined) {
+			includeFilesPanelStates = {
+				...includeFilesPanelStates,
+				[relativePath]: true
+			};
 		}
-
-		includeFilesPanelStates = nextPanelStates;
-		includeFilesHasErrors = nextErrors;
-		includeFilesValidationReady = nextValidationReady;
-
-		if (selectedIncludeTab && !(selectedIncludeTab in nextPanelStates)) {
-			selectedIncludeTab = null;
+		if (includeFilesHasErrors[relativePath] === undefined) {
+			includeFilesHasErrors = {
+				...includeFilesHasErrors,
+				[relativePath]: false
+			};
 		}
-		if (selectedFile !== 'compose' && selectedFile !== 'env' && !(selectedFile in nextPanelStates)) {
-			selectedFile = 'compose';
+		if (includeFilesValidationReady[relativePath] === undefined) {
+			includeFilesValidationReady = {
+				...includeFilesValidationReady,
+				[relativePath]: true
+			};
 		}
 	}
 
-	function applyProjectDetailsToEditor(details: Project, mode: ApplyProjectMode) {
-		details = withLoadedProjectFileContent(details);
-		project = details;
-		lastSeenProjectSignature = buildProjectSyncSignature(details);
-		syncIncludeFileUiState(details);
+	function rebaseEditorDraft(details: Project) {
+		const normalizedProject = withLoadedProjectFileContent(details);
+		if (!normalizedProject) return;
 
-		const nextName = details.name || '';
-		const nextComposeContent = details.composeContent || '';
-		const nextEnvContent = details.envContent || '';
-		const nextIncludeFiles = buildIncludeFilesMap(details);
-		const shouldSyncEditorState = mode === 'initialize' || mode === 'saved' || lastAppliedProjectId !== details.id || !hasChanges;
-
-		if (shouldSyncEditorState) {
-			originalName = nextName;
-			originalComposeContent = nextComposeContent;
-			originalEnvContent = nextEnvContent;
-			originalIncludeFiles = { ...nextIncludeFiles };
-			$inputs.name.value = nextName;
-			$inputs.composeContent.value = nextComposeContent;
-			$inputs.envContent.value = nextEnvContent;
-			includeFilesState = { ...nextIncludeFiles };
-		}
-
-		lastAppliedProjectId = details.id;
+		$inputs.name.value = normalizedProject.name || '';
+		$inputs.composeContent.value = normalizedProject.composeContent || '';
+		$inputs.envContent.value = normalizedProject.envContent || '';
+		includeFilesState = Object.fromEntries(
+			(normalizedProject.includeFiles ?? []).flatMap((file) =>
+				file.content === undefined ? [] : [[file.relativePath, file.content] as const]
+			)
+		);
 	}
 
 	async function syncProjectQueries(updatedProject: Project) {
@@ -301,27 +274,6 @@
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.statusCounts(currentEnvId) })
 		]);
 	}
-
-	$effect(() => {
-		const incomingProject = data.project;
-		if (!incomingProject) return;
-
-		const normalizedProject = withLoadedProjectFileContent(incomingProject);
-		const incomingProjectSignature = buildProjectSyncSignature(normalizedProject);
-		const previousSignature = untrack(() => lastSeenProjectSignature);
-		if (incomingProjectSignature === previousSignature) return;
-
-		lastSeenProjectSignature = incomingProjectSignature;
-
-		const projectChanged = untrack(() => lastAppliedProjectId) !== normalizedProject.id;
-		if (projectChanged || !hasChanges) {
-			applyProjectDetailsToEditor(normalizedProject, projectChanged ? 'initialize' : 'refresh');
-			return;
-		}
-
-		project = normalizedProject;
-		syncIncludeFileUiState(normalizedProject);
-	});
 
 	$effect(() => {
 		if (!project?.id) return;
@@ -337,7 +289,7 @@
 		composeOpen = cur.composeOpen ?? defaultComposeUIPrefs.composeOpen;
 		envOpen = cur.envOpen ?? defaultComposeUIPrefs.envOpen;
 		autoScrollStackLogs = cur.autoScroll ?? defaultComposeUIPrefs.autoScroll;
-		selectedFile = cur.selectedFile ?? defaultComposeUIPrefs.selectedFile ?? 'compose';
+		selectedFilePreference = cur.selectedFile ?? defaultComposeUIPrefs.selectedFile ?? 'compose';
 
 		// Auto-detect layout mode based on includeFiles or directoryFiles
 		const hasIncludes = project?.includeFiles && project.includeFiles.length > 0;
@@ -374,7 +326,7 @@
 						continue;
 					}
 
-					if (includeFileContent !== originalIncludeFiles[relativePath]) {
+					if (includeFileContent !== serverIncludeFiles[relativePath]) {
 						const includeResult = await tryCatch(
 							projectService.updateProjectIncludeFile(projectId, relativePath, includeFileContent)
 						);
@@ -386,19 +338,23 @@
 					}
 				}
 
-				applyProjectDetailsToEditor(savedProject, 'saved');
-				// Pass the enriched project (with locally-preserved include file
-				// content) to the query cache so that any reactive re-read after
-				// save doesn't revert the editor to the lazy-loaded (content-less)
-				// server response.
-				await syncProjectQueries(withLoadedProjectFileContent(savedProject));
+				loadedIncludeFileContents = {
+					...loadedIncludeFileContents,
+					...Object.fromEntries(
+						Object.entries(includeFilesState).filter(([relativePath]) =>
+							(savedProject.includeFiles ?? []).some((file) => file.relativePath === relativePath)
+						)
+					)
+				};
+				rebaseEditorDraft(savedProject);
+				await syncProjectQueries(savedProject);
 				toast.success(m.common_update_success({ resource: m.project() }));
 			}
 		});
 	}
 
 	function saveNameIfChanged() {
-		if ($inputs.name.value === originalName) return;
+		if ($inputs.name.value === serverName) return;
 		const validated = form.validate();
 		if (!validated) return;
 		handleSaveChanges();
@@ -430,31 +386,24 @@
 	}
 
 	function updateLoadedProjectFile(kind: ProjectFileKind, relativePath: string, content: string) {
-		if (!project) return;
-
 		if (kind === 'include') {
-			project = {
-				...project,
-				includeFiles: (project.includeFiles ?? []).map((file) =>
-					file.relativePath === relativePath ? { ...file, content } : file
-				)
-			};
-			includeFilesState = {
-				...includeFilesState,
+			ensureIncludeFileUiState(relativePath);
+			loadedIncludeFileContents = {
+				...loadedIncludeFileContents,
 				[relativePath]: content
 			};
-			originalIncludeFiles = {
-				...originalIncludeFiles,
-				[relativePath]: content
-			};
+			if (includeFilesState[relativePath] === undefined) {
+				includeFilesState = {
+					...includeFilesState,
+					[relativePath]: content
+				};
+			}
 			return;
 		}
 
-		project = {
-			...project,
-			directoryFiles: (project.directoryFiles ?? []).map((file) =>
-				file.relativePath === relativePath ? { ...file, content } : file
-			)
+		loadedDirectoryFileContents = {
+			...loadedDirectoryFileContents,
+			[relativePath]: content
 		};
 	}
 
@@ -462,6 +411,9 @@
 		const currentProjectId = project?.id;
 		if (!currentProjectId) {
 			throw new Error('Project is not loaded');
+		}
+		if (kind === 'include') {
+			ensureIncludeFileUiState(relativePath);
 		}
 
 		const targetFile =
@@ -500,23 +452,25 @@
 	}
 
 	function selectComposeFile() {
-		selectedFile = 'compose';
+		selectedFilePreference = 'compose';
 	}
 
 	function selectEnvFile() {
-		selectedFile = 'env';
+		selectedFilePreference = 'env';
 	}
 
 	function selectIncludeFile(relativePath: string) {
-		selectedFile = relativePath;
+		ensureIncludeFileUiState(relativePath);
+		selectedFilePreference = relativePath;
 	}
 
 	function selectDirectoryFile(relativePath: string) {
-		selectedFile = `dir:${relativePath}`;
+		selectedFilePreference = `dir:${relativePath}`;
 	}
 
 	function toggleIncludeFileTab(relativePath: string) {
-		selectedIncludeTab = selectedIncludeTab === relativePath ? null : relativePath;
+		ensureIncludeFileUiState(relativePath);
+		selectedIncludeTabPreference = selectedIncludeTab === relativePath ? null : relativePath;
 	}
 
 	const allComposeContents = $derived.by(() => {
@@ -533,15 +487,11 @@
 		handleApiResultWithCallbacks({
 			result: await tryCatch(projectService.getProject(projectId)),
 			message: m.common_refresh_failed({ resource: m.project() }),
-			onSuccess: (updatedProject) => {
-				updatedProject = withLoadedProjectFileContent(updatedProject);
-				if (hasChanges && lastAppliedProjectId === updatedProject.id) {
-					project = updatedProject;
-					syncIncludeFileUiState(updatedProject);
-					return;
+			onSuccess: async (updatedProject) => {
+				if (!hasChanges) {
+					rebaseEditorDraft(updatedProject);
 				}
-
-				applyProjectDetailsToEditor(updatedProject, 'refresh');
+				await syncProjectQueries(updatedProject);
 			}
 		});
 	}
@@ -610,7 +560,7 @@
 							bind:ref={nameInputRef}
 							variant="inline"
 							error={$inputs.name.error ?? undefined}
-							originalValue={originalName}
+							originalValue={serverName}
 							canEdit={canEditName}
 							onCommit={saveNameIfChanged}
 							class="max-w-[10rem] min-w-0 sm:max-w-[14rem] md:max-w-[18rem] lg:max-w-[22rem]"
@@ -704,7 +654,7 @@
 					bind:restartLoading={isLoading.restarting}
 					bind:removeLoading={isLoading.removing}
 					bind:redeployLoading={isLoading.redeploying}
-					onActionComplete={() => invalidateAll()}
+					onActionComplete={refreshProjectDetails}
 					onRefresh={refreshProjectDetails}
 				/>
 			</div>
@@ -774,8 +724,8 @@
 							onCheckedChange={(checked) => {
 								layoutMode = checked ? 'tree' : 'classic';
 								if (checked) {
-									selectedFile = 'compose';
-									selectedIncludeTab = null;
+									selectedFilePreference = 'compose';
+									selectedIncludeTabPreference = null;
 								}
 								persistPrefs();
 							}}
@@ -855,7 +805,7 @@
 												bind:hasErrors={composeHasErrors}
 												bind:validationReady={composeValidationReady}
 												fileId={`project:${projectId}:compose`}
-												originalValue={originalComposeContent}
+												originalValue={serverComposeContent}
 												enableDiff={true}
 												editorContext={codeEditorContext}
 											/>
@@ -870,7 +820,7 @@
 												bind:hasErrors={envHasErrors}
 												bind:validationReady={envValidationReady}
 												fileId={`project:${projectId}:env`}
-												originalValue={originalEnvContent}
+												originalValue={serverEnvContent}
 												enableDiff={true}
 												editorContext={codeEditorContext}
 											/>
@@ -914,7 +864,7 @@
 														bind:hasErrors={includeFilesHasErrors[includeFile.relativePath]}
 														bind:validationReady={includeFilesValidationReady[includeFile.relativePath]}
 														fileId={`project:${projectId}:include:${includeFile.relativePath}`}
-														originalValue={originalIncludeFiles[includeFile.relativePath]}
+														originalValue={serverIncludeFiles[includeFile.relativePath] ?? ''}
 														enableDiff={true}
 														editorContext={codeEditorContext}
 													/>
@@ -1014,7 +964,7 @@
 													bind:hasErrors={composeHasErrors}
 													bind:validationReady={composeValidationReady}
 													fileId={`project:${projectId}:compose`}
-													originalValue={originalComposeContent}
+													originalValue={serverComposeContent}
 													enableDiff={true}
 													editorContext={codeEditorContext}
 												/>
@@ -1029,7 +979,7 @@
 													bind:hasErrors={envHasErrors}
 													bind:validationReady={envValidationReady}
 													fileId={`project:${projectId}:env`}
-													originalValue={originalEnvContent}
+													originalValue={serverEnvContent}
 													enableDiff={true}
 													editorContext={codeEditorContext}
 												/>
@@ -1073,7 +1023,7 @@
 															bind:hasErrors={includeFilesHasErrors[includeFile.relativePath]}
 															bind:validationReady={includeFilesValidationReady[includeFile.relativePath]}
 															fileId={`project:${projectId}:include:${includeFile.relativePath}`}
-															originalValue={originalIncludeFiles[includeFile.relativePath]}
+															originalValue={serverIncludeFiles[includeFile.relativePath] ?? ''}
 															enableDiff={true}
 															editorContext={codeEditorContext}
 														/>
@@ -1126,7 +1076,7 @@
 												bind:hasErrors={includeFilesHasErrors[includeFile.relativePath]}
 												bind:validationReady={includeFilesValidationReady[includeFile.relativePath]}
 												fileId={`project:${projectId}:include:${includeFile.relativePath}`}
-												originalValue={originalIncludeFiles[includeFile.relativePath]}
+												originalValue={serverIncludeFiles[includeFile.relativePath] ?? ''}
 												enableDiff={true}
 												editorContext={codeEditorContext}
 											/>
@@ -1150,7 +1100,7 @@
 											bind:hasErrors={composeHasErrors}
 											bind:validationReady={composeValidationReady}
 											fileId={`project:${projectId}:compose`}
-											originalValue={originalComposeContent}
+											originalValue={serverComposeContent}
 											enableDiff={true}
 											editorContext={codeEditorContext}
 										/>
@@ -1164,7 +1114,7 @@
 											bind:hasErrors={envHasErrors}
 											bind:validationReady={envValidationReady}
 											fileId={`project:${projectId}:env`}
-											originalValue={originalEnvContent}
+											originalValue={serverEnvContent}
 											enableDiff={true}
 											editorContext={codeEditorContext}
 										/>
@@ -1194,7 +1144,7 @@
 													bind:hasErrors={composeHasErrors}
 													bind:validationReady={composeValidationReady}
 													fileId={`project:${projectId}:compose`}
-													originalValue={originalComposeContent}
+													originalValue={serverComposeContent}
 													enableDiff={true}
 													editorContext={codeEditorContext}
 												/>
@@ -1213,7 +1163,7 @@
 													bind:hasErrors={envHasErrors}
 													bind:validationReady={envValidationReady}
 													fileId={`project:${projectId}:env`}
-													originalValue={originalEnvContent}
+													originalValue={serverEnvContent}
 													enableDiff={true}
 													editorContext={codeEditorContext}
 												/>

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -1039,6 +1039,74 @@ test.describe('Project Detail Page', () => {
 		await expect(page.getByRole('button', { name: 'Save', exact: true }).first()).toBeEnabled();
 	});
 
+	test('should keep saved compose edits visible without a page refresh', async ({ page }) => {
+		const projectName = `save-persist-${Date.now()}`;
+		await createProjectViaUI(page, projectName);
+
+		try {
+			const configTab = page.getByRole('tab', { name: /Configuration|Config/i });
+			await configTab.click();
+			await page.waitForLoadState('networkidle');
+
+			let composeEditor = page.locator('.cm-editor:visible').first();
+			await expect(composeEditor).toBeVisible();
+
+			const marker = `ARCANE_SAVE_PERSIST_${Date.now()}`;
+			const composeContent = composeEditor.locator('.cm-content').first();
+			await expect(composeContent).toBeVisible();
+			await composeContent.click({ position: { x: 10, y: 10 } });
+			await page.keyboard.type(`# ${marker}\n`, { delay: 0 });
+
+			const saveButtons = page.getByRole('button', { name: 'Save', exact: true });
+			await expect(saveButtons.first()).toBeVisible();
+			await expect(saveButtons.first()).toBeEnabled();
+			await saveButtons.first().click();
+
+			await expect(saveButtons).toHaveCount(0);
+
+			composeEditor = page.locator('.cm-editor:visible').first();
+			await expect
+				.poll(async () => getCodeMirrorValue(composeEditor), {
+					message: 'expected saved compose editor content to remain visible'
+				})
+				.toContain(marker);
+
+			const layoutSwitch = page.getByRole('switch', {
+				name: /Classic|Tree View/i
+			});
+			if (await layoutSwitch.count()) {
+				await layoutSwitch.click();
+				await expect(page.locator('.cm-editor:visible').first()).toBeVisible();
+
+				composeEditor = page.locator('.cm-editor:visible').first();
+				await expect
+					.poll(async () => getCodeMirrorValue(composeEditor), {
+						message: 'expected saved compose editor content to persist across layout changes'
+					})
+					.toContain(marker);
+			}
+
+			await page.reload();
+			await page.waitForLoadState('networkidle');
+
+			const restoredConfigTab = page.getByRole('tab', { name: /Configuration|Config/i });
+			if ((await restoredConfigTab.getAttribute('aria-selected')) !== 'true') {
+				await restoredConfigTab.click();
+				await page.waitForLoadState('networkidle');
+			}
+
+			composeEditor = page.locator('.cm-editor:visible').first();
+			await expect(composeEditor).toBeVisible();
+			await expect
+				.poll(async () => getCodeMirrorValue(composeEditor), {
+					message: 'expected saved compose editor content to persist after reload'
+				})
+				.toContain(marker);
+		} finally {
+			await destroyCurrentProjectViaUI(page);
+		}
+	});
+
 	test('should show logs tab for running projects', async ({ page }) => {
 		test.skip(!realProjects.length, 'No projects available for logs test');
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2315
Fixes: https://github.com/getarcaneapp/arcane/issues/2293

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Svelte reactivity issues in the project editor by replacing static `$state(untrack(...))` snapshots (`originalName`, `originalComposeContent`, `originalEnvContent`, `originalIncludeFiles`) with properly reactive `$derived` values sourced from a new `createQuery` whose cache is updated via `setQueryData` after every save. It also renames `selectedFile`/`selectedIncludeTab` from mutable `$state` to a "preference + `$derived`" pattern, and adds an E2E test covering the persistence of saved edits without a page reload.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge; all remaining findings are minor style/hardening suggestions with no impact on the primary save-persist fix.

The reactivity refactor is sound: derived server values stay in sync with the query cache, rebaseEditorDraft + setQueryData correctly reset hasChanges after a save, and the include-file change detection logic is equivalent or better than the previous JSON.stringify comparison. The only open item is the envId || '0' fallback which is a P2 edge-case hardening suggestion, not a present defect on the fixed path.

No files require special attention beyond the minor envId guard suggestion in +page.svelte.
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fprojects%2F%5BprojectId%5D%2F%2Bpage.svelte%3A60-75%0A**%60'0'%60%20fallback%20for%20%60envId%60%20may%20trigger%20invalid%20API%20calls%20on%20refetch**%0A%0AWhen%20%60environmentStore.selected%3F.id%60%20is%20%60undefined%60%2C%20%60envId%60%20becomes%20%60'0'%60.%20With%20%60refetchOnMount%3A%20false%60%20and%20%60initialData%60%20set%20the%20initial%20mount%20is%20safe%2C%20but%20TanStack%20Query%20still%20refetches%20on%20window-focus%20events.%20If%20the%20environment%20store%20hasn't%20resolved%20by%20then%2C%20%60projectService.getProjectForEnvironment%28'0'%2C%20projectId%29%60%20will%20fire%2C%20potentially%20returning%20an%20error%20or%20stale%20data%20that%20overwrites%20the%20cache%20entry.%20Consider%20pairing%20the%20fallback%20with%20an%20%60enabled%3A%20!!environmentStore.selected%3F.id%60%20guard%20on%20the%20query%20so%20refetches%20are%20suppressed%20until%20a%20real%20environment%20ID%20is%20available.%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/routes/(app)/projects/[projectId]/+page.svelte
Line: 60-75

Comment:
**`'0'` fallback for `envId` may trigger invalid API calls on refetch**

When `environmentStore.selected?.id` is `undefined`, `envId` becomes `'0'`. With `refetchOnMount: false` and `initialData` set the initial mount is safe, but TanStack Query still refetches on window-focus events. If the environment store hasn't resolved by then, `projectService.getProjectForEnvironment('0', projectId)` will fire, potentially returning an error or stale data that overwrites the cache entry. Consider pairing the fallback with an `enabled: !!environmentStore.selected?.id` guard on the query so refetches are suppressed until a real environment ID is available.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: svelte reactivity issues in project..."](https://github.com/getarcaneapp/arcane/commit/1026c315b9ce707abac9aa25e7d8e756814b7174) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28067534)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->