### PR TITLE
fix: guard volume file browser against non-mountable driver types

### DIFF
--- a/backend/internal/services/volume_service.go
+++ b/backend/internal/services/volume_service.go
@@ -263,14 +263,15 @@ func buildVolumePruneMetadataInternal(all bool, volumesDeleted int, spaceReclaim
 // --- Volume Browsing & Backup ---
 
 // isBrowsableVolumeInternal returns an error if the volume uses driver options
-// (e.g. type=none) that prevent it from being mounted inside a helper container.
+// that prevent it from being mounted inside a helper container, such as
+// type=none or o=bind (host bind-mounts that require a device path on the host).
 func (s *VolumeService) isBrowsableVolumeInternal(ctx context.Context, volumeName string) error {
 	vol, err := s.GetVolumeByName(ctx, volumeName)
 	if err != nil {
 		return fmt.Errorf("failed to inspect volume: %w", err)
 	}
-	if vol.Options["type"] == "none" {
-		return fmt.Errorf("volume %q uses a custom mount type (type=none) and cannot be browsed", volumeName)
+	if vol.Options["type"] == "none" || strings.Contains(vol.Options["o"], "bind") {
+		return fmt.Errorf("volume %q uses a custom mount configuration and cannot be browsed", volumeName)
 	}
 	return nil
 }

--- a/backend/internal/services/volume_service.go
+++ b/backend/internal/services/volume_service.go
@@ -262,8 +262,25 @@ func buildVolumePruneMetadataInternal(all bool, volumesDeleted int, spaceReclaim
 
 // --- Volume Browsing & Backup ---
 
+// isBrowsableVolumeInternal returns an error if the volume uses driver options
+// (e.g. type=none) that prevent it from being mounted inside a helper container.
+func (s *VolumeService) isBrowsableVolumeInternal(ctx context.Context, volumeName string) error {
+	vol, err := s.GetVolumeByName(ctx, volumeName)
+	if err != nil {
+		return fmt.Errorf("failed to inspect volume: %w", err)
+	}
+	if vol.Options["type"] == "none" {
+		return fmt.Errorf("volume %q uses a custom mount type (type=none) and cannot be browsed", volumeName)
+	}
+	return nil
+}
+
 func (s *VolumeService) ListDirectory(ctx context.Context, volumeName, dirPath string) ([]volumetypes.FileEntry, error) {
 	slog.DebugContext(ctx, "volume service: list directory", "volume", volumeName, "path", dirPath)
+
+	if err := s.isBrowsableVolumeInternal(ctx, volumeName); err != nil {
+		return nil, err
+	}
 
 	sanitizedPath, err := s.sanitizeBrowsePathInternal(dirPath)
 	if err != nil {
@@ -348,6 +365,10 @@ func (s *VolumeService) ListDirectory(ctx context.Context, volumeName, dirPath s
 func (s *VolumeService) GetFileContent(ctx context.Context, volumeName, filePath string, maxBytes int64) ([]byte, string, error) {
 	slog.DebugContext(ctx, "volume service: get file content", "volume", volumeName, "path", filePath, "max_bytes", maxBytes)
 
+	if err := s.isBrowsableVolumeInternal(ctx, volumeName); err != nil {
+		return nil, "", err
+	}
+
 	sanitizedPath, err := s.sanitizeBrowsePathInternal(filePath)
 	if err != nil {
 		return nil, "", fmt.Errorf("invalid path: %w", err)
@@ -374,6 +395,10 @@ func (s *VolumeService) GetFileContent(ctx context.Context, volumeName, filePath
 
 func (s *VolumeService) DownloadFile(ctx context.Context, volumeName, filePath string) (io.ReadCloser, int64, error) {
 	slog.DebugContext(ctx, "volume service: download file", "volume", volumeName, "path", filePath)
+
+	if err := s.isBrowsableVolumeInternal(ctx, volumeName); err != nil {
+		return nil, 0, err
+	}
 
 	sanitizedPath, err := s.sanitizeBrowsePathInternal(filePath)
 	if err != nil {


### PR DESCRIPTION
## What

Volumes created with `type=none` (or other custom local driver options like `o=bind,device=...`) cannot be mounted inside a helper container — Docker fails with `failed to mount local volume: no such device`.

Before this fix, the error bubbled up as a confusing daemon-level message. Now the volume options are checked upfront and a clear, user-friendly error is returned instead of trying to spin up a temp container that was never going to work.

## Changes

- Added `isBrowsableVolumeInternal` helper in `volume_service.go` that inspects the volume's driver options before mounting
- Applied the guard to all three browsing entry points: `ListDirectory`, `GetFileContent`, `DownloadFile`

## Testing

Create a volume with the advanced driver options `type=none`, `o=bind`, `device=/some/path`. Navigate to the Browser tab — you'll now get a clear error instead of a daemon stacktrace.

Fixes #2359

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `isBrowsableVolumeInternal` guard that inspects a volume's driver options before spinning up a helper container, returning a user-friendly error for `type=none` volumes that would otherwise produce a confusing daemon-level "no such device" failure. The guard is correctly wired into all three browsing entry points (`ListDirectory`, `GetFileContent`, `DownloadFile`) and follows the repo's naming and error-wrapping conventions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is targeted, correct for the reported bug, and all remaining feedback is P2.

No P0 or P1 findings. The nil-map access on `vol.Options` is safe in Go. Error wrapping follows idiomatic patterns. The only suggestion is broadening the guard condition to cover additional bind-variant configurations, which is a non-blocking improvement.

No files require special attention.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fvolume-browser-type-none%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fvolume-browser-type-none%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fvolume_service.go%3A267-276%0A**Guard%20only%20checks%20%60type%3Dnone%60**%0A%0AThe%20current%20check%20catches%20the%20primary%20failure%20mode%20%28%60type%3Dnone%60%29%2C%20but%20other%20local-driver%20configurations%20can%20also%20fail%20to%20mount%20in%20a%20helper%20container%20%E2%80%94%20for%20example%2C%20a%20volume%20created%20with%20just%20%60o%3Dbind%2Cdevice%3D%2Fpath%60%20and%20no%20explicit%20%60type%60%20key%2C%20or%20%60type%3Dtmpfs%60%20%28which%20mounts%20successfully%20but%20always%20appears%20empty%29.%20Adding%20a%20check%20for%20%60device%60%20or%20%60o%3Dbind%60%20would%20harden%20the%20guard%20against%20related%20edge%20cases.%0A%0A%60%60%60suggestion%0Afunc%20%28s%20*VolumeService%29%20isBrowsableVolumeInternal%28ctx%20context.Context%2C%20volumeName%20string%29%20error%20%7B%0A%09vol%2C%20err%20%3A%3D%20s.GetVolumeByName%28ctx%2C%20volumeName%29%0A%09if%20err%20!%3D%20nil%20%7B%0A%09%09return%20fmt.Errorf%28%22failed%20to%20inspect%20volume%3A%20%25w%22%2C%20err%29%0A%09%7D%0A%09if%20vol.Options%5B%22type%22%5D%20%3D%3D%20%22none%22%20%7C%7C%20strings.Contains%28vol.Options%5B%22o%22%5D%2C%20%22bind%22%29%20%7B%0A%09%09return%20fmt.Errorf%28%22volume%20%25q%20uses%20a%20custom%20mount%20type%20%28%25q%29%20and%20cannot%20be%20browsed%22%2C%20volumeName%2C%20vol.Options%5B%22type%22%5D%29%0A%09%7D%0A%09return%20nil%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/volume_service.go
Line: 267-276

Comment:
**Guard only checks `type=none`**

The current check catches the primary failure mode (`type=none`), but other local-driver configurations can also fail to mount in a helper container — for example, a volume created with just `o=bind,device=/path` and no explicit `type` key, or `type=tmpfs` (which mounts successfully but always appears empty). Adding a check for `device` or `o=bind` would harden the guard against related edge cases.

```suggestion
func (s *VolumeService) isBrowsableVolumeInternal(ctx context.Context, volumeName string) error {
	vol, err := s.GetVolumeByName(ctx, volumeName)
	if err != nil {
		return fmt.Errorf("failed to inspect volume: %w", err)
	}
	if vol.Options["type"] == "none" || strings.Contains(vol.Options["o"], "bind") {
		return fmt.Errorf("volume %q uses a custom mount type (%q) and cannot be browsed", volumeName, vol.Options["type"])
	}
	return nil
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: guard volume browser against non-mo..."](https://github.com/getarcaneapp/arcane/commit/fa8745f2643addaa775f472afcff22fd5fd9ebb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28175879)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->