### PR TITLE
fix: surface registry fetch errors in GET /templates/registries (#2342)

### DIFF
--- a/backend/internal/huma/handlers/templates.go
+++ b/backend/internal/huma/handlers/templates.go
@@ -705,6 +705,16 @@ func (h *TemplateHandler) GetRegistries(ctx context.Context, _ *GetTemplateRegis
 		return nil, huma.Error500InternalServerError((&common.RegistryFetchError{Err: mapErr}).Error())
 	}
 
+	// Overlay the last fetch error from the in-memory tracker so the UI can
+	// display why a registry is not returning templates without requiring the
+	// user to check server logs.
+	fetchErrors := h.templateService.GetRegistryFetchErrors()
+	for i := range out {
+		if msg, ok := fetchErrors[out[i].ID]; ok {
+			out[i].LastFetchError = &msg
+		}
+	}
+
 	return &GetTemplateRegistriesOutput{
 		Body: base.ApiResponse[[]template.TemplateRegistry]{
 			Success: true,

--- a/backend/internal/services/template_service.go
+++ b/backend/internal/services/template_service.go
@@ -55,6 +55,7 @@ type TemplateService struct {
 
 	registryMu        sync.RWMutex
 	registryFetchMeta map[string]*registryFetchMeta
+	registryErrors    map[string]string // last fetch error per registry ID, cleared on success
 
 	fsSyncMu   sync.Mutex
 	lastFsSync time.Time
@@ -91,6 +92,7 @@ func NewTemplateService(ctx context.Context, db *database.DB, httpClient *http.C
 		settingsService:   settingsService,
 		remoteCache:       remoteCache{},
 		registryFetchMeta: make(map[string]*registryFetchMeta),
+		registryErrors:    make(map[string]string),
 	}
 	service.safeHTTPClient = service.newSafeHTTPClientInternal()
 	return service
@@ -404,6 +406,18 @@ func (s *TemplateService) GetRegistries(ctx context.Context) ([]models.TemplateR
 	return registries, nil
 }
 
+// GetRegistryFetchErrors returns a snapshot of the last fetch error per registry ID.
+// An absent entry means the registry fetched successfully (or has never been attempted).
+func (s *TemplateService) GetRegistryFetchErrors() map[string]string {
+	s.registryMu.RLock()
+	defer s.registryMu.RUnlock()
+	out := make(map[string]string, len(s.registryErrors))
+	for k, v := range s.registryErrors {
+		out[k] = v
+	}
+	return out
+}
+
 func (s *TemplateService) CreateRegistry(ctx context.Context, registry *models.TemplateRegistry) error {
 	// Hydrate metadata if needed
 	if registry.Name == "" || registry.Description == "" {
@@ -534,11 +548,17 @@ func (s *TemplateService) loadRemoteTemplates(ctx context.Context) ([]models.Com
 			remoteTemplates, err := s.fetchRegistryTemplates(groupCtx, &reg)
 			if err != nil {
 				slog.WarnContext(groupCtx, "failed to fetch templates from registry", "registry", reg.Name, "url", reg.URL, "error", err)
+				s.registryMu.Lock()
+				s.registryErrors[reg.ID] = err.Error()
+				s.registryMu.Unlock()
 				return nil // Don't fail the whole group if one registry fails
 			}
 
 			mu.Lock()
 			defer mu.Unlock()
+			s.registryMu.Lock()
+			delete(s.registryErrors, reg.ID)
+			s.registryMu.Unlock()
 			for _, template := range remoteTemplates {
 				template.Registry = cloneRegistry(&reg)
 				template.RegistryID = stringPtr(reg.ID)

--- a/backend/internal/services/template_service.go
+++ b/backend/internal/services/template_service.go
@@ -554,11 +554,12 @@ func (s *TemplateService) loadRemoteTemplates(ctx context.Context) ([]models.Com
 				return nil // Don't fail the whole group if one registry fails
 			}
 
-			mu.Lock()
-			defer mu.Unlock()
 			s.registryMu.Lock()
 			delete(s.registryErrors, reg.ID)
 			s.registryMu.Unlock()
+
+			mu.Lock()
+			defer mu.Unlock()
 			for _, template := range remoteTemplates {
 				template.Registry = cloneRegistry(&reg)
 				template.RegistryID = stringPtr(reg.ID)

--- a/frontend/src/lib/types/template.type.ts
+++ b/frontend/src/lib/types/template.type.ts
@@ -6,6 +6,7 @@ export interface TemplateRegistry {
 	description: string;
 	createdAt?: string;
 	updatedAt?: string;
+	lastFetchError?: string;
 }
 
 export interface Template {

--- a/frontend/src/routes/(app)/customize/templates/components/RegistryManager.svelte
+++ b/frontend/src/routes/(app)/customize/templates/components/RegistryManager.svelte
@@ -7,7 +7,7 @@
 	import { Snippet } from '$lib/components/ui/snippet';
 	import { m } from '$lib/paraglide/messages';
 	import type { TemplateRegistry } from '$lib/types/template.type';
-	import { TrashIcon, RegistryIcon, CommunityIcon, RefreshIcon, ExternalLinkIcon, AddIcon } from '$lib/icons';
+	import { TrashIcon, RegistryIcon, CommunityIcon, RefreshIcon, ExternalLinkIcon, AddIcon, AlertTriangleIcon } from '$lib/icons';
 
 	let {
 		registries,
@@ -75,6 +75,12 @@
 							<p class="text-muted-foreground text-sm break-all">{registry.url}</p>
 							{#if registry.description}
 								<p class="text-muted-foreground mt-1 text-sm">{registry.description}</p>
+							{/if}
+							{#if registry.lastFetchError}
+								<div class="mt-2 flex items-start gap-1.5 rounded-md border border-destructive/30 bg-destructive/10 px-2 py-1.5">
+									<AlertTriangleIcon class="text-destructive mt-0.5 size-3.5 shrink-0" />
+									<p class="text-destructive text-xs break-all">{registry.lastFetchError}</p>
+								</div>
 							{/if}
 						</div>
 						<div class="flex items-center gap-2 self-end sm:self-center">

--- a/types/template/template.go
+++ b/types/template/template.go
@@ -114,6 +114,11 @@ type TemplateRegistry struct {
 	//
 	// Required: true
 	Enabled bool `json:"enabled"`
+
+	// LastFetchError is the error message from the most recent failed fetch, if any.
+	//
+	// Required: false
+	LastFetchError *string `json:"lastFetchError,omitempty"`
 }
 
 // TemplateContent contains a template with its associated content and metadata.


### PR DESCRIPTION
## Summary

- Template registry fetch errors were silently swallowed in `loadRemoteTemplates` (`return nil // Don't fail the whole group`), leaving users with no way to diagnose why templates stopped loading after upgrading.
- Root cause in v1.17.3: SSRF protection (`ValidateSafeRemoteURL`) performs a DNS lookup on the registry URL. In restricted network environments (no outbound DNS, private registries on RFC1918 addresses) this blocks the request with no user-visible feedback.
- Fix: track the last fetch error per registry ID in a lightweight in-memory map on `TemplateService`. On success the entry is cleared. The existing `GET /templates/registries` response now includes `lastFetchError` on each registry object so users can see the exact error without checking server logs.

Closes #2342

## Test plan

- [ ] Add a template registry with an unreachable URL
- [ ] Call `GET /templates/registries` — verify `lastFetchError` is populated with the error message
- [ ] Fix the URL / make the registry reachable
- [ ] Verify `lastFetchError` disappears from the next response after a successful fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR surfaces per-registry fetch errors (previously silently swallowed) through a new in-memory `registryErrors` map on `TemplateService`, exposed via `GetRegistryFetchErrors()` and overlaid onto the `GET /templates/registries` response as `lastFetchError`. The approach is lightweight, correctly protected by the existing `registryMu` RWMutex, and non-breaking. Two minor housekeeping gaps: (1) the success path holds the local `mu` while acquiring `registryMu`, unnecessarily coupling two independent critical sections; (2) `DeleteRegistry` does not remove the registry's entry from `registryErrors`, leaving a small orphaned entry in the map.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all findings are minor style/cleanup items that don't affect correctness.

The core logic is correct — the mutex usage is sound (no deadlock risk), the snapshot copy in GetRegistryFetchErrors is proper, and the DTO change is backward-compatible. Both flagged issues are P2 quality improvements rather than correctness or reliability bugs.

backend/internal/services/template_service.go — lock nesting and missing DeleteRegistry cleanup
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/internal/services/template_service.go`, line 509-526 ([link](https://github.com/getarcaneapp/arcane/blob/764913845b8becf3439bbac8846daadc6e90c788/backend/internal/services/template_service.go#L509-L526)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`registryErrors` entry not removed on registry deletion**

   When a registry is deleted, its entry in `s.registryErrors` is never cleaned up. With UUID IDs the practical impact is negligible, but it is a minor memory leak and would surface stale error state if the ID were ever reused. Clearing the entry here alongside `invalidateRemoteCache()` keeps the map consistent with the database.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/template_service.go
   Line: 509-526

   Comment:
   **`registryErrors` entry not removed on registry deletion**

   When a registry is deleted, its entry in `s.registryErrors` is never cleaned up. With UUID IDs the practical impact is negligible, but it is a minor memory leak and would surface stale error state if the ID were ever reused. Clearing the entry here alongside `invalidateRemoteCache()` keeps the map consistent with the database.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Ftemplate-registry-surface-errors%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftemplate-registry-surface-errors%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Ftemplate_service.go%0ALine%3A%20509-526%0A%0AComment%3A%0A**%60registryErrors%60%20entry%20not%20removed%20on%20registry%20deletion**%0A%0AWhen%20a%20registry%20is%20deleted%2C%20its%20entry%20in%20%60s.registryErrors%60%20is%20never%20cleaned%20up.%20With%20UUID%20IDs%20the%20practical%20impact%20is%20negligible%2C%20but%20it%20is%20a%20minor%20memory%20leak%20and%20would%20surface%20stale%20error%20state%20if%20the%20ID%20were%20ever%20reused.%20Clearing%20the%20entry%20here%20alongside%20%60invalidateRemoteCache%28%29%60%20keeps%20the%20map%20consistent%20with%20the%20database.%0A%0A%60%60%60suggestion%0A%09s.invalidateRemoteCache%28%29%0A%0A%09s.registryMu.Lock%28%29%0A%09delete%28s.registryErrors%2C%20id%29%0A%09s.registryMu.Unlock%28%29%0A%0A%09return%20nil%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Ftemplate-registry-surface-errors%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftemplate-registry-surface-errors%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Finternal%2Fservices%2Ftemplate_service.go%3A557-561%0A**Unnecessary%20lock%20nesting%20in%20success%20path**%0A%0A%60s.registryMu%60%20is%20acquired%20while%20%60mu%60%20is%20already%20held.%20The%20registry-error%20cleanup%20and%20the%20templates-slice%20append%20are%20independent%20operations%3B%20holding%20%60mu%60%20across%20the%20%60registryMu%60%20lock%2Funlock%20needlessly%20extends%20the%20window%20during%20which%20%60mu%60%20is%20held%20and%20couples%20two%20unrelated%20critical%20sections.%0A%0A%60%60%60suggestion%0A%09%09%09s.registryMu.Lock%28%29%0A%09%09%09delete%28s.registryErrors%2C%20reg.ID%29%0A%09%09%09s.registryMu.Unlock%28%29%0A%0A%09%09%09mu.Lock%28%29%0A%09%09%09defer%20mu.Unlock%28%29%0A%60%60%60%0A%0A**Rule%20Used%3A**%20%23%20Go%20Development%20Patterns%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Finternal%2Fservices%2Ftemplate_service.go%3A509-526%0A**%60registryErrors%60%20entry%20not%20removed%20on%20registry%20deletion**%0A%0AWhen%20a%20registry%20is%20deleted%2C%20its%20entry%20in%20%60s.registryErrors%60%20is%20never%20cleaned%20up.%20With%20UUID%20IDs%20the%20practical%20impact%20is%20negligible%2C%20but%20it%20is%20a%20minor%20memory%20leak%20and%20would%20surface%20stale%20error%20state%20if%20the%20ID%20were%20ever%20reused.%20Clearing%20the%20entry%20here%20alongside%20%60invalidateRemoteCache%28%29%60%20keeps%20the%20map%20consistent%20with%20the%20database.%0A%0A%60%60%60suggestion%0A%09s.invalidateRemoteCache%28%29%0A%0A%09s.registryMu.Lock%28%29%0A%09delete%28s.registryErrors%2C%20id%29%0A%09s.registryMu.Unlock%28%29%0A%0A%09return%20nil%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/template_service.go
Line: 557-561

Comment:
**Unnecessary lock nesting in success path**

`s.registryMu` is acquired while `mu` is already held. The registry-error cleanup and the templates-slice append are independent operations; holding `mu` across the `registryMu` lock/unlock needlessly extends the window during which `mu` is held and couples two unrelated critical sections.

```suggestion
			s.registryMu.Lock()
			delete(s.registryErrors, reg.ID)
			s.registryMu.Unlock()

			mu.Lock()
			defer mu.Unlock()
```

**Rule Used:** # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/services/template_service.go
Line: 509-526

Comment:
**`registryErrors` entry not removed on registry deletion**

When a registry is deleted, its entry in `s.registryErrors` is never cleaned up. With UUID IDs the practical impact is negligible, but it is a minor memory leak and would surface stale error state if the ID were ever reused. Clearing the entry here alongside `invalidateRemoteCache()` keeps the map consistent with the database.

```suggestion
	s.invalidateRemoteCache()

	s.registryMu.Lock()
	delete(s.registryErrors, id)
	s.registryMu.Unlock()

	return nil
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: surface registry fetch errors in GE..."](https://github.com/getarcaneapp/arcane/commit/764913845b8becf3439bbac8846daadc6e90c788) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28132662)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

<!-- /greptile_comment -->