### PR TITLE
fix: light mode contrast for container stats CPU/memory monitor (#2341)

### DIFF
--- a/frontend/src/routes/(app)/containers/components/ContainerLogStatMonitor.svelte
+++ b/frontend/src/routes/(app)/containers/components/ContainerLogStatMonitor.svelte
@@ -18,8 +18,10 @@
 
 	let { icon, label, value, detail, history, tone = 'cpu', loading = false, disabled = false, testId }: Props = $props();
 
-	const barColorClass = $derived(tone === 'cpu' ? 'bg-sky-400/75' : 'bg-emerald-400/75');
-	const iconColorClass = $derived(tone === 'cpu' ? 'text-sky-300' : 'text-emerald-300');
+	const barColorClass = $derived(
+		tone === 'cpu' ? 'bg-sky-500/75 dark:bg-sky-400/75' : 'bg-emerald-500/75 dark:bg-emerald-400/75'
+	);
+	const iconColorClass = $derived(tone === 'cpu' ? 'text-sky-600 dark:text-sky-300' : 'text-emerald-600 dark:text-emerald-300');
 	const Icon = $derived(icon);
 </script>
 
@@ -32,15 +34,15 @@
 >
 	<div class="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3">
 		<div class="flex min-w-0 items-center gap-2">
-			<div class="bg-background/70 flex size-7 shrink-0 items-center justify-center rounded-md border border-white/8">
+			<div class="bg-background/70 border-border/60 flex size-7 shrink-0 items-center justify-center rounded-md border">
 				<Icon class={cn('size-4', disabled ? 'text-muted-foreground' : iconColorClass)} />
 			</div>
 			<div class="min-w-0">
-				<div class="text-[11px] font-medium tracking-normal text-white/70">{label}</div>
+				<div class="text-muted-foreground text-[11px] font-medium tracking-normal">{label}</div>
 				{#if loading}
 					<Skeleton class="mt-1 h-5 w-20" />
 				{:else}
-					<div class={cn('truncate text-sm font-semibold tabular-nums', disabled ? 'text-muted-foreground' : 'text-white')}>
+					<div class={cn('truncate text-sm font-semibold tabular-nums', disabled ? 'text-muted-foreground' : 'text-foreground')}>
 						{value}
 					</div>
 				{/if}
@@ -50,19 +52,19 @@
 		{#if loading}
 			<Skeleton class="mt-0.5 h-4 w-16 justify-self-end" />
 		{:else}
-			<div class="shrink-0 justify-self-end pl-2 text-right text-[11px] text-white/55 tabular-nums">{detail}</div>
+			<div class="text-muted-foreground shrink-0 justify-self-end pl-2 text-right text-[11px] tabular-nums">{detail}</div>
 		{/if}
 	</div>
 
 	{#if loading}
 		<Skeleton class="h-8 w-full" />
 	{:else}
-		<div class="bg-background/60 flex h-8 items-end gap-[3px] overflow-hidden rounded-md border border-white/8 px-1.5 py-1">
+		<div class="bg-background/60 border-border/60 flex h-8 items-end gap-[3px] overflow-hidden rounded-md border px-1.5 py-1">
 			{#each history as sample, index (`${tone}-${index}`)}
 				<ArcaneTooltip.Root>
 					<ArcaneTooltip.Trigger class="flex h-full min-w-0 flex-1 items-end self-stretch">
 						<div
-							class={cn('min-w-0 flex-1 rounded-[2px] transition-opacity', disabled ? 'bg-white/8' : barColorClass)}
+							class={cn('min-w-0 flex-1 rounded-[2px] transition-opacity', disabled ? 'bg-muted' : barColorClass)}
 							style={`height: ${Math.max(disabled ? 12 : Math.min(Math.max(sample.percent, 6), 100), 6)}%; opacity: ${disabled ? 0.35 : 0.45 + Math.min(sample.percent, 100) / 180};`}
 						></div>
 					</ArcaneTooltip.Trigger>


### PR DESCRIPTION
## Summary

Fixes #2341 — CPU / Memory stat cards in the container logs panel were unreadable in light mode because `ContainerLogStatMonitor.svelte` used hardcoded `text-white`, `text-white/70`, `text-white/55`, `border-white/8` and `bg-white/8` utility classes. On a light background, white-on-white made the values, labels, detail text and the inner panel borders effectively invisible.

## Changes

- Swap hardcoded white text classes for theme-aware tokens (`text-foreground`, `text-muted-foreground`)
- Swap hardcoded `border-white/8` for `border-border/60` so the icon box and history chart panel border render correctly in both themes
- Swap the disabled-bar `bg-white/8` for `bg-muted`
- Give the CPU/Memory tone colors a darker light-mode shade (`sky-600` / `emerald-600`, `sky-500/75` / `emerald-500/75`) plus the existing `dark:` variants — the 300/400 tones were too washed out against a light background

Scope is confined to one file (`ContainerLogStatMonitor.svelte`). No backend or logic changes.

## Test plan

- [ ] Open a running container → Logs tab in dark mode — CPU / Memory cards look unchanged
- [ ] Switch profile to light mode from the sidebar — labels, values, detail and history bars are all readable with proper contrast
- [ ] Toggle back to dark mode — visuals match baseline

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a light-mode contrast bug in `ContainerLogStatMonitor.svelte` by replacing hardcoded white utility classes (`text-white`, `border-white/8`, `bg-white/8`) with theme-aware tokens (`text-foreground`, `text-muted-foreground`, `border-border/60`, `bg-muted`) and adding explicit dark-mode variants to the tone color derivations.

The change is scoped to a single file with no logic or backend changes. The Svelte runes usage (`$derived`, `$props`) follows the project's Svelte 5 best practices, and all full Tailwind class names appear as literal strings so they will be correctly picked up by the content scanner.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely visual fix with no logic, data, or backend changes.

All findings are P2 or lower. The styling substitutions are semantically correct, theme tokens are used consistently, and the Svelte reactivity patterns follow project rules. No functional regressions were identified.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: light mode contrast for container s..."](https://github.com/getarcaneapp/arcane/commit/0805c331f53c628b59ffb7c90b0a02483cfdc899) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28084738)</sub>

<!-- /greptile_comment -->