### PR TITLE
fix: skip gitops-managed projects in filesystem cleanup (#2266)

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -1009,7 +1009,7 @@ func (s *ProjectService) cleanupDBProjects(ctx context.Context, seen map[string]
 		// Skip projects whose lifecycle is owned by the gitops system.
 		// Their compose files may not exist on disk yet (e.g. during a sync
 		// or after an SSH/clone failure) and should never be deleted here.
-		if p.GitOpsManagedBy != nil && *p.GitOpsManagedBy != "" {
+		if p.GitOpsManagedBy != nil && strings.TrimSpace(*p.GitOpsManagedBy) != "" {
 			continue
 		}
 

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -1006,6 +1006,13 @@ func (s *ProjectService) cleanupDBProjects(ctx context.Context, seen map[string]
 			continue
 		}
 
+		// Skip projects whose lifecycle is owned by the gitops system.
+		// Their compose files may not exist on disk yet (e.g. during a sync
+		// or after an SSH/clone failure) and should never be deleted here.
+		if p.GitOpsManagedBy != nil && *p.GitOpsManagedBy != "" {
+			continue
+		}
+
 		validDir, err := projects.IsProjectDirectoryPath(p.Path, followProjectSymlinks)
 		if err != nil {
 			if os.IsNotExist(err) {


### PR DESCRIPTION
## Summary

- `cleanupDBProjects` was permanently deleting DB records for projects linked via Git-Sync whenever the compose file was missing from disk (e.g. after an SSH/clone failure, or during a sync cycle where files haven't been written yet).
- After removing a Git-Sync link, `DeleteSync` clears `GitOpsManagedBy` before the next cleanup run — so even a brief window where the directory is empty caused the record to be deleted with no recovery path.
- Fix: add a guard at the top of the cleanup loop that skips any project with `GitOpsManagedBy` set, since its lifecycle belongs to the gitops system, not the filesystem scanner.

Closes #2266

## Test plan

- [ ] Configure a project with Git-Sync enabled
- [ ] Stop the git-sync job so the compose file is absent from disk
- [ ] Trigger a filesystem scan (or wait for the periodic cleanup)
- [ ] Verify the project still appears in the UI (was previously deleted)
- [ ] Remove the Git-Sync link; verify the project record persists after the next cleanup pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a guard in `cleanupDBProjects` that skips any project with a non-empty `GitOpsManagedBy`, preventing the filesystem cleanup loop from permanently deleting gitops-managed projects when their compose files are temporarily absent (e.g. during a sync cycle or after an SSH/clone failure). The fix is minimal and correctly scoped; it aligns with how the same field is guarded in other parts of the service.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is minimal, targeted, and correct; only a cosmetic style inconsistency remains.

All findings are P2 (style/consistency). The logic itself correctly addresses the described bug and is consistent with the codebase's existing handling of GitOpsManagedBy.

No files require special attention.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fgitops-cleanup-skip-managed-projects%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fgitops-cleanup-skip-managed-projects%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A1012%0A**Inconsistent%20whitespace%20guard%20vs.%20the%20parallel%20check**%0A%0AThe%20existing%20check%20for%20the%20same%20field%20at%20line%20397%20uses%20%60strings.TrimSpace%28*proj.GitOpsManagedBy%29%20!%3D%20%22%22%60%2C%20but%20this%20new%20guard%20compares%20directly%20against%20%60%22%22%60.%20Since%20%60GitOpsManagedBy%60%20values%20are%20always%20UUIDs%20in%20practice%20this%20will%20never%20differ%2C%20but%20for%20defensive%20consistency%20it's%20worth%20aligning%20the%20two.%0A%0A%60%60%60suggestion%0A%09%09if%20p.GitOpsManagedBy%20!%3D%20nil%20%26%26%20strings.TrimSpace%28*p.GitOpsManagedBy%29%20!%3D%20%22%22%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/project_service.go
Line: 1012

Comment:
**Inconsistent whitespace guard vs. the parallel check**

The existing check for the same field at line 397 uses `strings.TrimSpace(*proj.GitOpsManagedBy) != ""`, but this new guard compares directly against `""`. Since `GitOpsManagedBy` values are always UUIDs in practice this will never differ, but for defensive consistency it's worth aligning the two.

```suggestion
		if p.GitOpsManagedBy != nil && strings.TrimSpace(*p.GitOpsManagedBy) != "" {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: skip gitops-managed projects in fil..."](https://github.com/getarcaneapp/arcane/commit/cb7c94cfb1bad3a7159a5ccb99ae2f118f541091) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28132653)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->