### PR TITLE
fix: keep project build context as container path so local builder can stat it (#2314)

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -1894,7 +1894,7 @@ func (s *ProjectService) prepareServiceBuildRequest(
 	// therefore stay as a container path; translating it to the host path
 	// (which is what bind mount sources need) makes `os.Stat` fail because
 	// the host path doesn't exist inside the Arcane container. See #2314.
-	_ = pathMapper
+	// pathMapper is intentionally not consumed here for that reason.
 	contextDir, err := resolveBuildContextInternal(project.WorkingDir, updatedSvc, serviceName)
 	if err != nil {
 		return imagetypes.BuildRequest{}, updatedSvc, updated, err

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -1759,14 +1759,6 @@ func resolveDockerfilePathInternal(svc composetypes.ServiceConfig) (string, erro
 	return dockerfilePath, nil
 }
 
-func translateBuildPathInternal(path string, pathMapper *projects.PathMapper) (string, error) {
-	if pathMapper == nil || strings.TrimSpace(path) == "" || !filepath.IsAbs(path) {
-		return path, nil
-	}
-
-	return pathMapper.ContainerToHost(path)
-}
-
 func buildArgsFromCompose(args map[string]*string) map[string]string {
 	buildArgs := map[string]string{}
 	for key, value := range args {
@@ -1895,13 +1887,17 @@ func (s *ProjectService) prepareServiceBuildRequest(
 		return imagetypes.BuildRequest{}, updatedSvc, updated, fmt.Errorf("service %s must define an image when push is enabled", serviceName)
 	}
 
+	// The build context (and any absolute Dockerfile path) is read locally by
+	// Arcane — both the docker provider (`archive.TarWithOptions`) and the
+	// buildkit provider (`SolveOpt.LocalDirs`) stream the directory contents
+	// to the daemon from the Arcane process's own filesystem. It must
+	// therefore stay as a container path; translating it to the host path
+	// (which is what bind mount sources need) makes `os.Stat` fail because
+	// the host path doesn't exist inside the Arcane container. See #2314.
+	_ = pathMapper
 	contextDir, err := resolveBuildContextInternal(project.WorkingDir, updatedSvc, serviceName)
 	if err != nil {
 		return imagetypes.BuildRequest{}, updatedSvc, updated, err
-	}
-	contextDir, err = translateBuildPathInternal(contextDir, pathMapper)
-	if err != nil {
-		return imagetypes.BuildRequest{}, updatedSvc, updated, fmt.Errorf("translate build context for service %s: %w", serviceName, err)
 	}
 
 	dockerfileInline := updatedSvc.Build.DockerfileInline
@@ -1914,10 +1910,6 @@ func (s *ProjectService) prepareServiceBuildRequest(
 		dockerfilePath, err = resolveDockerfilePathInternal(updatedSvc)
 		if err != nil {
 			return imagetypes.BuildRequest{}, updatedSvc, updated, err
-		}
-		dockerfilePath, err = translateBuildPathInternal(dockerfilePath, pathMapper)
-		if err != nil {
-			return imagetypes.BuildRequest{}, updatedSvc, updated, fmt.Errorf("translate Dockerfile path for service %s: %w", serviceName, err)
 		}
 	}
 

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -1436,7 +1436,13 @@ func TestProjectService_PrepareServiceBuildRequest_MapsComposeFields(t *testing.
 	assert.Contains(t, req.ExtraHosts[0], "10.0.0.5")
 }
 
-func TestProjectService_PrepareServiceBuildRequest_UsesExecutorVisiblePaths(t *testing.T) {
+// TestProjectService_PrepareServiceBuildRequest_KeepsContainerPaths is a
+// regression test for #2314: Arcane's local build pipeline (the docker and
+// buildkit providers both read the build context via the Arcane process's own
+// filesystem) cannot use host paths, so prepareServiceBuildRequest must leave
+// the build context and any absolute Dockerfile path as container paths even
+// when the projects mount has a non-matching host prefix.
+func TestProjectService_PrepareServiceBuildRequest_KeepsContainerPaths(t *testing.T) {
 	svc := &ProjectService{}
 	proj := &composetypes.Project{WorkingDir: "/app/data/projects/demo", Name: "demo"}
 	pm := projects.NewPathMapper("/app/data/projects", "/docker-data/arcane/projects")
@@ -1461,8 +1467,42 @@ func TestProjectService_PrepareServiceBuildRequest_UsesExecutorVisiblePaths(t *t
 	)
 	require.NoError(t, err)
 
-	assert.Equal(t, "/docker-data/arcane/projects/demo", req.ContextDir)
-	assert.Equal(t, "/docker-data/arcane/projects/demo/Dockerfile.custom", req.Dockerfile)
+	assert.Equal(t, "/app/data/projects/demo", req.ContextDir)
+	assert.Equal(t, "/app/data/projects/demo/Dockerfile.custom", req.Dockerfile)
+}
+
+// TestProjectService_PrepareServiceBuildRequest_BuildDotKeepsContainerPath
+// reproduces the exact configuration from #2314: a compose file with
+// `build: .` next to its Dockerfile, on an installation where the projects
+// directory is bind-mounted from a different host path than the container
+// path. The resulting BuildRequest must point at the container path so the
+// local builder can stat / tar the directory.
+func TestProjectService_PrepareServiceBuildRequest_BuildDotKeepsContainerPath(t *testing.T) {
+	svc := &ProjectService{}
+	proj := &composetypes.Project{WorkingDir: "/app/data/projects/caddy", Name: "caddy"}
+	pm := projects.NewPathMapper("/app/data/projects", "/storage/volumes/arcane/projects")
+
+	serviceCfg := composetypes.ServiceConfig{
+		Name:  "caddy",
+		Image: "caddy",
+		Build: &composetypes.BuildConfig{
+			Context: ".",
+		},
+	}
+
+	req, _, _, err := svc.prepareServiceBuildRequest(
+		context.Background(),
+		"project-id",
+		proj,
+		"caddy",
+		serviceCfg,
+		ProjectBuildOptions{},
+		pm,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/app/data/projects/caddy", req.ContextDir)
+	assert.Equal(t, "Dockerfile", req.Dockerfile)
 }
 
 func TestProjectService_PrepareServiceBuildRequest_UsesInlineDockerfile(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #2314 — clicking **Build** on a project whose compose file contains a `build:` section fails with `build context not found: stat /<host-projects-dir>/<service>: no such file or directory` whenever the projects bind mount uses a different host path than the container path (e.g. `/storage/volumes/arcane:/app/data`). The reporter's case is the canonical setup:

```yaml
services:
  caddy:
    image: caddy
    container_name: caddy
    build: .
```

with `Dockerfile` next to `compose.yaml` under `PROJECTS_DIRECTORY=/app/data/projects`.

## Root cause

`prepareServiceBuildRequest` in `backend/internal/services/project_service.go` was passing the build context (and any absolute Dockerfile path) through `translateBuildPathInternal` → `pathMapper.ContainerToHost`, converting `/app/data/projects/caddy` into `/storage/volumes/arcane/projects/caddy` before stuffing it into the `BuildRequest`.

This translation is correct for **bind mount sources** — those are sent to the daemon and have to make sense from the host's perspective. It is wrong for the **build context**, which is read by Arcane's own process:

- The docker provider tarballs the context locally via `archive.TarWithOptions(contextDir, …)` and then streams it through the daemon's `/build` API (`backend/pkg/libarcane/libbuild/builder_docker.go:208`).
- The buildkit provider hands the context to buildkit through `SolveOpt.LocalDirs{"context": contextDir, "dockerfile": dockerfileDir}` (`backend/pkg/libarcane/libbuild/builder_buildkit.go:149`), which is a *client-side* local directory.
- Both paths then hit `validateBuildRequestInternal` which calls `os.Stat(contextDir)` on the Arcane process's filesystem (`backend/pkg/libarcane/libbuild/builder_utils.go:31`).

Once the contextDir has been rewritten to the host path, none of those steps can see the directory and the build aborts. Inline Dockerfile builds were just as broken (they go through the same code path), which is why the reporter found that the workaround from #1959 also failed.

The translation was added in cea81408 (PR #1875, "feat(autoupdate/compose): implement docker compose aware update logic"). The accompanying test, `TestProjectService_PrepareServiceBuildRequest_UsesExecutorVisiblePaths`, locked in the regression by asserting host paths.

## Fix

- Remove both `translateBuildPathInternal` calls in `prepareServiceBuildRequest` — the build context and Dockerfile path now flow through unchanged.
- Drop the now-unused `translateBuildPathInternal` helper.
- Add a comment at the call site explaining *why* the build context must stay as a container path so this regression doesn't get reintroduced.
- Rename and rewrite the existing test to assert the **container** path, and add a second regression test (`TestProjectService_PrepareServiceBuildRequest_BuildDotKeepsContainerPath`) that mirrors #2314 exactly: `build: .`, projects mounted at `/app/data/projects` from `/storage/volumes/arcane/projects`.

`pathMapper` is still received by `prepareServiceBuildRequest` (callers up the chain pass it through), but is no longer consumed inside this function. I left the parameter in place to keep the diff scoped to the bug — it can be cleaned up alongside any future refactor of the build orchestration entry points.

## Tests

- `go test ./backend/internal/services/... -run PrepareServiceBuildRequest -v` ✅ (5/5)
- `go test ./backend/internal/services/...` ✅
- `gofmt -l` clean, `go vet ./backend/internal/services/...` clean

## Test plan

- [ ] On an installation with a non-matching projects mount (e.g. `/storage/volumes/arcane:/app/data`), create a project with `build: .` and `Dockerfile` next to `compose.yaml`, hit **Build** — image builds successfully
- [ ] Same setup, hit **Build & Deploy** — image builds and the project comes up
- [ ] Inline Dockerfile (`dockerfile_inline:`) variant of the same project also builds (covers the regression from #1959 that #2314 also re-tripped)
- [ ] Existing matching-mount installations (Linux default `/app/data/projects:/app/data/projects`) still build

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug (#2314) where clicking **Build** on a project with a `build:` section in its compose file would fail with `stat /<host-path>/...: no such file or directory` on installations where the projects bind mount uses a different host path than the container path. The root cause was `prepareServiceBuildRequest` translating the build context and Dockerfile paths from container paths to host paths via `pathMapper.ContainerToHost`, even though both the docker provider (`archive.TarWithOptions`) and the buildkit provider (`SolveOpt.LocalDirs`) read those paths from the Arcane process's own (container) filesystem — not the host's.

The fix removes both `translateBuildPathInternal` calls and deletes the now-unused helper, adds a clear explanatory comment at the call site, and includes two regression tests mirroring the exact failure scenario.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix correctly removes erroneous container-to-host path translation for build contexts, is well-tested, and introduces no new risk.

The logic change is correct and well-understood: os.Stat, archive.TarWithOptions, and SolveOpt.LocalDirs all operate on the Arcane container's filesystem, so keeping the container path is the only valid option. The fix removes the helper entirely rather than just disabling it, and two targeted regression tests guard against re-introduction. Only a P2 style note remains about the _ = pathMapper blank assignment.

No files require special attention.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fproject-build-context-resolution%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fproject-build-context-resolution%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A1897%0A**Consider%20renaming%20the%20unused%20parameter%20instead%20of%20blank-assigning%20it**%0A%0AIn%20Go%2C%20function%20parameters%20don't%20cause%20a%20compile%20error%20when%20unused%2C%20so%20%60_%20%3D%20pathMapper%60%20isn't%20required%20by%20the%20toolchain.%20The%20comment%20above%20it%20already%20documents%20the%20intent%20clearly.%20When%20the%20follow-up%20refactor%20happens%2C%20prefer%20renaming%20the%20parameter%20to%20%60_%60%20in%20the%20function%20signature%20rather%20than%20keeping%20the%20blank%20assignment%20%E2%80%94%20that%20keeps%20the%20signal%20at%20the%20declaration%20site%20and%20avoids%20a%20no-op%20statement%20in%20the%20body.%0A%0A%28Remove%20the%20%60_%20%3D%20pathMapper%60%20line%3B%20the%20comment%20above%20already%20explains%20the%20intent.%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/project_service.go
Line: 1897

Comment:
**Consider renaming the unused parameter instead of blank-assigning it**

In Go, function parameters don't cause a compile error when unused, so `_ = pathMapper` isn't required by the toolchain. The comment above it already documents the intent clearly. When the follow-up refactor happens, prefer renaming the parameter to `_` in the function signature rather than keeping the blank assignment — that keeps the signal at the declaration site and avoids a no-op statement in the body.

(Remove the `_ = pathMapper` line; the comment above already explains the intent.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep project build context as conta..."](https://github.com/getarcaneapp/arcane/commit/8ed2ad32afc7d5d6240c4c18d396bae70451b2fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28085172)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->