### PR TITLE
fix: preserve webhook URL query params in generic notification provider (#2292)

### DIFF
--- a/backend/pkg/utils/notifications/generic_sender.go
+++ b/backend/pkg/utils/notifications/generic_sender.go
@@ -42,31 +42,18 @@ func BuildGenericURL(config models.GenericConfig) (string, error) {
 
 	// Build generic service URL
 	// Format: generic://host[:port]/path?params
-	// Shoutrrr's generic service uses HTTP or HTTPS based on the DisableTLS setting
-	scheme := "generic"
+	// Shoutrrr's generic service uses HTTP or HTTPS based on the DisableTLS setting.
 
-	// Start with the base URL.
-	// Preserve any query parameters from the original webhook URL by encoding
-	// the ? as %3F so it stays in the path component. Shoutrrr decodes the path
-	// when constructing the outbound HTTP request, recovering the original query
-	// string for the upstream service.
-	rawPath := webhookURL.Path
-	decodedPath := webhookURL.Path
-	if webhookURL.RawQuery != "" {
-		rawPath = webhookURL.Path + "%3F" + webhookURL.RawQuery
-		decodedPath = webhookURL.Path + "?" + webhookURL.RawQuery
-	}
-	shoutrrrURL := &url.URL{
-		Scheme:  scheme,
-		Host:    webhookURL.Host,
-		RawPath: rawPath,
-		Path:    decodedPath,
-	}
+	// Start from the user's existing query parameters. Shoutrrr's generic
+	// service preserves any query keys it does not recognise, so provider
+	// tokens embedded in the webhook URL (e.g. PushPlus's `?token=...`) flow
+	// straight through to the outbound HTTP request untouched.
+	query := webhookURL.Query()
 
-	// Build query parameters
-	query := url.Values{}
-
-	// Set template to JSON (default for generic webhooks)
+	// Set template to JSON (default for generic webhooks). Shoutrrr's JSON
+	// template marshals the notification params as a flat JSON object at the
+	// root level, which is the format most providers (PushPlus, custom APIs,
+	// Home Assistant, etc.) expect.
 	query.Set("template", "json")
 
 	// Set content type if provided
@@ -106,7 +93,12 @@ func BuildGenericURL(config models.GenericConfig) (string, error) {
 		}
 	}
 
-	shoutrrrURL.RawQuery = query.Encode()
+	shoutrrrURL := &url.URL{
+		Scheme:   "generic",
+		Host:     webhookURL.Host,
+		Path:     webhookURL.Path,
+		RawQuery: query.Encode(),
+	}
 
 	return shoutrrrURL.String(), nil
 }

