### PR TITLE
fix: set all api endpoints to use auth by default and explicitly remove auth for public endpoints

### DIFF
--- a/backend/internal/huma/handlers/appimages.go
+++ b/backend/internal/huma/handlers/appimages.go
@@ -57,6 +57,7 @@ func RegisterAppImages(api huma.API, appImagesService *services.ApplicationImage
 		Summary:     "Get application logo",
 		Description: "Get the application logo image",
 		Tags:        []string{"Application Images"},
+		Security:    []map[string][]string{},
 	}, h.GetLogo)
 
 	huma.Register(api, huma.Operation{
@@ -66,6 +67,7 @@ func RegisterAppImages(api huma.API, appImagesService *services.ApplicationImage
 		Summary:     "Get application logo for email",
 		Description: "Get the application logo image in PNG format for emails",
 		Tags:        []string{"Application Images"},
+		Security:    []map[string][]string{},
 	}, h.GetLogoEmail)
 
 	huma.Register(api, huma.Operation{
@@ -75,6 +77,7 @@ func RegisterAppImages(api huma.API, appImagesService *services.ApplicationImage
 		Summary:     "Get application favicon",
 		Description: "Get the application favicon image",
 		Tags:        []string{"Application Images"},
+		Security:    []map[string][]string{},
 	}, h.GetFavicon)
 
 	huma.Register(api, huma.Operation{
@@ -84,6 +87,7 @@ func RegisterAppImages(api huma.API, appImagesService *services.ApplicationImage
 		Summary:     "Get default profile image",
 		Description: "Get the default user profile image",
 		Tags:        []string{"Application Images"},
+		Security:    []map[string][]string{},
 	}, h.GetDefaultProfile)
 
 	huma.Register(api, huma.Operation{
@@ -93,6 +97,7 @@ func RegisterAppImages(api huma.API, appImagesService *services.ApplicationImage
 		Summary:     "Get PWA icon",
 		Description: "Get a Progressive Web App icon image",
 		Tags:        []string{"Application Images"},
+		Security:    []map[string][]string{},
 	}, h.GetPWAIcon)
 }
 

--- a/backend/internal/huma/handlers/auth.go
+++ b/backend/internal/huma/handlers/auth.go
@@ -76,6 +76,7 @@ func RegisterAuth(api huma.API, userService *services.UserService, authService *
 		Summary:     "Login",
 		Description: "Authenticate a user with username and password",
 		Tags:        []string{"Auth"},
+		Security:    []map[string][]string{},
 	}, h.Login)
 
 	huma.Register(api, huma.Operation{
@@ -85,6 +86,7 @@ func RegisterAuth(api huma.API, userService *services.UserService, authService *
 		Summary:     "Logout",
 		Description: "Clear authentication session",
 		Tags:        []string{"Auth"},
+		Security:    []map[string][]string{},
 	}, h.Logout)
 
 	huma.Register(api, huma.Operation{
@@ -107,6 +109,7 @@ func RegisterAuth(api huma.API, userService *services.UserService, authService *
 		Summary:     "Refresh token",
 		Description: "Obtain a new access token using a refresh token",
 		Tags:        []string{"Auth"},
+		Security:    []map[string][]string{},
 	}, h.RefreshToken)
 
 	huma.Register(api, huma.Operation{

--- a/backend/internal/huma/handlers/environments.go
+++ b/backend/internal/huma/handlers/environments.go
@@ -298,6 +298,7 @@ func RegisterEnvironments(api huma.API, environmentService *services.Environment
 		Description:  "Agent sends API key to complete environment pairing",
 		Tags:         []string{"Environments"},
 		MaxBodyBytes: 1024,
+		Security:     []map[string][]string{},
 	}, h.PairEnvironment)
 
 	huma.Register(api, huma.Operation{

--- a/backend/internal/huma/handlers/health.go
+++ b/backend/internal/huma/handlers/health.go
@@ -22,6 +22,7 @@ func RegisterHealth(api huma.API) {
 		Summary:     "Health check",
 		Description: "Check if the API is healthy",
 		Tags:        []string{"Health"},
+		Security:    []map[string][]string{},
 	}, func(ctx context.Context, input *struct{}) (*HealthOutput, error) {
 		return &HealthOutput{
 			Body: system.HealthResponse{
@@ -37,6 +38,7 @@ func RegisterHealth(api huma.API) {
 		Summary:     "Health check (HEAD)",
 		Description: "Check if the API is healthy (HEAD request)",
 		Tags:        []string{"Health"},
+		Security:    []map[string][]string{},
 	}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
 		return nil, nil
 	})

--- a/backend/internal/huma/handlers/oidc.go
+++ b/backend/internal/huma/handlers/oidc.go
@@ -99,6 +99,7 @@ func RegisterOidc(api huma.API, authService *services.AuthService, oidcService *
 		Summary:     "Get OIDC status",
 		Description: "Get the current OIDC configuration status",
 		Tags:        []string{"OIDC"},
+		Security:    []map[string][]string{},
 	}, h.GetOidcStatus)
 
 	huma.Register(api, huma.Operation{
@@ -108,6 +109,7 @@ func RegisterOidc(api huma.API, authService *services.AuthService, oidcService *
 		Summary:     "Get OIDC config",
 		Description: "Get the OIDC client configuration",
 		Tags:        []string{"OIDC"},
+		Security:    []map[string][]string{},
 	}, h.GetOidcConfig)
 
 	huma.Register(api, huma.Operation{
@@ -117,6 +119,7 @@ func RegisterOidc(api huma.API, authService *services.AuthService, oidcService *
 		Summary:     "Get OIDC auth URL",
 		Description: "Generate an OIDC authorization URL for login",
 		Tags:        []string{"OIDC"},
+		Security:    []map[string][]string{},
 	}, h.GetOidcAuthUrl)
 
 	huma.Register(api, huma.Operation{
@@ -126,6 +129,7 @@ func RegisterOidc(api huma.API, authService *services.AuthService, oidcService *
 		Summary:     "Handle OIDC callback",
 		Description: "Process the OIDC callback and complete authentication",
 		Tags:        []string{"OIDC"},
+		Security:    []map[string][]string{},
 	}, h.HandleOidcCallback)
 
 	huma.Register(api, huma.Operation{
@@ -135,6 +139,7 @@ func RegisterOidc(api huma.API, authService *services.AuthService, oidcService *
 		Summary:     "Initiate OIDC device authorization",
 		Description: "Start the device authorization flow for CLI authentication",
 		Tags:        []string{"OIDC"},
+		Security:    []map[string][]string{},
 	}, h.InitiateDeviceAuth)
 
 	huma.Register(api, huma.Operation{
@@ -144,6 +149,7 @@ func RegisterOidc(api huma.API, authService *services.AuthService, oidcService *
 		Summary:     "Exchange device code for tokens",
 		Description: "Exchange a device code for authentication tokens",
 		Tags:        []string{"OIDC"},
+		Security:    []map[string][]string{},
 	}, h.ExchangeDeviceToken)
 }
 

--- a/backend/internal/huma/handlers/settings.go
+++ b/backend/internal/huma/handlers/settings.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/common"
 	"github.com/getarcaneapp/arcane/backend/internal/config"
 	humamw "github.com/getarcaneapp/arcane/backend/internal/huma/middleware"
+	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/getarcaneapp/arcane/backend/internal/services"
 	"github.com/getarcaneapp/arcane/backend/pkg/projects"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils/mapper"
@@ -68,11 +69,11 @@ type GetCategoriesOutput struct {
 	Body []category.Category
 }
 
-// validateProjectsDirectoryValue validates a projects directory value allowing:
+// validateProjectsDirectoryValueInternal validates a projects directory value allowing:
 // - Unix absolute paths (/...)
 // - Windows drive paths (C:/..., C:\...)
 // - Mapping format "container:host" where container is absolute Unix or Windows path
-func validateProjectsDirectoryValue(path string) error {
+func validateProjectsDirectoryValueInternal(path string) error {
 	switch {
 	case projects.IsWindowsDrivePath(path):
 		return nil
@@ -94,10 +95,10 @@ func validateProjectsDirectoryValue(path string) error {
 	}
 }
 
-// validateAbsoluteDirectoryPath validates a plain absolute directory path allowing:
+// validateAbsoluteDirectoryPathInternal validates a plain absolute directory path allowing:
 // - Unix absolute paths (/...)
 // - Windows drive paths (C:/..., C:\...)
-func validateAbsoluteDirectoryPath(path string) error {
+func validateAbsoluteDirectoryPathInternal(path string) error {
 	switch {
 	case projects.IsWindowsDrivePath(path):
 		return nil
@@ -125,6 +126,7 @@ func RegisterSettings(api huma.API, settingsService *services.SettingsService, s
 		Summary:     "Get public settings",
 		Description: "Get all public settings for an environment",
 		Tags:        []string{"Settings"},
+		Security:    []map[string][]string{},
 	}, h.GetPublicSettings)
 
 	huma.Register(api, huma.Operation{
@@ -205,14 +207,14 @@ func (h *SettingsHandler) GetPublicSettings(ctx context.Context, input *GetPubli
 		return &GetPublicSettingsOutput{Body: settingsDto}, nil
 	}
 
-	settingsList := h.settingsService.ListSettings(false)
+	settingsList := h.settingsService.ListSettings(models.SettingVisibilityPublic)
 
 	var settingsDto []settings.PublicSetting
 	if err := mapper.MapStructList(settingsList, &settingsDto); err != nil {
 		return nil, huma.Error500InternalServerError((&common.SettingsMappingError{Err: err}).Error())
 	}
 
-	return &GetPublicSettingsOutput{Body: h.appendRuntimeSettings(settingsDto)}, nil
+	return &GetPublicSettingsOutput{Body: h.appendRuntimeSettings(settingsDto, false)}, nil
 }
 
 // GetSettings returns all settings for an environment.
@@ -241,46 +243,51 @@ func (h *SettingsHandler) GetSettings(ctx context.Context, input *GetSettingsInp
 		return &GetSettingsOutput{Body: settingsDto}, nil
 	}
 
-	showAll := isAdmin
-	settingsList := h.settingsService.ListSettings(showAll)
+	visibility := models.SettingVisibilityNonAdmin
+	if isAdmin {
+		visibility = models.SettingVisibilityAll
+	}
+	settingsList := h.settingsService.ListSettings(visibility)
 
 	var settingsDto []settings.PublicSetting
 	if err := mapper.MapStructList(settingsList, &settingsDto); err != nil {
 		return nil, huma.Error500InternalServerError((&common.SettingsMappingError{Err: err}).Error())
 	}
 
-	return &GetSettingsOutput{Body: h.appendRuntimeSettings(settingsDto)}, nil
+	return &GetSettingsOutput{Body: h.appendRuntimeSettings(settingsDto, true)}, nil
 }
 
-func (h *SettingsHandler) appendRuntimeSettings(settingsDto []settings.PublicSetting) []settings.PublicSetting {
+func (h *SettingsHandler) appendRuntimeSettings(settingsDto []settings.PublicSetting, includeAuthenticatedOnly bool) []settings.PublicSetting {
 	uiConfigDisabled := false
-	if h.cfg != nil {
+	if includeAuthenticatedOnly && h.cfg != nil {
 		uiConfigDisabled = h.cfg.UIConfigurationDisabled
 	}
-	settingsDto = append(settingsDto, settings.PublicSetting{
-		Key:   "uiConfigDisabled",
-		Value: strconv.FormatBool(uiConfigDisabled),
-		Type:  "boolean",
-	})
-
-	backupVolumeName := "arcane-backups"
-	if h.cfg != nil && strings.TrimSpace(h.cfg.BackupVolumeName) != "" {
-		backupVolumeName = h.cfg.BackupVolumeName
-	}
-	settingsDto = append(settingsDto, settings.PublicSetting{
-		Key:   "backupVolumeName",
-		Value: backupVolumeName,
-		Type:  "string",
-	})
-
-	if h.settingsService != nil {
-		cfg := h.settingsService.GetSettingsConfig()
-		depotConfigured := strings.TrimSpace(cfg.DepotProjectId.Value) != "" && strings.TrimSpace(cfg.DepotToken.Value) != ""
+	if includeAuthenticatedOnly {
 		settingsDto = append(settingsDto, settings.PublicSetting{
-			Key:   "depotConfigured",
-			Value: strconv.FormatBool(depotConfigured),
+			Key:   "uiConfigDisabled",
+			Value: strconv.FormatBool(uiConfigDisabled),
 			Type:  "boolean",
 		})
+
+		backupVolumeName := "arcane-backups"
+		if h.cfg != nil && strings.TrimSpace(h.cfg.BackupVolumeName) != "" {
+			backupVolumeName = h.cfg.BackupVolumeName
+		}
+		settingsDto = append(settingsDto, settings.PublicSetting{
+			Key:   "backupVolumeName",
+			Value: backupVolumeName,
+			Type:  "string",
+		})
+
+		if h.settingsService != nil {
+			cfg := h.settingsService.GetSettingsConfig()
+			depotConfigured := strings.TrimSpace(cfg.DepotProjectId.Value) != "" && strings.TrimSpace(cfg.DepotToken.Value) != ""
+			settingsDto = append(settingsDto, settings.PublicSetting{
+				Key:   "depotConfigured",
+				Value: strconv.FormatBool(depotConfigured),
+				Type:  "boolean",
+			})
+		}
 	}
 
 	return settingsDto
@@ -315,7 +322,7 @@ func (h *SettingsHandler) validateSettingsUpdateInput(input settings.Update) err
 	if input.ProjectsDirectory != nil && *input.ProjectsDirectory != "" {
 		currentDir := h.settingsService.GetSettingsConfig().ProjectsDirectory.Value
 		if *input.ProjectsDirectory != currentDir {
-			if err := validateProjectsDirectoryValue(*input.ProjectsDirectory); err != nil {
+			if err := validateProjectsDirectoryValueInternal(*input.ProjectsDirectory); err != nil {
 				return huma.Error400BadRequest(err.Error())
 			}
 		}
@@ -324,7 +331,7 @@ func (h *SettingsHandler) validateSettingsUpdateInput(input settings.Update) err
 	if input.SwarmStackSourcesDirectory != nil && *input.SwarmStackSourcesDirectory != "" {
 		currentDir := h.settingsService.GetSettingsConfig().SwarmStackSourcesDirectory.Value
 		if *input.SwarmStackSourcesDirectory != currentDir {
-			if err := validateAbsoluteDirectoryPath(*input.SwarmStackSourcesDirectory); err != nil {
+			if err := validateAbsoluteDirectoryPathInternal(*input.SwarmStackSourcesDirectory); err != nil {
 				return huma.Error400BadRequest("swarmStackSourcesDirectory " + err.Error())
 			}
 		}
@@ -339,7 +346,7 @@ func (h *SettingsHandler) updateSettingsForRemoteEnvironment(ctx context.Context
 	}
 
 	// Check if trying to update auth settings on non-local environment.
-	if hasAuthSettingsUpdate(input.Body) {
+	if hasAuthSettingsUpdateInternal(input.Body) {
 		return nil, huma.Error403Forbidden((&common.AuthSettingsUpdateError{}).Error())
 	}
 
@@ -389,7 +396,7 @@ func (h *SettingsHandler) updateSettingsForLocalEnvironment(ctx context.Context,
 	}, nil
 }
 
-func hasAuthSettingsUpdate(req settings.Update) bool {
+func hasAuthSettingsUpdateInternal(req settings.Update) bool {
 	return req.AuthLocalEnabled != nil || req.OidcEnabled != nil ||
 		req.AuthSessionTimeout != nil || req.AuthPasswordPolicy != nil ||
 		req.AuthOidcConfig != nil || req.OidcClientId != nil ||

--- a/backend/internal/huma/handlers/settings_test.go
+++ b/backend/internal/huma/handlers/settings_test.go
@@ -1,0 +1,40 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/getarcaneapp/arcane/backend/internal/config"
+	apitypes "github.com/getarcaneapp/arcane/types/settings"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSettingsHandler_AppendRuntimeSettings(t *testing.T) {
+	handler := &SettingsHandler{
+		cfg: &config.Config{
+			UIConfigurationDisabled: true,
+			BackupVolumeName:        "custom-backups",
+		},
+	}
+
+	publicSettings := handler.appendRuntimeSettings(nil, false)
+	publicKeys := runtimeSettingKeysInternal(publicSettings)
+	require.NotContains(t, publicKeys, "uiConfigDisabled")
+	require.NotContains(t, publicKeys, "backupVolumeName")
+	require.NotContains(t, publicKeys, "depotConfigured")
+
+	authenticatedSettings := handler.appendRuntimeSettings(nil, true)
+	authenticatedKeys := runtimeSettingKeysInternal(authenticatedSettings)
+	require.Contains(t, authenticatedKeys, "uiConfigDisabled")
+	require.Contains(t, authenticatedKeys, "backupVolumeName")
+	require.Equal(t, "true", authenticatedKeys["uiConfigDisabled"])
+	require.Equal(t, "custom-backups", authenticatedKeys["backupVolumeName"])
+}
+
+func runtimeSettingKeysInternal(settings []apitypes.PublicSetting) map[string]string {
+	keys := make(map[string]string, len(settings))
+	for _, setting := range settings {
+		keys[setting.Key] = setting.Value
+	}
+
+	return keys
+}

--- a/backend/internal/huma/handlers/templates.go
+++ b/backend/internal/huma/handlers/templates.go
@@ -177,7 +177,7 @@ type UpdateGlobalVariablesOutput struct {
 func RegisterTemplates(api huma.API, templateService *services.TemplateService, environmentService *services.EnvironmentService) {
 	h := &TemplateHandler{templateService: templateService, environmentService: environmentService}
 
-	// Public endpoints (no auth required in original)
+	// Template registry endpoint.
 	huma.Register(api, huma.Operation{
 		OperationID: "fetchTemplateRegistry",
 		Method:      "GET",

--- a/backend/internal/huma/handlers/templates_test.go
+++ b/backend/internal/huma/handlers/templates_test.go
@@ -73,6 +73,44 @@ func TestFetchTemplateRegistryAuthenticatedUnsafeTargetIsSanitized(t *testing.T)
 	require.NotContains(t, rec.Body.String(), "Invalid JSON response")
 }
 
+func TestTemplateReadEndpointsRequireAuthentication(t *testing.T) {
+	router := newTemplateFetchTestRouter(t, http.DefaultClient)
+
+	testCases := []struct {
+		name string
+		path string
+	}{
+		{name: "list templates", path: "/api/templates"},
+		{name: "list all templates", path: "/api/templates/all"},
+		{name: "get template", path: "/api/templates/test-template"},
+		{name: "get template content", path: "/api/templates/test-template/content"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, testCase.path, nil)
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusUnauthorized, rec.Code)
+			require.Contains(t, rec.Body.String(), "Unauthorized")
+		})
+	}
+}
+
+func TestHealthEndpointRemainsPublic(t *testing.T) {
+	router := newTemplateFetchTestRouter(t, http.DefaultClient)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "UP")
+}
+
 func newTemplateFetchTestRouter(t *testing.T, httpClient *http.Client) *gin.Engine {
 	t.Helper()
 
@@ -114,9 +152,14 @@ func newTemplateFetchTestRouter(t *testing.T, httpClient *http.Client) *gin.Engi
 			Name: "X-API-Key",
 		},
 	}
+	humaConfig.Security = []map[string][]string{
+		{"BearerAuth": {}},
+		{"ApiKeyAuth": {}},
+	}
 
 	api := humagin.NewWithGroup(router, apiGroup, humaConfig)
 	api.UseMiddleware(humamiddleware.NewAuthBridge(api, authService, nil, &config.Config{}))
+	RegisterHealth(api)
 	RegisterTemplates(api, templateService, nil)
 
 	return router

--- a/backend/internal/huma/handlers/version.go
+++ b/backend/internal/huma/handlers/version.go
@@ -47,6 +47,7 @@ func RegisterVersion(api huma.API, versionService *services.VersionService) {
 		Summary:     "Get version information",
 		Description: "Get application version information and check for updates",
 		Tags:        []string{"Version"},
+		Security:    []map[string][]string{},
 	}, h.GetVersion)
 
 	huma.Register(api, huma.Operation{
@@ -56,6 +57,7 @@ func RegisterVersion(api huma.API, versionService *services.VersionService) {
 		Summary:     "Get app version",
 		Description: "Get the current application version",
 		Tags:        []string{"Version"},
+		Security:    []map[string][]string{},
 	}, h.GetAppVersion)
 }
 

--- a/backend/internal/huma/huma.go
+++ b/backend/internal/huma/huma.go
@@ -210,6 +210,10 @@ func SetupAPI(router *gin.Engine, apiGroup *gin.RouterGroup, cfg *config.Config,
 			Description: "API Key authentication",
 		},
 	}
+	humaConfig.Security = []map[string][]string{
+		{"BearerAuth": {}},
+		{"ApiKeyAuth": {}},
+	}
 
 	// Use custom schema namer to avoid conflicts between types with same name
 	// from different packages (e.g., image.Summary vs env.Summary)
@@ -286,6 +290,10 @@ func SetupAPIForSpec() huma.API {
 			Name:        "X-API-Key",
 			Description: "API Key authentication",
 		},
+	}
+	humaConfig.Security = []map[string][]string{
+		{"BearerAuth": {}},
+		{"ApiKeyAuth": {}},
 	}
 
 	// Use custom schema namer to avoid conflicts between types with same name

--- a/backend/internal/huma/huma_test.go
+++ b/backend/internal/huma/huma_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	humav2 "github.com/danielgtaylor/huma/v2"
 	basetypes "github.com/getarcaneapp/arcane/types/base"
 	envtypes "github.com/getarcaneapp/arcane/types/env"
 	imagetypes "github.com/getarcaneapp/arcane/types/image"
@@ -55,5 +56,118 @@ func TestCustomSchemaNamer_DisambiguatesGenericUsageCounts(t *testing.T) {
 	}
 	if volumeResp == imageResp {
 		t.Fatalf("expected unique generic schema names, got %q", volumeResp)
+	}
+}
+
+func TestSetupAPIForSpec_DefaultSecurity(t *testing.T) {
+	api := SetupAPIForSpec()
+
+	expectedSecurity := []map[string][]string{
+		{"BearerAuth": {}},
+		{"ApiKeyAuth": {}},
+	}
+
+	if !reflect.DeepEqual(api.OpenAPI().Security, expectedSecurity) {
+		t.Fatalf("expected default API security %v, got %v", expectedSecurity, api.OpenAPI().Security)
+	}
+}
+
+func TestSetupAPIForSpec_PublicRoutesOverrideSecurity(t *testing.T) {
+	api := SetupAPIForSpec()
+
+	getOperation := func(path, method string) *humav2.Operation {
+		pathItem := api.OpenAPI().Paths[path]
+		if pathItem == nil {
+			t.Fatalf("expected path %q to be registered", path)
+		}
+
+		switch method {
+		case "GET":
+			return pathItem.Get
+		case "POST":
+			return pathItem.Post
+		case "HEAD":
+			return pathItem.Head
+		default:
+			t.Fatalf("unsupported method %q", method)
+			return nil
+		}
+	}
+
+	testCases := []struct {
+		path   string
+		method string
+	}{
+		{path: "/app-images/logo", method: "GET"},
+		{path: "/app-images/logo-email", method: "GET"},
+		{path: "/app-images/favicon", method: "GET"},
+		{path: "/app-images/profile", method: "GET"},
+		{path: "/app-images/pwa/{filename}", method: "GET"},
+		{path: "/auth/login", method: "POST"},
+		{path: "/auth/logout", method: "POST"},
+		{path: "/auth/refresh", method: "POST"},
+		{path: "/health", method: "GET"},
+		{path: "/health", method: "HEAD"},
+		{path: "/oidc/status", method: "GET"},
+		{path: "/oidc/config", method: "GET"},
+		{path: "/oidc/url", method: "POST"},
+		{path: "/oidc/callback", method: "POST"},
+		{path: "/oidc/device/code", method: "POST"},
+		{path: "/oidc/device/token", method: "POST"},
+		{path: "/environments/{id}/settings/public", method: "GET"},
+		{path: "/environments/pair", method: "POST"},
+		{path: "/version", method: "GET"},
+		{path: "/app-version", method: "GET"},
+		{path: "/fonts/sans", method: "GET"},
+		{path: "/fonts/mono", method: "GET"},
+		{path: "/fonts/serif", method: "GET"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.method+" "+testCase.path, func(t *testing.T) {
+			operation := getOperation(testCase.path, testCase.method)
+			if operation == nil {
+				t.Fatalf("expected operation %s %s to be registered", testCase.method, testCase.path)
+			}
+			if operation.Security == nil {
+				t.Fatalf("expected operation %s %s to explicitly override security", testCase.method, testCase.path)
+			}
+			if len(operation.Security) != 0 {
+				t.Fatalf("expected operation %s %s to be public, got security %v", testCase.method, testCase.path, operation.Security)
+			}
+		})
+	}
+}
+
+func TestSetupAPIForSpec_TemplateReadRoutesProtected(t *testing.T) {
+	api := SetupAPIForSpec()
+
+	expectedSecurity := []map[string][]string{
+		{"BearerAuth": {}},
+		{"ApiKeyAuth": {}},
+	}
+
+	testCases := []struct {
+		path string
+	}{
+		{path: "/templates"},
+		{path: "/templates/all"},
+		{path: "/templates/{id}"},
+		{path: "/templates/{id}/content"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.path, func(t *testing.T) {
+			pathItem := api.OpenAPI().Paths[testCase.path]
+			if pathItem == nil || pathItem.Get == nil {
+				t.Fatalf("expected GET %s to be registered", testCase.path)
+			}
+			if pathItem.Get.Security != nil {
+				t.Fatalf("expected GET %s to inherit API security, got explicit security %v", testCase.path, pathItem.Get.Security)
+			}
+			if !reflect.DeepEqual(api.OpenAPI().Security, expectedSecurity) {
+				t.Fatalf("expected API security %v, got %v", expectedSecurity, api.OpenAPI().Security)
+			}
+		})
 	}
 }

--- a/backend/internal/huma/middleware/auth.go
+++ b/backend/internal/huma/middleware/auth.go
@@ -60,28 +60,43 @@ type operationProvider interface {
 	Operation() *huma.Operation
 }
 
-// parseSecurityRequirements extracts security requirements from a Huma operation.
-func parseSecurityRequirements(ctx operationProvider) securityRequirements {
+// parseSecurityRequirementsInternal extracts security requirements from a Huma operation.
+func parseSecurityRequirementsInternal(api huma.API, ctx operationProvider) securityRequirements {
 	reqs := securityRequirements{}
-	if ctx.Operation() == nil || len(ctx.Operation().Security) == 0 {
+	if ctx.Operation() == nil {
 		return reqs
 	}
-	for _, secReq := range ctx.Operation().Security {
+
+	security := ctx.Operation().Security
+	if security == nil && api != nil && api.OpenAPI() != nil {
+		security = api.OpenAPI().Security
+	}
+	if len(security) == 0 {
+		return reqs
+	}
+
+	optional := false
+	for _, secReq := range security {
+		if len(secReq) == 0 {
+			optional = true
+			continue
+		}
 		if _, ok := secReq["BearerAuth"]; ok {
-			reqs.isRequired = true
 			reqs.bearerAuth = true
 		}
 		if _, ok := secReq["ApiKeyAuth"]; ok {
-			reqs.isRequired = true
 			reqs.apiKeyAuth = true
 		}
 	}
+
+	reqs.isRequired = !optional && (reqs.bearerAuth || reqs.apiKeyAuth)
+
 	return reqs
 }
 
-// tryBearerAuth attempts Bearer token authentication.
-func tryBearerAuth(ctx huma.Context, authService *services.AuthService) (*models.User, bool) {
-	token := extractBearerToken(ctx)
+// tryBearerAuthInternal attempts Bearer token authentication.
+func tryBearerAuthInternal(ctx huma.Context, authService *services.AuthService) (*models.User, bool) {
+	token := extractBearerTokenInternal(ctx)
 	if token == "" {
 		return nil, false
 	}
@@ -92,8 +107,8 @@ func tryBearerAuth(ctx huma.Context, authService *services.AuthService) (*models
 	return user, true
 }
 
-// tryApiKeyAuth checks if API key authentication should be allowed through.
-func tryApiKeyAuth(ctx huma.Context, apiKeyService *services.ApiKeyService) (*models.User, bool) {
+// tryApiKeyAuthInternal checks if API key authentication should be allowed through.
+func tryApiKeyAuthInternal(ctx huma.Context, apiKeyService *services.ApiKeyService) (*models.User, bool) {
 	apiKey := ctx.Header(headerApiKey)
 	if apiKey == "" {
 		return nil, false
@@ -107,9 +122,9 @@ func tryApiKeyAuth(ctx huma.Context, apiKeyService *services.ApiKeyService) (*mo
 	return user, true
 }
 
-// tryAgentAuth checks if the request is from an authenticated agent.
+// tryAgentAuthInternal checks if the request is from an authenticated agent.
 // Returns a sudo agent user if the agent token is valid.
-func tryAgentAuth(ctx huma.Context, cfg *config.Config) (*models.User, bool) {
+func tryAgentAuthInternal(ctx huma.Context, cfg *config.Config) (*models.User, bool) {
 	if cfg == nil || !cfg.AgentMode {
 		return nil, false
 	}
@@ -120,24 +135,24 @@ func tryAgentAuth(ctx huma.Context, cfg *config.Config) (*models.User, bool) {
 	if strings.HasPrefix(path, agentPairingPrefix) &&
 		cfg.AgentToken != "" &&
 		ctx.Header(headerAgentBootstrap) == cfg.AgentToken {
-		return createAgentSudoUser(), true
+		return createAgentSudoUserInternal(), true
 	}
 
 	// Check for agent token
 	if tok := ctx.Header(headerAgentToken); tok != "" && cfg.AgentToken != "" && tok == cfg.AgentToken {
-		return createAgentSudoUser(), true
+		return createAgentSudoUserInternal(), true
 	}
 
 	// Check for API key as agent token
 	if tok := ctx.Header(headerApiKey); tok != "" && cfg.AgentToken != "" && tok == cfg.AgentToken {
-		return createAgentSudoUser(), true
+		return createAgentSudoUserInternal(), true
 	}
 
 	return nil, false
 }
 
-// createAgentSudoUser creates a sudo user for agent authentication.
-func createAgentSudoUser() *models.User {
+// createAgentSudoUserInternal creates a sudo user for agent authentication.
+func createAgentSudoUserInternal() *models.User {
 	email := "agent@getarcane.app"
 	return &models.User{
 		BaseModel: models.BaseModel{ID: "agent"},
@@ -157,15 +172,15 @@ func NewAuthBridge(api huma.API, authService *services.AuthService, apiKeyServic
 
 		// Check agent authentication first (if in agent mode)
 		if cfg != nil && cfg.AgentMode {
-			if user, ok := tryAgentAuth(ctx, cfg); ok {
-				newCtx := setUserInContext(ctx.Context(), user)
+			if user, ok := tryAgentAuthInternal(ctx, cfg); ok {
+				newCtx := setUserInContextInternal(ctx.Context(), user)
 				ctx = huma.WithContext(ctx, newCtx)
 				next(ctx)
 				return
 			}
 		}
 
-		reqs := parseSecurityRequirements(ctx)
+		reqs := parseSecurityRequirementsInternal(api, ctx)
 		if !reqs.isRequired {
 			next(ctx)
 			return
@@ -174,8 +189,8 @@ func NewAuthBridge(api huma.API, authService *services.AuthService, apiKeyServic
 		// If API key header is present and API key auth is allowed, prioritize it.
 		// If validation fails, do NOT fall back to Bearer auth.
 		if reqs.apiKeyAuth && ctx.Header(headerApiKey) != "" {
-			if user, ok := tryApiKeyAuth(ctx, apiKeyService); ok {
-				newCtx := setUserInContext(ctx.Context(), user)
+			if user, ok := tryApiKeyAuthInternal(ctx, apiKeyService); ok {
+				newCtx := setUserInContextInternal(ctx.Context(), user)
 				ctx = huma.WithContext(ctx, newCtx)
 				next(ctx)
 				return
@@ -186,8 +201,8 @@ func NewAuthBridge(api huma.API, authService *services.AuthService, apiKeyServic
 		}
 
 		if reqs.bearerAuth {
-			if user, ok := tryBearerAuth(ctx, authService); ok {
-				newCtx := setUserInContext(ctx.Context(), user)
+			if user, ok := tryBearerAuthInternal(ctx, authService); ok {
+				newCtx := setUserInContextInternal(ctx.Context(), user)
 				ctx = huma.WithContext(ctx, newCtx)
 				next(ctx)
 				return
@@ -199,8 +214,8 @@ func NewAuthBridge(api huma.API, authService *services.AuthService, apiKeyServic
 	}
 }
 
-// extractBearerToken extracts the JWT token from Authorization header or cookie.
-func extractBearerToken(ctx huma.Context) string {
+// extractBearerTokenInternal extracts the JWT token from Authorization header or cookie.
+func extractBearerTokenInternal(ctx huma.Context) string {
 	// Try Authorization header first
 	authHeader := ctx.Header("Authorization")
 	if len(authHeader) > 7 && strings.ToLower(authHeader[:7]) == "bearer " {
@@ -210,14 +225,14 @@ func extractBearerToken(ctx huma.Context) string {
 	// Try cookie as fallback
 	cookieHeader := ctx.Header("Cookie")
 	if cookieHeader != "" {
-		return extractTokenFromCookieHeader(cookieHeader)
+		return extractTokenFromCookieHeaderInternal(cookieHeader)
 	}
 
 	return ""
 }
 
-// extractTokenFromCookieHeader parses the token cookie from a Cookie header string.
-func extractTokenFromCookieHeader(cookieHeader string) string {
+// extractTokenFromCookieHeaderInternal parses the token cookie from a Cookie header string.
+func extractTokenFromCookieHeaderInternal(cookieHeader string) string {
 	cookies := strings.SplitSeq(cookieHeader, ";")
 	for c := range cookies {
 		c = strings.TrimSpace(c)
@@ -231,8 +246,8 @@ func extractTokenFromCookieHeader(cookieHeader string) string {
 	return ""
 }
 
-// setUserInContext adds the authenticated user to the context.
-func setUserInContext(ctx context.Context, user *models.User) context.Context {
+// setUserInContextInternal adds the authenticated user to the context.
+func setUserInContextInternal(ctx context.Context, user *models.User) context.Context {
 	ctx = context.WithValue(ctx, ContextKeyUserID, user.ID)
 	ctx = context.WithValue(ctx, ContextKeyCurrentUser, user)
 	ctx = context.WithValue(ctx, ContextKeyUserIsAdmin, pkgutils.UserHasRole(user.Roles, "admin"))

--- a/backend/internal/huma/middleware/auth_test.go
+++ b/backend/internal/huma/middleware/auth_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humagin"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type testOperationProvider struct {
+	operation *huma.Operation
+}
+
+func (p testOperationProvider) Operation() *huma.Operation {
+	return p.operation
+}
+
+func TestParseSecurityRequirements(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	apiGroup := router.Group("/api")
+	humaConfig := huma.DefaultConfig("test", "1.0.0")
+	humaConfig.Security = []map[string][]string{
+		{"BearerAuth": {}},
+		{"ApiKeyAuth": {}},
+	}
+	api := humagin.NewWithGroup(router, apiGroup, humaConfig)
+
+	testCases := []struct {
+		name     string
+		security []map[string][]string
+		expected securityRequirements
+	}{
+		{
+			name:     "nil operation security inherits top-level auth",
+			security: nil,
+			expected: securityRequirements{
+				isRequired: true,
+				bearerAuth: true,
+				apiKeyAuth: true,
+			},
+		},
+		{
+			name:     "explicit empty security stays public",
+			security: []map[string][]string{},
+			expected: securityRequirements{},
+		},
+		{
+			name: "explicit dual auth stays protected",
+			security: []map[string][]string{
+				{"BearerAuth": {}},
+				{"ApiKeyAuth": {}},
+			},
+			expected: securityRequirements{
+				isRequired: true,
+				bearerAuth: true,
+				apiKeyAuth: true,
+			},
+		},
+		{
+			name: "explicit api key auth stays api-key-only",
+			security: []map[string][]string{
+				{"ApiKeyAuth": {}},
+			},
+			expected: securityRequirements{
+				isRequired: true,
+				apiKeyAuth: true,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, parseSecurityRequirementsInternal(api, testOperationProvider{
+				operation: &huma.Operation{Security: testCase.security},
+			}))
+		})
+	}
+}

--- a/backend/internal/models/settings.go
+++ b/backend/internal/models/settings.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,13 +22,22 @@ type SettingVariable struct {
 	Value string
 }
 
+type SettingVisibility int
+
+const (
+	SettingVisibilityPublic SettingVisibility = iota
+	SettingVisibilityNonAdmin
+	SettingVisibilityAll
+)
+
 type settingFieldMeta struct {
-	index       int
-	key         string
-	attrs       string
-	isPublic    bool
-	isSensitive bool
-	isLocal     bool
+	index               int
+	key                 string
+	attrs               string
+	isPublic            bool
+	isVisibleToNonAdmin bool
+	isSensitive         bool
+	isLocal             bool
 }
 
 var settingsFieldCache struct {
@@ -113,7 +123,7 @@ type Settings struct {
 	GitSyncMaxFiles            SettingVariable `key:"gitSyncMaxFiles,envOverride" meta:"label=Git Sync Max Files;type=number;keywords=git,sync,files,limit,repository,compose,gitops;category=general;description=Maximum number of repository files copied during a Git sync. Set 0 to disable the environment cap (default: 500)"`
 	GitSyncMaxTotalSizeMb      SettingVariable `key:"gitSyncMaxTotalSizeMb,envOverride" meta:"label=Git Sync Max Total Size (MB);type=number;keywords=git,sync,size,limit,repository,compose,gitops,mb;category=general;description=Maximum combined size in MB for files copied during a Git sync. Set 0 to disable the environment cap (default: 50)"`
 	GitSyncMaxBinarySizeMb     SettingVariable `key:"gitSyncMaxBinarySizeMb,envOverride" meta:"label=Git Sync Max Binary Size (MB);type=number;keywords=git,sync,binary,size,limit,repository,compose,gitops,mb;category=general;description=Maximum size in MB for a single binary file copied during a Git sync. Set 0 to disable the environment cap (default: 10)"`
-	DockerHost                 SettingVariable `key:"dockerHost,public,envOverride" meta:"label=Docker Host;type=text;keywords=docker,host,daemon,socket,unix,remote;category=internal;description=URI for Docker daemon"`
+	DockerHost                 SettingVariable `key:"dockerHost,authrequired,envOverride" meta:"label=Docker Host;type=text;keywords=docker,host,daemon,socket,unix,remote;category=internal;description=URI for Docker daemon"`
 	BuildProvider              SettingVariable `key:"buildProvider,envOverride" meta:"label=Build Provider;type=select;keywords=build,buildkit,depot,provider,remote,local;category=build;description=Default build provider (local or depot)" catmeta:"id=build;title=Build;icon=code;url=/settings/builds;description=Configure BuildKit and Depot build settings"`
 	BuildsDirectory            SettingVariable `key:"buildsDirectory,envOverride" meta:"label=Builds Directory;type=text;keywords=builds,directory,path,workspace,context;category=build;description=Root directory for manual build workspaces"`
 	BuildTimeout               SettingVariable `key:"buildTimeout,envOverride" meta:"label=Build Timeout;type=number;keywords=build,timeout,seconds,buildkit;category=build;description=Timeout for BuildKit builds in seconds (default: 1800 = 30 minutes)"`
@@ -139,28 +149,28 @@ type Settings struct {
 	TrivyIgnore                     SettingVariable `key:"trivyIgnore" meta:"label=.trivyignore;type=textarea;keywords=trivy,ignore,ignorefile,vulnerabilities,exceptions,exclusions;category=security;description=Trivy ignore file content - one vulnerability ID per line"`
 	AuthOidcConfig                  SettingVariable `key:"authOidcConfig,sensitive,deprecated" meta:"label=OIDC Config;type=text;keywords=oidc,config,client,id,issuer,secret,oauth;category=authentication;description=OIDC provider configuration (deprecated - use individual fields)"`
 	OidcEnabled                     SettingVariable `key:"oidcEnabled,public,envOverride" meta:"label=OIDC Authentication;type=boolean;keywords=oidc,openid,connect,sso,oauth,external,provider,federation;category=authentication;description=Enable OpenID Connect (OIDC) authentication"`
-	OidcClientId                    SettingVariable `key:"oidcClientId,public,envOverride" meta:"label=OIDC Client ID;type=text;keywords=oidc,client,id,oauth,openid;category=authentication;description=OIDC provider client ID"`
+	OidcClientId                    SettingVariable `key:"oidcClientId,authrequired,envOverride" meta:"label=OIDC Client ID;type=text;keywords=oidc,client,id,oauth,openid;category=authentication;description=OIDC provider client ID"`
 	OidcClientSecret                SettingVariable `key:"oidcClientSecret,sensitive,envOverride" meta:"label=OIDC Client Secret;type=password;keywords=oidc,client,secret,oauth,openid;category=authentication;description=OIDC provider client secret"`
-	OidcIssuerUrl                   SettingVariable `key:"oidcIssuerUrl,public,envOverride" meta:"label=OIDC Issuer URL;type=text;keywords=oidc,issuer,url,oauth,openid,provider;category=authentication;description=OIDC provider issuer URL"`
+	OidcIssuerUrl                   SettingVariable `key:"oidcIssuerUrl,authrequired,envOverride" meta:"label=OIDC Issuer URL;type=text;keywords=oidc,issuer,url,oauth,openid,provider;category=authentication;description=OIDC provider issuer URL"`
 	OidcAuthorizationEndpoint       SettingVariable `key:"oidcAuthorizationEndpoint,envOverride" meta:"label=OIDC Authorization Endpoint;type=text;keywords=oidc,authorization,endpoint,oauth,openid;category=authentication;description=Override OIDC authorization endpoint"`
 	OidcTokenEndpoint               SettingVariable `key:"oidcTokenEndpoint,envOverride" meta:"label=OIDC Token Endpoint;type=text;keywords=oidc,token,endpoint,oauth,openid;category=authentication;description=Override OIDC token endpoint"`
 	OidcUserinfoEndpoint            SettingVariable `key:"oidcUserinfoEndpoint,envOverride" meta:"label=OIDC Userinfo Endpoint;type=text;keywords=oidc,userinfo,endpoint,oauth,openid;category=authentication;description=Override OIDC userinfo endpoint"`
 	OidcJwksEndpoint                SettingVariable `key:"oidcJwksEndpoint,envOverride" meta:"label=OIDC JWKS Endpoint;type=text;keywords=oidc,jwks,keys,endpoint,oauth,openid;category=authentication;description=Override OIDC JWKS endpoint"`
 	OidcDeviceAuthorizationEndpoint SettingVariable `key:"oidcDeviceAuthorizationEndpoint,envOverride" meta:"label=OIDC Device Authorization Endpoint;type=text;keywords=oidc,device,authorization,endpoint,oauth,openid,cli;category=authentication;description=Override OIDC device authorization endpoint for CLI authentication"`
-	OidcScopes                      SettingVariable `key:"oidcScopes,public,envOverride" meta:"label=OIDC Scopes;type=text;keywords=oidc,scopes,oauth,openid,permissions;category=authentication;description=OIDC scopes to request"`
-	OidcAdminClaim                  SettingVariable `key:"oidcAdminClaim,public,envOverride" meta:"label=OIDC Admin Claim;type=text;keywords=oidc,admin,claim,role,group;category=authentication;description=Claim name for admin role mapping"`
-	OidcAdminValue                  SettingVariable `key:"oidcAdminValue,public,envOverride" meta:"label=OIDC Admin Value;type=text;keywords=oidc,admin,value,role,group;category=authentication;description=Claim value that grants admin access"`
-	OidcSkipTlsVerify               SettingVariable `key:"oidcSkipTlsVerify,public,envOverride" meta:"label=OIDC Skip TLS Verify;type=boolean;keywords=oidc,tls,verify,skip,insecure;category=authentication;description=Skip TLS verification for OIDC provider"`
+	OidcScopes                      SettingVariable `key:"oidcScopes,authrequired,envOverride" meta:"label=OIDC Scopes;type=text;keywords=oidc,scopes,oauth,openid,permissions;category=authentication;description=OIDC scopes to request"`
+	OidcAdminClaim                  SettingVariable `key:"oidcAdminClaim,authrequired,envOverride" meta:"label=OIDC Admin Claim;type=text;keywords=oidc,admin,claim,role,group;category=authentication;description=Claim name for admin role mapping"`
+	OidcAdminValue                  SettingVariable `key:"oidcAdminValue,authrequired,envOverride" meta:"label=OIDC Admin Value;type=text;keywords=oidc,admin,value,role,group;category=authentication;description=Claim value that grants admin access"`
+	OidcSkipTlsVerify               SettingVariable `key:"oidcSkipTlsVerify,authrequired,envOverride" meta:"label=OIDC Skip TLS Verify;type=boolean;keywords=oidc,tls,verify,skip,insecure;category=authentication;description=Skip TLS verification for OIDC provider"`
 	OidcAutoRedirectToProvider      SettingVariable `key:"oidcAutoRedirectToProvider,public,envOverride" meta:"label=OIDC Auto Redirect;type=boolean;keywords=oidc,auto,redirect,automatic,login,provider,sso;category=authentication;description=Automatically redirect to OIDC provider on login page"`
-	OidcMergeAccounts               SettingVariable `key:"oidcMergeAccounts,public,envOverride" meta:"label=OIDC Account Merging;type=boolean;keywords=oidc,merge,link,accounts,email,match,existing,users,combine;category=authentication;description=Allow OIDC logins to merge with existing accounts by email"`
+	OidcMergeAccounts               SettingVariable `key:"oidcMergeAccounts,authrequired,envOverride" meta:"label=OIDC Account Merging;type=boolean;keywords=oidc,merge,link,accounts,email,match,existing,users,combine;category=authentication;description=Allow OIDC logins to merge with existing accounts by email"`
 	OidcProviderName                SettingVariable `key:"oidcProviderName,public,envOverride" meta:"label=OIDC Provider Name;type=text;keywords=oidc,provider,name,display,label,sso;category=authentication;description=Custom name for the OIDC provider (e.g., Authentik, Keycloak)"`
 	OidcProviderLogoUrl             SettingVariable `key:"oidcProviderLogoUrl,public,envOverride" meta:"label=OIDC Provider Logo URL;type=text;keywords=oidc,provider,logo,url,image,icon,sso;category=authentication;description=Custom logo URL for the OIDC provider"`
 
 	// Appearance category
-	MobileNavigationMode       SettingVariable `key:"mobileNavigationMode,public,local" meta:"label=Mobile Navigation Mode;type=select;keywords=mode,style,type,floating,docked,position,layout,design,appearance,bottom;category=appearance;description=Choose between floating or docked navigation on mobile" catmeta:"id=appearance;title=Appearance;icon=appearance;url=/settings/appearance;description=Customize navigation, theme, and interface behavior"`
-	MobileNavigationShowLabels SettingVariable `key:"mobileNavigationShowLabels,public,local" meta:"label=Show Navigation Labels;type=boolean;keywords=labels,text,icons,display,show,hide,names,captions,titles,visible,toggle;category=appearance;description=Display text labels alongside navigation icons"`
-	SidebarHoverExpansion      SettingVariable `key:"sidebarHoverExpansion,public,local" meta:"label=Sidebar Hover Expansion;type=boolean;keywords=sidebar,hover,expansion,expand,desktop,mouse,over,collapsed,collapsible,icon,labels,text,preview,peek,tooltip,overlay,temporary,quick,access,navigation,menu,items,submenu,nested;category=appearance;description=Expand sidebar on hover in desktop mode"`
-	KeyboardShortcutsEnabled   SettingVariable `key:"keyboardShortcutsEnabled,public,local" meta:"label=Keyboard Shortcuts;type=boolean;keywords=keyboard,shortcuts,hotkeys,keybindings,navigation,tooltips,disable;category=appearance;description=Enable keyboard shortcuts for navigation and show shortcut hints in tooltips"`
+	MobileNavigationMode       SettingVariable `key:"mobileNavigationMode,authrequired,local" meta:"label=Mobile Navigation Mode;type=select;keywords=mode,style,type,floating,docked,position,layout,design,appearance,bottom;category=appearance;description=Choose between floating or docked navigation on mobile" catmeta:"id=appearance;title=Appearance;icon=appearance;url=/settings/appearance;description=Customize navigation, theme, and interface behavior"`
+	MobileNavigationShowLabels SettingVariable `key:"mobileNavigationShowLabels,authrequired,local" meta:"label=Show Navigation Labels;type=boolean;keywords=labels,text,icons,display,show,hide,names,captions,titles,visible,toggle;category=appearance;description=Display text labels alongside navigation icons"`
+	SidebarHoverExpansion      SettingVariable `key:"sidebarHoverExpansion,authrequired,local" meta:"label=Sidebar Hover Expansion;type=boolean;keywords=sidebar,hover,expansion,expand,desktop,mouse,over,collapsed,collapsible,icon,labels,text,preview,peek,tooltip,overlay,temporary,quick,access,navigation,menu,items,submenu,nested;category=appearance;description=Expand sidebar on hover in desktop mode"`
+	KeyboardShortcutsEnabled   SettingVariable `key:"keyboardShortcutsEnabled,authrequired,local" meta:"label=Keyboard Shortcuts;type=boolean;keywords=keyboard,shortcuts,hotkeys,keybindings,navigation,tooltips,disable;category=appearance;description=Enable keyboard shortcuts for navigation and show shortcut hints in tooltips"`
 
 	// Notifications category (placeholder for category metadata only - actual settings managed via notification service)
 	NotificationsCategoryPlaceholder SettingVariable `key:"notificationsCategory,internal" meta:"label=Notifications;type=internal;keywords=notifications,alerts,email,discord,webhooks,events,messages;category=notifications;description=Configure notification providers and alerts" catmeta:"id=notifications;title=Notifications;icon=bell;url=/settings/notifications;description=Configure email and Discord notifications for container and image updates"`
@@ -203,13 +213,16 @@ func buildSettingsFieldCacheInternal() {
 			continue
 		}
 
+		attrList := splitSettingAttrsInternal(attrs)
+
 		meta := settingFieldMeta{
-			index:       i,
-			key:         key,
-			attrs:       attrs,
-			isPublic:    strings.Contains(attrs, "public"),
-			isSensitive: strings.Contains(attrs, "sensitive"),
-			isLocal:     strings.Contains(attrs, "local"),
+			index:               i,
+			key:                 key,
+			attrs:               attrs,
+			isPublic:            slices.Contains(attrList, "public"),
+			isVisibleToNonAdmin: slices.Contains(attrList, "public") || slices.Contains(attrList, "authrequired"),
+			isSensitive:         slices.Contains(attrList, "sensitive"),
+			isLocal:             slices.Contains(attrList, "local"),
 		}
 		ordered = append(ordered, meta)
 		byKey[key] = meta
@@ -224,6 +237,14 @@ func getSettingsFieldCacheInternal() ([]settingFieldMeta, map[string]settingFiel
 	return settingsFieldCache.ordered, settingsFieldCache.byKey
 }
 
+func splitSettingAttrsInternal(attrs string) []string {
+	if attrs == "" {
+		return nil
+	}
+
+	return strings.Split(attrs, ",")
+}
+
 func (s *Settings) Clone() *Settings {
 	if s == nil {
 		return &Settings{}
@@ -232,13 +253,13 @@ func (s *Settings) Clone() *Settings {
 	return new(*s)
 }
 
-func (s *Settings) ToSettingVariableSlice(showAll bool, redactSensitiveValues bool) []SettingVariable {
+func (s *Settings) ToSettingVariableSlice(visibility SettingVisibility, redactSensitiveValues bool) []SettingVariable {
 	cfgValue := reflect.ValueOf(s).Elem()
 	fields, _ := getSettingsFieldCacheInternal()
 
 	res := make([]SettingVariable, 0, len(fields))
 	for _, field := range fields {
-		if !showAll && !field.isPublic {
+		if !fieldVisibleForSettingVisibilityInternal(field, visibility) {
 			continue
 		}
 
@@ -253,6 +274,19 @@ func (s *Settings) ToSettingVariableSlice(showAll bool, redactSensitiveValues bo
 	}
 
 	return res
+}
+
+func fieldVisibleForSettingVisibilityInternal(field settingFieldMeta, visibility SettingVisibility) bool {
+	switch visibility {
+	case SettingVisibilityPublic:
+		return field.isPublic
+	case SettingVisibilityNonAdmin:
+		return field.isVisibleToNonAdmin
+	case SettingVisibilityAll:
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Settings) FieldByKey(key string) (defaultValue string, isPublic bool, isSensitive bool, err error) {

--- a/backend/internal/models/settings_test.go
+++ b/backend/internal/models/settings_test.go
@@ -42,3 +42,69 @@ func TestOidcConfig_MarshalDocument_PreservesOmitemptySemantics(t *testing.T) {
 	require.Equal(t, "https://issuer.example/jwks", doc["jwksUri"])
 	require.Equal(t, "admins", doc["adminValue"])
 }
+
+func TestSettings_ToSettingVariableSlice_Visibility(t *testing.T) {
+	settings := &Settings{
+		ApplicationTheme:           SettingVariable{Value: "default"},
+		AccentColor:                SettingVariable{Value: "oklch(0.6 0.2 240)"},
+		OledMode:                   SettingVariable{Value: "false"},
+		AuthLocalEnabled:           SettingVariable{Value: "true"},
+		OidcEnabled:                SettingVariable{Value: "true"},
+		OidcAutoRedirectToProvider: SettingVariable{Value: "false"},
+		OidcProviderName:           SettingVariable{Value: "Pocket ID"},
+		OidcProviderLogoUrl:        SettingVariable{Value: "https://id.ofkm.us/logo.png"},
+		DockerHost:                 SettingVariable{Value: "unix:///var/run/docker.sock"},
+		OidcClientId:               SettingVariable{Value: "client-id"},
+		OidcIssuerUrl:              SettingVariable{Value: "https://issuer.example"},
+		OidcScopes:                 SettingVariable{Value: "openid email profile"},
+		OidcAdminClaim:             SettingVariable{Value: "groups"},
+		OidcAdminValue:             SettingVariable{Value: "_arcane_admins"},
+		OidcSkipTlsVerify:          SettingVariable{Value: "false"},
+		OidcMergeAccounts:          SettingVariable{Value: "true"},
+		MobileNavigationMode:       SettingVariable{Value: "floating"},
+		MobileNavigationShowLabels: SettingVariable{Value: "true"},
+		SidebarHoverExpansion:      SettingVariable{Value: "true"},
+		KeyboardShortcutsEnabled:   SettingVariable{Value: "true"},
+		OidcClientSecret:           SettingVariable{Value: "secret"},
+	}
+
+	publicKeys := settingKeysFromSliceInternal(settings.ToSettingVariableSlice(SettingVisibilityPublic, true))
+	require.Contains(t, publicKeys, "applicationTheme")
+	require.Contains(t, publicKeys, "authLocalEnabled")
+	require.Contains(t, publicKeys, "oidcEnabled")
+	require.Contains(t, publicKeys, "oidcAutoRedirectToProvider")
+	require.Contains(t, publicKeys, "oidcProviderName")
+	require.Contains(t, publicKeys, "oidcProviderLogoUrl")
+	require.NotContains(t, publicKeys, "dockerHost")
+	require.NotContains(t, publicKeys, "oidcClientId")
+	require.NotContains(t, publicKeys, "mobileNavigationMode")
+
+	nonAdminKeys := settingKeysFromSliceInternal(settings.ToSettingVariableSlice(SettingVisibilityNonAdmin, true))
+	require.Contains(t, nonAdminKeys, "applicationTheme")
+	require.Contains(t, nonAdminKeys, "dockerHost")
+	require.Contains(t, nonAdminKeys, "oidcClientId")
+	require.Contains(t, nonAdminKeys, "oidcIssuerUrl")
+	require.Contains(t, nonAdminKeys, "oidcScopes")
+	require.Contains(t, nonAdminKeys, "oidcAdminClaim")
+	require.Contains(t, nonAdminKeys, "oidcAdminValue")
+	require.Contains(t, nonAdminKeys, "oidcSkipTlsVerify")
+	require.Contains(t, nonAdminKeys, "oidcMergeAccounts")
+	require.Contains(t, nonAdminKeys, "mobileNavigationMode")
+	require.Contains(t, nonAdminKeys, "keyboardShortcutsEnabled")
+	require.NotContains(t, nonAdminKeys, "enableGravatar")
+	require.NotContains(t, nonAdminKeys, "baseServerUrl")
+	require.NotContains(t, nonAdminKeys, "defaultShell")
+	require.NotContains(t, nonAdminKeys, "oidcClientSecret")
+
+	allKeys := settingKeysFromSliceInternal(settings.ToSettingVariableSlice(SettingVisibilityAll, true))
+	require.Contains(t, allKeys, "oidcClientSecret")
+}
+
+func settingKeysFromSliceInternal(settings []SettingVariable) map[string]string {
+	keys := make(map[string]string, len(settings))
+	for _, setting := range settings {
+		keys[setting.Key] = setting.Value
+	}
+
+	return keys
+}

--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -685,7 +685,7 @@ func (s *SettingsService) UpdateSettings(ctx context.Context, updates settings.U
 		s.OnTimeoutSettingsChanged(ctx, changedTimeouts)
 	}
 
-	return settings.ToSettingVariableSlice(false, false), nil
+	return settings.ToSettingVariableSlice(models.SettingVisibilityNonAdmin, false), nil
 }
 
 func (s *SettingsService) prepareUpdateValues(updates settings.Update, cfg, defaultCfg *models.Settings) ([]models.SettingVariable, bool, bool, bool, bool, bool, []libarcane.SettingUpdate, error) {
@@ -868,7 +868,7 @@ func (s *SettingsService) handleOidcConfigUpdate(ctx context.Context, updates se
 
 func (s *SettingsService) EnsureDefaultSettings(ctx context.Context) error {
 	defaultSettings := s.getDefaultSettings()
-	defaultSettingVars := defaultSettings.ToSettingVariableSlice(true, false)
+	defaultSettingVars := defaultSettings.ToSettingVariableSlice(models.SettingVisibilityAll, false)
 
 	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		for _, defaultSetting := range defaultSettingVars {
@@ -1016,8 +1016,8 @@ func (s *SettingsService) upsertEnvSetting(ctx context.Context, tx *gorm.DB, key
 	return nil
 }
 
-func (s *SettingsService) ListSettings(all bool) []models.SettingVariable {
-	return s.GetSettingsConfig().ToSettingVariableSlice(all, true)
+func (s *SettingsService) ListSettings(visibility models.SettingVisibility) []models.SettingVariable {
+	return s.GetSettingsConfig().ToSettingVariableSlice(visibility, true)
 }
 
 // GetSettingType returns the type from the setting metadata

--- a/backend/internal/services/settings_service_test.go
+++ b/backend/internal/services/settings_service_test.go
@@ -637,7 +637,7 @@ func TestSettingsService_UpdateSettings_RefreshesCache(t *testing.T) {
 	require.NoError(t, err)
 
 	// ListSettings uses the cached snapshot; should reflect updated value
-	list := svc.ListSettings(true)
+	list := svc.ListSettings(models.SettingVisibilityAll)
 	found := false
 	for _, sv := range list {
 		if sv.Key == "projectsDirectory" {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements "auth by default" by configuring global `humaConfig.Security` with BearerAuth and ApiKeyAuth, so any operation that doesn't explicitly override its `Security` field inherits the requirement. Public endpoints (health, login, OIDC flows, app images, public settings, environment pairing) correctly opt out with `Security: []map[string][]string{}`. Template read endpoints now intentionally require authentication by relying on global inheritance, confirmed by the new `TestSetupAPIForSpec_TemplateReadRoutesProtected` test. The settings model gains a new `SettingVisibilityNonAdmin` tier, surfacing only `public`- and `authrequired`-tagged fields to authenticated non-admin users.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — auth-by-default logic is correct and well-tested; only a naming convention P2 remains.

All remaining findings are P2 style suggestions (unexported function naming convention). The core security logic — global security inheritance, public endpoint opt-out, visibility tier filtering — is sound and covered by new tests.

backend/internal/huma/middleware/auth.go — naming convention; no functional issues.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/internal/huma/handlers/templates.go`, line 199-209 ([link](https://github.com/getarcaneapp/arcane/blob/31879204021403e17a4d3c02a13140b014d60440/backend/internal/huma/handlers/templates.go#L199-L209)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Redundant explicit security on template handlers**

   The four template read handlers (`listTemplates`, `getAllTemplates`, `getTemplate`, `getTemplateContent`) now carry an explicit `Security` block that is byte-for-byte identical to the global API security set in `huma.go`. Because any operation that omits `Security` already inherits the global default via `parseSecurityRequirements`, these blocks add noise without changing behaviour. Removing them would reduce boilerplate and make future global-security changes automatic for these routes.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/huma/handlers/templates.go
   Line: 199-209

   Comment:
   **Redundant explicit security on template handlers**

   The four template read handlers (`listTemplates`, `getAllTemplates`, `getTemplate`, `getTemplateContent`) now carry an explicit `Security` block that is byte-for-byte identical to the global API security set in `huma.go`. Because any operation that omits `Security` already inherits the global default via `parseSecurityRequirements`, these blocks add noise without changing behaviour. Removing them would reduce boilerplate and make future global-security changes automatic for these routes.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fauth-by-default%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fauth-by-default%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fhuma%2Fhandlers%2Ftemplates.go%0ALine%3A%20199-209%0A%0AComment%3A%0A**Redundant%20explicit%20security%20on%20template%20handlers**%0A%0AThe%20four%20template%20read%20handlers%20%28%60listTemplates%60%2C%20%60getAllTemplates%60%2C%20%60getTemplate%60%2C%20%60getTemplateContent%60%29%20now%20carry%20an%20explicit%20%60Security%60%20block%20that%20is%20byte-for-byte%20identical%20to%20the%20global%20API%20security%20set%20in%20%60huma.go%60.%20Because%20any%20operation%20that%20omits%20%60Security%60%20already%20inherits%20the%20global%20default%20via%20%60parseSecurityRequirements%60%2C%20these%20blocks%20add%20noise%20without%20changing%20behaviour.%20Removing%20them%20would%20reduce%20boilerplate%20and%20make%20future%20global-security%20changes%20automatic%20for%20these%20routes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fauth-by-default%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fauth-by-default%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fhuma%2Fmiddleware%2Fauth.go%3A64-95%0A**Unexported%20functions%20missing%20%22Internal%22%20suffix**%0A%0ASeveral%20unexported%20functions%20added%20in%20this%20file%20don't%20follow%20the%20project-wide%20convention%20requiring%20the%20%60Internal%60%20suffix%20on%20all%20unexported%20functions.%20%60parseSecurityRequirements%60%20%28the%20core%20of%20this%20PR's%20auth-by-default%20mechanism%29%20and%20the%20other%20helpers%20should%20all%20carry%20the%20suffix.%0A%0AFunctions%20affected%20in%20%60middleware%2Fauth.go%60%3A%20%60parseSecurityRequirements%60%2C%20%60tryBearerAuth%60%2C%20%60tryApiKeyAuth%60%2C%20%60tryAgentAuth%60%2C%20%60createAgentSudoUser%60%2C%20%60extractBearerToken%60%2C%20%60extractTokenFromCookieHeader%60%2C%20%60setUserInContext%60.%20The%20same%20pattern%20appears%20in%20the%20new%20unexported%20helpers%20added%20to%20%60handlers%2Fsettings.go%60%20%28%60validateProjectsDirectoryValue%60%2C%20%60validateAbsoluteDirectoryPath%60%2C%20%60hasAuthSettingsUpdate%60%29.%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/huma/middleware/auth.go
Line: 64-95

Comment:
**Unexported functions missing "Internal" suffix**

Several unexported functions added in this file don't follow the project-wide convention requiring the `Internal` suffix on all unexported functions. `parseSecurityRequirements` (the core of this PR's auth-by-default mechanism) and the other helpers should all carry the suffix.

Functions affected in `middleware/auth.go`: `parseSecurityRequirements`, `tryBearerAuth`, `tryApiKeyAuth`, `tryAgentAuth`, `createAgentSudoUser`, `extractBearerToken`, `extractTokenFromCookieHeader`, `setUserInContext`. The same pattern appears in the new unexported helpers added to `handlers/settings.go` (`validateProjectsDirectoryValue`, `validateAbsoluteDirectoryPath`, `hasAuthSettingsUpdate`).

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: set all api endpoints to use auth b..."](https://github.com/getarcaneapp/arcane/commit/3c1e7905fdc836221ff596a72a75a829841bc93d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28557622)</sub>

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->