### PR TITLE
fix: actually redeploy swarm stack when saving edits

### DIFF
--- a/frontend/src/routes/(app)/swarm/stacks/new/+page.svelte
+++ b/frontend/src/routes/(app)/swarm/stacks/new/+page.svelte
@@ -103,7 +103,7 @@
 		const { name, composeContent, envContent } = validated;
 
 		handleApiResultWithCallbacks({
-			result: await tryCatch(swarmService.updateStackSource(name, { composeContent, envContent })),
+			result: await tryCatch(swarmService.deployStack({ name, composeContent, envContent })),
 			message: m.common_update_failed({ resource: `${m.swarm_stack()} "${name}"` }),
 			setLoadingState: (value) => (saving = value),
 			onSuccess: async () => {


### PR DESCRIPTION
## What

Editing a Swarm stack and clicking Save only persisted the new compose source to disk — the running services were never updated. Docker was left running the original config, so any changes (new ports, volumes, env vars) were silently dropped.

## Root cause

In edit mode, the form's submit handler called `updateStackSource` which is a storage-only endpoint. It writes files but doesn't touch Swarm.

## Fix

Wire the save button in edit mode to `deployStack` instead. `deployStack` does the actual `docker stack deploy` AND persists the source, so the stack ends up in the right state without needing a separate redeploy step.

Fixes #2361

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where editing a Swarm stack and saving only persisted the compose source to disk but never redeployed the running services. The one-line fix replaces the `updateStackSource` (storage-only `PUT`) call with `deployStack` (which runs `docker stack deploy` and persists the source) inside `handleSaveStackSource`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, targeted fix that correctly wires the save action to the deploy endpoint.

Single-line change with a clear root cause and well-understood fix. No new logic is introduced; the edit-mode save path now mirrors what `docker stack deploy` does (idempotent create-or-update). Error messages and redirect paths in the success callback remain appropriate for edit mode.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: redeploy swarm stack when saving ed..."](https://github.com/getarcaneapp/arcane/commit/ba33b862dc12afa43d29425992fe55c3685042ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28175897)</sub>

<!-- /greptile_comment -->