### PR TITLE
fix: detect provider-level failures in generic webhook notifications (#2352)

### DIFF
--- a/backend/internal/models/notification.go
+++ b/backend/internal/models/notification.go
@@ -191,6 +191,13 @@ type GenericConfig struct {
 	CustomHeaders map[string]string              `json:"customHeaders,omitempty"`
 	DisableTLS    bool                           `json:"disableTls"`
 	Events        map[NotificationEventType]bool `json:"events,omitempty"`
+	// SuccessBodyContains is an optional substring that must appear in the
+	// response body for the send to be considered successful. Useful for
+	// providers that always return HTTP 200 but embed a status indicator in
+	// the JSON body (e.g. PushPlus returns {"code":200,...} on success and
+	// {"code":900,...} on failure). When empty, only the HTTP status code is
+	// checked (existing behaviour).
+	SuccessBodyContains string `json:"successBodyContains,omitempty"`
 }
 
 type AppriseSettings struct {

--- a/backend/pkg/utils/notifications/generic_sender.go
+++ b/backend/pkg/utils/notifications/generic_sender.go
@@ -1,8 +1,12 @@
 package notifications
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -108,10 +112,21 @@ func BuildGenericURL(config models.GenericConfig) (string, error) {
 	return shoutrrrURL.String(), nil
 }
 
-// SendGenericWithTitle sends a message with title via Shoutrrr Generic webhook
+// SendGenericWithTitle sends a message with title via Shoutrrr Generic webhook.
+// When config.SuccessBodyContains is set the response body is also inspected —
+// this is necessary for providers (e.g. PushPlus) that always return HTTP 200
+// but embed a success/failure indicator inside the JSON body.
 func SendGenericWithTitle(ctx context.Context, config models.GenericConfig, title, message string) error {
 	if config.WebhookURL == "" {
 		return fmt.Errorf("webhook URL is empty")
+	}
+
+	// When the caller needs response-body validation we make the HTTP request
+	// ourselves so that we can inspect the body.  Otherwise we delegate to
+	// shoutrrr, which preserves the existing behaviour for everyone who does
+	// not set SuccessBodyContains.
+	if config.SuccessBodyContains != "" {
+		return sendGenericDirect(ctx, config, title, message)
 	}
 
 	shoutrrrURL, err := BuildGenericURL(config)
@@ -138,4 +153,109 @@ func SendGenericWithTitle(ctx context.Context, config models.GenericConfig, titl
 		}
 	}
 	return nil
+}
+
+// sendGenericDirect makes the webhook HTTP call directly, giving access to the
+// response body so that provider-level success/failure can be detected even
+// when the HTTP status is always 200.
+func sendGenericDirect(ctx context.Context, config models.GenericConfig, title, message string) error {
+	webhookURL, err := resolveWebhookURL(config)
+	if err != nil {
+		return err
+	}
+
+	// Build JSON payload using the configured message/title keys.
+	msgKey := config.MessageKey
+	if msgKey == "" {
+		msgKey = "message"
+	}
+	titleKey := config.TitleKey
+	if titleKey == "" {
+		titleKey = "title"
+	}
+
+	payload := map[string]string{msgKey: message}
+	if title != "" {
+		payload[titleKey] = title
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal webhook payload: %w", err)
+	}
+
+	method := strings.ToUpper(config.Method)
+	if method == "" {
+		method = http.MethodPost
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, webhookURL.String(), bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create webhook request: %w", err)
+	}
+
+	contentType := config.ContentType
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	for k, v := range config.CustomHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send webhook request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read webhook response body: %w", err)
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("webhook returned HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if config.SuccessBodyContains != "" && !strings.Contains(string(respBody), config.SuccessBodyContains) {
+		return fmt.Errorf("webhook response did not contain expected success indicator %q: %s", config.SuccessBodyContains, string(respBody))
+	}
+
+	return nil
+}
+
+// resolveWebhookURL parses and normalises the configured webhook URL,
+// adding a default scheme when the user omitted one.
+func resolveWebhookURL(config models.GenericConfig) (*url.URL, error) {
+	parsed, err := url.Parse(config.WebhookURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid webhook URL: %w", err)
+	}
+
+	hasScheme := strings.Contains(config.WebhookURL, "://")
+	if parsed.Host == "" && !hasScheme {
+		scheme := "https"
+		if config.DisableTLS {
+			scheme = "http"
+		}
+		normalized := strings.TrimPrefix(config.WebhookURL, "//")
+		parsed, err = url.Parse(fmt.Sprintf("%s://%s", scheme, normalized))
+		if err != nil {
+			return nil, fmt.Errorf("invalid webhook URL: %w", err)
+		}
+	}
+
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("invalid webhook URL: missing host")
+	}
+
+	switch strings.ToLower(parsed.Scheme) {
+	case "http", "https":
+	default:
+		return nil, fmt.Errorf("invalid webhook URL scheme: %s", parsed.Scheme)
+	}
+
+	return parsed, nil
 }

