### PR TITLE
fix: send notification on single container update

### DIFF
--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -625,7 +625,7 @@ func (s *UpdaterService) UpdateSingleContainer(ctx context.Context, containerID 
 			out.Duration = time.Since(start).String()
 
 			if s.notificationService != nil {
-				if notifErr := s.notificationService.SendContainerUpdateNotification(ctx, containerName, normalizedRef, inspectBefore.Image, s.normalizeRef(normalizedRef)); notifErr != nil {
+				if notifErr := s.notificationService.SendContainerUpdateNotification(ctx, containerName, imageRef, inspectBefore.Image, normalizedRef); notifErr != nil {
 					slog.WarnContext(ctx, "Failed to send container update notification", "containerID", containerID, "containerName", containerName, "imageRef", normalizedRef, "error", notifErr.Error())
 				}
 			}
@@ -659,7 +659,7 @@ func (s *UpdaterService) UpdateSingleContainer(ctx context.Context, containerID 
 		out.Updated++
 
 		if s.notificationService != nil {
-			if notifErr := s.notificationService.SendContainerUpdateNotification(ctx, containerName, normalizedRef, inspectBefore.Image, s.normalizeRef(normalizedRef)); notifErr != nil {
+			if notifErr := s.notificationService.SendContainerUpdateNotification(ctx, containerName, imageRef, inspectBefore.Image, normalizedRef); notifErr != nil {
 				slog.WarnContext(ctx, "Failed to send container update notification", "containerID", containerID, "containerName", containerName, "imageRef", normalizedRef, "error", notifErr.Error())
 			}
 		}

--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -624,6 +624,12 @@ func (s *UpdaterService) UpdateSingleContainer(ctx context.Context, containerID 
 			out.Checked = 1
 			out.Duration = time.Since(start).String()
 
+			if s.notificationService != nil {
+				if notifErr := s.notificationService.SendContainerUpdateNotification(ctx, containerName, normalizedRef, inspectBefore.Image, s.normalizeRef(normalizedRef)); notifErr != nil {
+					slog.WarnContext(ctx, "Failed to send container update notification", "containerID", containerID, "containerName", containerName, "imageRef", normalizedRef, "error", notifErr.Error())
+				}
+			}
+
 			// Prune old image if no longer in use
 			if inspectBefore.Image != "" {
 				_ = s.pruneImageIDsWithInUseSetInternal(ctx, []string{inspectBefore.Image}, nil)
@@ -651,6 +657,12 @@ func (s *UpdaterService) UpdateSingleContainer(ctx context.Context, containerID 
 			Status:       "updated",
 		})
 		out.Updated++
+
+		if s.notificationService != nil {
+			if notifErr := s.notificationService.SendContainerUpdateNotification(ctx, containerName, normalizedRef, inspectBefore.Image, s.normalizeRef(normalizedRef)); notifErr != nil {
+				slog.WarnContext(ctx, "Failed to send container update notification", "containerID", containerID, "containerName", containerName, "imageRef", normalizedRef, "error", notifErr.Error())
+			}
+		}
 
 		// Clear the update record for this exact image ID when no running container still uses it.
 		// This avoids repo-name canonicalization mismatches (e.g. "nginx" vs "docker.io/library/nginx").


### PR DESCRIPTION
Fixes #1802.

## What happened

The bulk **Update Containers** button sends Discord/Apprise notifications correctly. The per-container **Update** button (single container) was silently skipping them — `SendContainerUpdateNotification` was never called in either the compose-project or standalone success branch of `UpdateSingleContainer`.

## Fix

Added the notification call in both success paths inside `UpdateSingleContainer`, mirroring exactly what `restartContainersUsingOldIDs` already does for bulk updates.

## Testing

Trigger a single-container update via the container's **Update** button → notification fires. Bulk update → still fires. No-op update (digest unchanged) → no notification, same as before.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `SendContainerUpdateNotification` calls to both success branches inside `UpdateSingleContainer` — the compose-project path and the standalone path — fixing a bug where single-container updates silently skipped Discord/Apprise notifications. The fix correctly mirrors the existing bulk-update implementation in `restartContainersUsingOldIDs` and preserves the no-op-skip behavior (no notification when digest is unchanged).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the fix is correct and the only finding is a minor style point.

Both notification call sites use the correct function with semantically valid arguments. The only issue is a redundant double-normalization that is harmless at runtime. No P0 or P1 findings.

No files require special attention.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fsingle-container-update-notification%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsingle-container-update-notification%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fupdater_service.go%3A628%0A**Redundant%20double-normalization%20for%20%60newDigest%60**%0A%0A%60normalizedRef%60%20is%20already%20%60s.normalizeRef%28imageRef%29%60%2C%20so%20passing%20%60s.normalizeRef%28normalizedRef%29%60%20as%20%60newDigest%60%20applies%20the%20normalizer%20twice%20to%20the%20same%20string%2C%20making%20%60imageRef%60%20and%20%60newDigest%60%20identical%20in%20the%20notification.%20The%20bulk-update%20path%20intentionally%20passes%20the%20raw%20%60p.newRef%60%20as%20%60imageRef%60%20and%20%60s.normalizeRef%28p.newRef%29%60%20as%20%60newDigest%60%20so%20the%20two%20fields%20can%20differ%20%28e.g.%20%60%22nginx%3Alatest%22%60%20vs%20%60%22docker.io%2Flibrary%2Fnginx%3Alatest%22%60%29.%20To%20match%20that%20pattern%20here%2C%20pass%20the%20pre-normalized%20%60imageRef%60%20as%20the%20second%20argument%20and%20%60normalizedRef%60%20as%20the%20last%3A%0A%0A%60%60%60suggestion%0A%09%09%09%09if%20notifErr%20%3A%3D%20s.notificationService.SendContainerUpdateNotification%28ctx%2C%20containerName%2C%20imageRef%2C%20inspectBefore.Image%2C%20normalizedRef%29%3B%20notifErr%20!%3D%20nil%20%7B%0A%60%60%60%0A%0AThe%20same%20applies%20to%20the%20standalone%20path%20at%20line%20662.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/updater_service.go
Line: 628

Comment:
**Redundant double-normalization for `newDigest`**

`normalizedRef` is already `s.normalizeRef(imageRef)`, so passing `s.normalizeRef(normalizedRef)` as `newDigest` applies the normalizer twice to the same string, making `imageRef` and `newDigest` identical in the notification. The bulk-update path intentionally passes the raw `p.newRef` as `imageRef` and `s.normalizeRef(p.newRef)` as `newDigest` so the two fields can differ (e.g. `"nginx:latest"` vs `"docker.io/library/nginx:latest"`). To match that pattern here, pass the pre-normalized `imageRef` as the second argument and `normalizedRef` as the last:

```suggestion
				if notifErr := s.notificationService.SendContainerUpdateNotification(ctx, containerName, imageRef, inspectBefore.Image, normalizedRef); notifErr != nil {
```

The same applies to the standalone path at line 662.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: single container update now pings y..."](https://github.com/getarcaneapp/arcane/commit/baa004f1bff2c15ce6c8c7a62b4eadf1e4f6c1d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28136497)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->