### PR TITLE
fix: Locale selector background was inconsistent

### DIFF
--- a/frontend/src/routes/(app)/settings/appearance/+page.svelte
+++ b/frontend/src/routes/(app)/settings/appearance/+page.svelte
@@ -213,7 +213,7 @@
 								<LocalePicker
 									inline={true}
 									id="appearanceLocalePicker"
-									class="bg-background/50 border-border/30 text-foreground h-9 w-32 text-sm font-medium"
+									class="border-border/30 text-foreground h-9 w-32 text-sm font-medium"
 								/>
 							</div>
 						</div>


### PR DESCRIPTION
## Checklist

- [X] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

Fixes #2347 
Removes the conflicting Tailwind class that causes the bg of the language selector to be inconsistent with the rest of the UI.

**Before:**
<img width="332" height="111" alt="image" src="https://github.com/user-attachments/assets/93e5605b-2608-4281-bb10-3d56b5008447" />
<img width="301" height="114" alt="image" src="https://github.com/user-attachments/assets/fec2c709-c8cd-4566-95fe-73633d87e9cc" />


**After:**
<img width="343" height="122" alt="image" src="https://github.com/user-attachments/assets/13ba3ae7-e576-45c9-b128-e4ced94fa902" />
<img width="362" height="122" alt="image" src="https://github.com/user-attachments/assets/f6b9372a-c7a2-4c26-a86e-17fcaa70c9bc" />


Fixes: 

Removed the `bg-background/50` class from the Locale Picker

- [X] Development environment started: `./scripts/development/dev.sh start`
- [X] Frontend verified at http://localhost:3000
- [X] Backend verified at http://localhost:3552
- [X] Manual testing completed (describe): Frontend built and background verified to be consistent
- [X] No linting errors (e.g., `just lint all`)
- [X] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

N/A

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the `bg-background/50` Tailwind class from the `LocalePicker`'s `class` prop in the appearance settings page. Because `LocalePicker` applies the passed `className` to its outer wrapper `<div>` rather than the `Select.Trigger` (which already carries its own `bg-popover/90` styling), the extra semi-transparent background was bleeding through and causing the visible inconsistency. The fix is minimal and correct.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single class removal with a clear visual improvement and no logic changes.

The change is a one-line CSS class removal that directly fixes the reported visual bug. There are no logic changes, no new dependencies, and no side effects. All remaining class attributes on the wrapper are pre-existing and unrelated to this fix.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Locale selector background was inco..."](https://github.com/getarcaneapp/arcane/commit/3b24a7d1217dce26af0000924d31769d7e6e16eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28088268)</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->