--- a/backend/pkg/utils/notifications/generic_sender.go
+++ b/backend/pkg/utils/notifications/generic_sender.go
@@ -15,38 +15,52 @@ import (
 	shoutrrrTypes "github.com/nicholas-fedor/shoutrrr/pkg/types"
 )
 
-// BuildGenericURL converts GenericConfig to Shoutrrr URL format for generic webhooks
-func BuildGenericURL(config models.GenericConfig) (string, error) {
+// resolveWebhookURLInternal parses and normalises the configured webhook URL,
+// adding a default scheme when the user omitted one. It is the single source
+// of truth for scheme normalisation and host validation used by both
+// BuildGenericURL and sendGenericDirectInternal.
+func resolveWebhookURLInternal(config models.GenericConfig) (*url.URL, error) {
 	if config.WebhookURL == "" {
-		return "", fmt.Errorf("webhook URL is empty")
+		return nil, fmt.Errorf("webhook URL is empty")
 	}
 
-	// Parse the webhook URL
-	webhookURL, err := url.Parse(config.WebhookURL)
+	parsed, err := url.Parse(config.WebhookURL)
 	if err != nil {
-		return "", fmt.Errorf("invalid webhook URL: %w", err)
+		return nil, fmt.Errorf("invalid webhook URL: %w", err)
 	}
 
 	hasScheme := strings.Contains(config.WebhookURL, "://")
-	if webhookURL.Host == "" && !hasScheme {
-		fallbackScheme := "https"
+	if parsed.Host == "" && !hasScheme {
+		scheme := "https"
 		if config.DisableTLS {
-			fallbackScheme = "http"
+			scheme = "http"
 		}
 		normalized := strings.TrimPrefix(config.WebhookURL, "//")
-		webhookURL, err = url.Parse(fmt.Sprintf("%s://%s", fallbackScheme, normalized))
+		parsed, err = url.Parse(fmt.Sprintf("%s://%s", scheme, normalized))
 		if err != nil {
-			return "", fmt.Errorf("invalid webhook URL: %w", err)
+			return nil, fmt.Errorf("invalid webhook URL: %w", err)
 		}
 	}
 
-	if webhookURL.Host == "" {
-		return "", fmt.Errorf("invalid webhook URL: missing host")
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("invalid webhook URL: missing host")
 	}
 
-	// Build generic service URL
-	// Format: generic://host[:port]/path?params
-	// Shoutrrr's generic service uses HTTP or HTTPS based on the DisableTLS setting.
+	switch strings.ToLower(parsed.Scheme) {
+	case "http", "https":
+	default:
+		return nil, fmt.Errorf("invalid webhook URL scheme: %s", parsed.Scheme)
+	}
+
+	return parsed, nil
+}
+
+// BuildGenericURL converts GenericConfig to Shoutrrr URL format for generic webhooks
+func BuildGenericURL(config models.GenericConfig) (string, error) {
+	webhookURL, err := resolveWebhookURLInternal(config)
+	if err != nil {
+		return "", err
+	}
 
 	// Start from the user's existing query parameters. Shoutrrr's generic
 	// service preserves any query keys it does not recognise, so provider
@@ -82,16 +96,12 @@ func BuildGenericURL(config models.GenericConfig) (string, error) {
 	setDefault("messagekey", config.MessageKey)
 
 	// Determine TLS setting from the webhook URL scheme (http/https) when the
-	// user has not already passed `disabletls` explicitly. If the scheme is
-	// missing here we treat it as a hard error because Shoutrrr needs an
-	// explicit transport.
+	// user has not already passed `disabletls` explicitly.
 	switch strings.ToLower(webhookURL.Scheme) {
 	case "http":
 		setDefault("disabletls", "yes")
 	case "https":
 		setDefault("disabletls", "no")
-	default:
-		return "", fmt.Errorf("invalid webhook URL scheme: %s", webhookURL.Scheme)
 	}
 
 	// Add custom headers as query parameters with @ prefix
@@ -126,7 +136,7 @@ func SendGenericWithTitle(ctx context.Context, config models.GenericConfig, titl
 	// shoutrrr, which preserves the existing behaviour for everyone who does
 	// not set SuccessBodyContains.
 	if config.SuccessBodyContains != "" {
-		return sendGenericDirect(ctx, config, title, message)
+		return sendGenericDirectInternal(ctx, config, title, message)
 	}
 
 	shoutrrrURL, err := BuildGenericURL(config)
@@ -155,11 +165,11 @@ func SendGenericWithTitle(ctx context.Context, config models.GenericConfig, titl
 	return nil
 }
 
-// sendGenericDirect makes the webhook HTTP call directly, giving access to the
-// response body so that provider-level success/failure can be detected even
-// when the HTTP status is always 200.
-func sendGenericDirect(ctx context.Context, config models.GenericConfig, title, message string) error {
-	webhookURL, err := resolveWebhookURL(config)
+// sendGenericDirectInternal makes the webhook HTTP call directly, giving access
+// to the response body so that provider-level success/failure can be detected
+// even when the HTTP status is always 200.
+func sendGenericDirectInternal(ctx context.Context, config models.GenericConfig, title, message string) error {
+	webhookURL, err := resolveWebhookURLInternal(config)
 	if err != nil {
 		return err
 	}
@@ -219,43 +229,9 @@ func sendGenericDirect(ctx context.Context, config models.GenericConfig, title, 
 		return fmt.Errorf("webhook returned HTTP %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	if config.SuccessBodyContains != "" && !strings.Contains(string(respBody), config.SuccessBodyContains) {
+	if !strings.Contains(string(respBody), config.SuccessBodyContains) {
 		return fmt.Errorf("webhook response did not contain expected success indicator %q: %s", config.SuccessBodyContains, string(respBody))
 	}
 
 	return nil
-}
-
-// resolveWebhookURL parses and normalises the configured webhook URL,
-// adding a default scheme when the user omitted one.
-func resolveWebhookURL(config models.GenericConfig) (*url.URL, error) {
-	parsed, err := url.Parse(config.WebhookURL)
-	if err != nil {
-		return nil, fmt.Errorf("invalid webhook URL: %w", err)
-	}
-
-	hasScheme := strings.Contains(config.WebhookURL, "://")
-	if parsed.Host == "" && !hasScheme {
-		scheme := "https"
-		if config.DisableTLS {
-			scheme = "http"
-		}
-		normalized := strings.TrimPrefix(config.WebhookURL, "//")
-		parsed, err = url.Parse(fmt.Sprintf("%s://%s", scheme, normalized))
-		if err != nil {
-			return nil, fmt.Errorf("invalid webhook URL: %w", err)
-		}
-	}
-
-	if parsed.Host == "" {
-		return nil, fmt.Errorf("invalid webhook URL: missing host")
-	}
-
-	switch strings.ToLower(parsed.Scheme) {
-	case "http", "https":
-	default:
-		return nil, fmt.Errorf("invalid webhook URL scheme: %s", parsed.Scheme)
-	}
-
-	return parsed, nil
 }


### PR DESCRIPTION
## Summary

- Providers like PushPlus always return HTTP 200 even on failure (wrong field name, invalid token, etc.). shoutrrr's generic service only checks the HTTP status code, so Arcane incorrectly reported the notification as sent.
- Add an optional `successBodyContains` field to `GenericConfig`. When set, `SendGenericWithTitle` bypasses shoutrrr and makes the HTTP call directly, reads the full response body, and returns an error if the expected substring is absent.
- Existing behaviour is unchanged for users who do not set `successBodyContains` — they still go through shoutrrr.

**Example PushPlus config:** set `successBodyContains` to `"code":200` to distinguish a real success (body contains `{"code":200,...}`) from a failure (body contains `{"code":900,...}`).

Closes #2352

## Test plan

- [ ] Configure a Generic webhook for PushPlus with a **valid** token and `successBodyContains: '"code":200'`
- [ ] Send a test notification — verify it is delivered and no error is shown
- [ ] Configure with an **invalid** token
- [ ] Send a test notification — verify an error is returned to the UI (previously showed as success)
- [ ] Configure a standard webhook (no `successBodyContains`) — verify existing behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an optional `successBodyContains` field to `GenericConfig` and a new direct HTTP path in `SendGenericWithTitle` to handle providers (e.g. PushPlus) that always return HTTP 200 but signal failure in the response body. Existing behaviour is fully preserved when the field is not set.

Two new unexported helpers (`sendGenericDirect`, `resolveWebhookURL`) are missing the project-required `Internal` suffix, and `resolveWebhookURL` duplicates URL-normalisation logic already present in `BuildGenericURL`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all findings are P2 style/naming issues that do not affect runtime behaviour.

No P0 or P1 issues found. The logic is sound, backward-compatible, and the two remaining findings are naming-convention violations and a code-duplication note.

backend/pkg/utils/notifications/generic_sender.go — naming convention violations on the two new private helpers.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fgeneric-webhook-response-validation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fgeneric-webhook-response-validation%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Fpkg%2Futils%2Fnotifications%2Fgeneric_sender.go%3A161%0A**Unexported%20functions%20missing%20%22Internal%22%20suffix**%0A%0ABoth%20new%20unexported%20functions%20%E2%80%94%20%60sendGenericDirect%60%20%28line%20161%29%20and%20%60resolveWebhookURL%60%20%28line%20231%29%20%E2%80%94%20are%20missing%20the%20required%20%60Internal%60%20suffix%20for%20private%20helpers.%0A%0A%60%60%60suggestion%0Afunc%20sendGenericDirectInternal%28ctx%20context.Context%2C%20config%20models.GenericConfig%2C%20title%2C%20message%20string%29%20error%20%7B%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A%23%23%23%20Issue%202%20of%203%0Abackend%2Fpkg%2Futils%2Fnotifications%2Fgeneric_sender.go%3A231%0A**%22Internal%22%20suffix%20required%20for%20unexported%20helper**%0A%0ASame%20naming%20rule%20applies%20here%20%E2%80%94%20the%20private%20helper%20should%20be%20%60resolveWebhookURLInternal%60.%0A%0A%60%60%60suggestion%0Afunc%20resolveWebhookURLInternal%28config%20models.GenericConfig%29%20%28*url.URL%2C%20error%29%20%7B%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A%23%23%23%20Issue%203%20of%203%0Abackend%2Fpkg%2Futils%2Fnotifications%2Fgeneric_sender.go%3A229-261%0A**URL-parsing%20logic%20duplicated%20from%20%60BuildGenericURL%60**%0A%0A%60resolveWebhookURL%60%20reproduces%20the%20same%20scheme-normalisation%20and%20host-validation%20logic%20that%20already%20exists%20in%20%60BuildGenericURL%60%20%28lines%2025%E2%80%9345%29.%20If%20the%20normalisation%20rules%20ever%20diverge%2C%20the%20two%20code%20paths%20will%20behave%20differently%20for%20the%20same%20%60WebhookURL%60%20value.%20Consider%20extracting%20the%20shared%20logic%20into%20one%20helper%20and%20calling%20it%20from%20both%20%60BuildGenericURL%60%20and%20%60sendGenericDirect%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/utils/notifications/generic_sender.go
Line: 161

Comment:
**Unexported functions missing "Internal" suffix**

Both new unexported functions — `sendGenericDirect` (line 161) and `resolveWebhookURL` (line 231) — are missing the required `Internal` suffix for private helpers.

```suggestion
func sendGenericDirectInternal(ctx context.Context, config models.GenericConfig, title, message string) error {
```

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/utils/notifications/generic_sender.go
Line: 231

Comment:
**"Internal" suffix required for unexported helper**

Same naming rule applies here — the private helper should be `resolveWebhookURLInternal`.

```suggestion
func resolveWebhookURLInternal(config models.GenericConfig) (*url.URL, error) {
```

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/utils/notifications/generic_sender.go
Line: 229-261

Comment:
**URL-parsing logic duplicated from `BuildGenericURL`**

`resolveWebhookURL` reproduces the same scheme-normalisation and host-validation logic that already exists in `BuildGenericURL` (lines 25–45). If the normalisation rules ever diverge, the two code paths will behave differently for the same `WebhookURL` value. Consider extracting the shared logic into one helper and calling it from both `BuildGenericURL` and `sendGenericDirect`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: detect provider-level failures in g..."](https://github.com/getarcaneapp/arcane/commit/c9a83581dd4ecef591527430e0ca8ac636f6dd3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28132671)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->