--- a/backend/pkg/utils/notifications/generic_sender.go
+++ b/backend/pkg/utils/notifications/generic_sender.go
@@ -48,39 +48,44 @@ func BuildGenericURL(config models.GenericConfig) (string, error) {
 	// service preserves any query keys it does not recognise, so provider
 	// tokens embedded in the webhook URL (e.g. PushPlus's `?token=...`) flow
 	// straight through to the outbound HTTP request untouched.
+	//
+	// For Shoutrrr config keys (template, contenttype, method, titlekey,
+	// messagekey, disabletls) we only fill in defaults / configured values
+	// when the user has not already set the same key inline in the URL.
+	// That way an explicit `?template=custom` or `?disabletls=yes` from the
+	// user is always respected and never silently overwritten by the
+	// provider settings or the URL-scheme-derived TLS flag.
 	query := webhookURL.Query()
 
-	// Set template to JSON (default for generic webhooks). Shoutrrr's JSON
-	// template marshals the notification params as a flat JSON object at the
-	// root level, which is the format most providers (PushPlus, custom APIs,
-	// Home Assistant, etc.) expect.
-	query.Set("template", "json")
-
-	// Set content type if provided
-	if config.ContentType != "" {
-		query.Set("contenttype", config.ContentType)
+	setDefault := func(key, value string) {
+		if value == "" {
+			return
+		}
+		if query.Get(key) != "" {
+			return
+		}
+		query.Set(key, value)
 	}
 
-	// Set HTTP method if provided
-	if config.Method != "" {
-		query.Set("method", config.Method)
-	}
+	// Default to the JSON template — Shoutrrr's JSON template marshals the
+	// notification params as a flat JSON object at the root level, which is
+	// the format most providers (PushPlus, custom APIs, Home Assistant, etc.)
+	// expect.
+	setDefault("template", "json")
+	setDefault("contenttype", config.ContentType)
+	setDefault("method", config.Method)
+	setDefault("titlekey", config.TitleKey)
+	setDefault("messagekey", config.MessageKey)
 
-	// Set title and message keys if provided
-	if config.TitleKey != "" {
-		query.Set("titlekey", config.TitleKey)
-	}
-	if config.MessageKey != "" {
-		query.Set("messagekey", config.MessageKey)
-	}
-
-	// Determine TLS setting from the webhook URL scheme (http/https)
-	// If scheme is missing, DisableTLS is only used to infer the default scheme above.
+	// Determine TLS setting from the webhook URL scheme (http/https) when the
+	// user has not already passed `disabletls` explicitly. If the scheme is
+	// missing here we treat it as a hard error because Shoutrrr needs an
+	// explicit transport.
 	switch strings.ToLower(webhookURL.Scheme) {
 	case "http":
-		query.Set("disabletls", "yes")
+		setDefault("disabletls", "yes")
 	case "https":
-		query.Set("disabletls", "no")
+		setDefault("disabletls", "no")
 	default:
 		return "", fmt.Errorf("invalid webhook URL scheme: %s", webhookURL.Scheme)
 	}

--- a/backend/pkg/utils/notifications/generic_sender_test.go
+++ b/backend/pkg/utils/notifications/generic_sender_test.go
@@ -352,3 +352,65 @@ func TestBuildGenericURL_CustomKeys(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildGenericURL_PreservesUserShoutrrrConfigKeys verifies that an
+// explicit Shoutrrr config key embedded by the user in the webhook URL is
+// never silently overwritten by the provider defaults, the configured field
+// values, or the URL-scheme-derived TLS flag.
+func TestBuildGenericURL_PreservesUserShoutrrrConfigKeys(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    models.GenericConfig
+		wantInURL []string
+		notInURL  []string
+	}{
+		{
+			name: "user template wins over default json",
+			config: models.GenericConfig{
+				WebhookURL: "https://example.com/api?template=custom",
+			},
+			wantInURL: []string{"template=custom"},
+			notInURL:  []string{"template=json"},
+		},
+		{
+			name: "user disabletls wins over scheme-derived value",
+			config: models.GenericConfig{
+				WebhookURL: "https://example.com/api?disabletls=yes",
+			},
+			wantInURL: []string{"disabletls=yes"},
+			notInURL:  []string{"disabletls=no"},
+		},
+		{
+			name: "user messagekey wins over configured value",
+			config: models.GenericConfig{
+				WebhookURL: "https://example.com/api?messagekey=user_msg",
+				MessageKey: "configured_msg",
+			},
+			wantInURL: []string{"messagekey=user_msg"},
+			notInURL:  []string{"messagekey=configured_msg"},
+		},
+		{
+			name: "user method wins over configured value",
+			config: models.GenericConfig{
+				WebhookURL: "https://example.com/api?method=PUT",
+				Method:     "POST",
+			},
+			wantInURL: []string{"method=PUT"},
+			notInURL:  []string{"method=POST"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, err := BuildGenericURL(tt.config)
+			require.NoError(t, err)
+
+			for _, want := range tt.wantInURL {
+				assert.Contains(t, gotURL, want)
+			}
+			for _, notWant := range tt.notInURL {
+				assert.NotContains(t, gotURL, notWant)
+			}
+		})
+	}
+}

--- a/backend/pkg/utils/notifications/generic_sender_test.go
+++ b/backend/pkg/utils/notifications/generic_sender_test.go
@@ -134,14 +134,28 @@ func TestBuildGenericURL(t *testing.T) {
 			config: models.GenericConfig{
 				WebhookURL: "http://www.pushplus.plus/send?token=abc123",
 			},
-			wantURL: "generic://www.pushplus.plus/send%3Ftoken=abc123?disabletls=yes&template=json",
+			wantURL: "generic://www.pushplus.plus/send?disabletls=yes&template=json&token=abc123",
 		},
 		{
 			name: "webhook URL with multiple query params preserved",
 			config: models.GenericConfig{
 				WebhookURL: "https://api.example.com/webhook?token=abc&channel=general",
 			},
-			wantURL: "generic://api.example.com/webhook%3Ftoken=abc&channel=general?disabletls=no&template=json",
+			wantURL: "generic://api.example.com/webhook?channel=general&disabletls=no&template=json&token=abc",
+		},
+		{
+			name: "PushPlus webhook with content message key",
+			config: models.GenericConfig{
+				WebhookURL: "http://www.pushplus.plus/send?token=abc123",
+				Method:     "POST",
+				MessageKey: "content",
+			},
+			// Shoutrrr's generic service preserves `token=abc123` through to the
+			// outbound HTTP request untouched, while consuming the config keys
+			// (disabletls, template, method, messagekey). This is what PushPlus
+			// needs: POST http://www.pushplus.plus/send?token=abc123 with
+			// {"title":"...","content":"..."} at the root.
+			wantURL: "generic://www.pushplus.plus/send?disabletls=yes&messagekey=content&method=POST&template=json&token=abc123",
 		},
 		{
 			name: "empty webhook URL",


### PR DESCRIPTION
## Summary

Fixes #2292 — the Generic Webhook provider could not deliver to PushPlus (and any other endpoint that authenticates via a query-string token) because `BuildGenericURL` encoded the user's `?` as `%3F` and stuffed the original query into the **path** of the Shoutrrr service URL. Shoutrrr then forwarded that literal path verbatim, so the outbound HTTP request looked like:

```
POST /send%3Ftoken=YOUR_TOKEN HTTP/1.1
Host: www.pushplus.plus
```

PushPlus replied `200 OK` (because the host responds to anything under `/`) but the `token` was sitting inside the path, not the query, so no notification was ever delivered.

## Root cause

`backend/pkg/utils/notifications/generic_sender.go` built the Shoutrrr URL like this:

```go
rawPath = webhookURL.Path + "%3F" + webhookURL.RawQuery
decodedPath = webhookURL.Path + "?" + webhookURL.RawQuery
shoutrrrURL := &url.URL{Scheme: "generic", Host: ..., RawPath: rawPath, Path: decodedPath}
```

When Go re-emits a URL with a `?` inside `Path`, `EscapedPath()` re-encodes it to `%3F`, which means `RequestURI()` produces `/send%3Ftoken=...` and the query is gone for good.

Shoutrrr's generic service already preserves any query keys it doesn't recognise (verified upstream in `generic_test.go` — `extra=param` survives `ConfigFromWebhookURL`), so the `%3F` workaround was never needed.

## Fix

- Drop the `%3F` encoding entirely
- Seed the Shoutrrr query map from `webhookURL.Query()` so the user's existing query parameters merge naturally with the Shoutrrr config keys (`template`, `messagekey`, `method`, `disabletls`, …)
- Build the service URL with `Path: webhookURL.Path` and the merged query

End result for the reporter's PushPlus configuration (`http://www.pushplus.plus/send?token=YOUR_TOKEN` + `messageKey=content`):

| | Before | After |
|---|---|---|
| Service URL | `generic://www.pushplus.plus/send%3Ftoken=YOUR_TOKEN?...` | `generic://www.pushplus.plus/send?token=YOUR_TOKEN&...` |
| Outbound `RequestURI` | `/send%3Ftoken=YOUR_TOKEN` | `/send?token=YOUR_TOKEN` |
| Outbound body | `{"title":"...","content":"..."}` | `{"title":"...","content":"..."}` |

The body was already a flat JSON at the root level — Shoutrrr's `template=json` marshals `params` directly — so no changes were needed there. The reporter's diagnosis ("payload mismatch") was a symptom of the URL being wrong; the body becomes deliverable as soon as the token reaches PushPlus.

## Tests

- Updated the two existing `BuildGenericURL` cases that asserted the `%3F` encoding to assert the new merged-query form
- Added a `PushPlus webhook with content message key` case that mirrors the reporter's exact configuration
- Verified end-to-end with a throwaway harness: `service.Config.WebhookURL().RequestURI()` resolves to `/send?token=abc123`, `MessageKey=content`, `RequestMethod=POST`
- `go test ./backend/pkg/utils/notifications/...` ✅
- `gofmt -l` clean, `go vet` clean

## Test plan

- [ ] Configure a Generic Webhook provider with `URL=http://www.pushplus.plus/send?token=YOUR_TOKEN`, `Method=POST`, `Message Key=content`
- [ ] Hit "Test Provider" — PushPlus delivers the notification
- [ ] Existing webhook destinations without query params still work (Home Assistant `/api/webhook/<id>`, custom JSON endpoints, etc.)

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the Generic Webhook provider's handling of webhook URLs that include query-string authentication tokens by dropping the broken percent-encoding workaround and instead seeding Shoutrrr's query map directly from `webhookURL.Query()`. The change is correct, the root cause is well-diagnosed, and the updated tests cover the reporter's exact configuration. The only minor concern is that Shoutrrr config keys (`template`, `disabletls`, etc.) will silently overwrite any identically-named query parameter a user places in their webhook URL — worth a brief comment if such collisions are possible in practice.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is correct and the only remaining finding is a P2 style suggestion about silent key collisions.

All findings are P2 or lower. The core logic change is clearly correct: webhookURL.Query() properly seeds the Shoutrrr query map and url.URL with Path (not RawPath) produces the right RequestURI. Tests pass and cover the reporter's scenario.

No files require special attention.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fgeneric-webhook-flat-payload%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fgeneric-webhook-flat-payload%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fpkg%2Futils%2Fnotifications%2Fgeneric_sender.go%3A51-57%0A**Silent%20overwrite%20of%20user-provided%20Shoutrrr%20config%20keys**%0A%0AThe%20code%20seeds%20%60query%60%20from%20the%20user's%20webhook%20URL%20and%20then%20unconditionally%20calls%20%60query.Set%28%22template%22%2C%20%22json%22%29%60.%20If%20a%20user's%20webhook%20URL%20already%20contains%20a%20key%20that%20Shoutrrr%20interprets%20as%20a%20config%20key%20%28%60template%60%2C%20%60disabletls%60%2C%20%60method%60%2C%20%60contenttype%60%2C%20%60titlekey%60%2C%20%60messagekey%60%29%2C%20their%20value%20is%20silently%20discarded.%20The%20most%20likely%20collision%20is%20%60template%60%20%E2%80%94%20any%20user%20who%20deliberately%20places%20%60%3Ftemplate%3D...%60%20in%20their%20webhook%20URL%20will%20always%20have%20it%20overwritten%20to%20%60json%60.%20Same%20applies%20if%20the%20URL%20contains%20%60%3Fdisabletls%3D...%60%2C%20which%20is%20always%20overwritten%20by%20the%20scheme-derived%20value.%0A%0AConsider%20documenting%20the%20known%20collision%20behavior%20in%20a%20comment%2C%20or%20%E2%80%94%20where%20the%20config%20field%20is%20unset%20%E2%80%94%20skipping%20%60query.Set%60%20when%20the%20key%20is%20already%20present%20via%20%60query.Get%60%3A%0A%0A%60%60%60go%0Aif%20query.Get%28%22template%22%29%20%3D%3D%20%22%22%20%7B%0A%20%20%20%20query.Set%28%22template%22%2C%20%22json%22%29%0A%7D%0A%60%60%60%0A%0AThis%20would%20preserve%20an%20explicit%20user%20override%20while%20still%20providing%20the%20default%20for%20the%20common%20case.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/utils/notifications/generic_sender.go
Line: 51-57

Comment:
**Silent overwrite of user-provided Shoutrrr config keys**

The code seeds `query` from the user's webhook URL and then unconditionally calls `query.Set("template", "json")`. If a user's webhook URL already contains a key that Shoutrrr interprets as a config key (`template`, `disabletls`, `method`, `contenttype`, `titlekey`, `messagekey`), their value is silently discarded. The most likely collision is `template` — any user who deliberately places `?template=...` in their webhook URL will always have it overwritten to `json`. Same applies if the URL contains `?disabletls=...`, which is always overwritten by the scheme-derived value.

Consider documenting the known collision behavior in a comment, or — where the config field is unset — skipping `query.Set` when the key is already present via `query.Get`:

```go
if query.Get("template") == "" {
    query.Set("template", "json")
}
```

This would preserve an explicit user override while still providing the default for the common case.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve webhook URL query params i..."](https://github.com/getarcaneapp/arcane/commit/742d70122dd463d412e7227e53e3d030f6eff0d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28085007)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->