### PR TITLE
fix: always show save button on template pages

### DIFF
--- a/frontend/src/routes/(app)/customize/templates/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/customize/templates/[id]/+page.svelte
@@ -211,15 +211,13 @@
 					<ArcaneButton action="cancel" onclick={handleReset} disabled={!hasChanges || saving}>
 						{m.common_reset()}
 					</ArcaneButton>
-					{#if composeValidationReady && envValidationReady && !composeHasErrors && !envHasErrors}
-						<ArcaneButton
-							action="save"
-							onclick={handleSave}
-							disabled={!canSave}
-							loading={saving}
-							loadingLabel={m.common_action_saving()}
-						/>
-					{/if}
+					<ArcaneButton
+						action="save"
+						onclick={handleSave}
+						disabled={!canSave}
+						loading={saving}
+						loadingLabel={m.common_action_saving()}
+					/>
 					<ArcaneButton
 						action="remove"
 						onclick={handleDelete}

--- a/frontend/src/routes/(app)/customize/templates/default/+page.svelte
+++ b/frontend/src/routes/(app)/customize/templates/default/+page.svelte
@@ -126,15 +126,13 @@
 				<ArcaneButton action="cancel" onclick={handleReset} disabled={!hasChanges || saving || isLoadingTemplate}>
 					{m.common_reset()}
 				</ArcaneButton>
-				{#if composeValidationReady && envValidationReady && !composeHasErrors && !envHasErrors}
-					<ArcaneButton
-						action="save"
-						onclick={handleSave}
-						disabled={!canSave || isLoadingTemplate}
-						loading={saving}
-						loadingLabel={m.common_action_saving()}
-					/>
-				{/if}
+				<ArcaneButton
+					action="save"
+					onclick={handleSave}
+					disabled={!canSave || isLoadingTemplate}
+					loading={saving}
+					loadingLabel={m.common_action_saving()}
+				/>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary

- The save button on `/customize/templates/default` and `/customize/templates/[id]` was hidden behind `{#if composeValidationReady && envValidationReady}` 
- After the switch from Monaco to CodeMirror, the linter only runs on content changes — so `validationReady` stays `false` on initial page load and the button never appears
- Removed the `{#if}` guard; button is always visible and disabled via `disabled={!canSave}` which already enforces `hasChanges`, `validationReady`, and `!hasErrors`

Fixes #2387

## Test plan
- [ ] Open `/customize/templates/default` — save button is visible but disabled until changes are made
- [ ] Open a custom template `/customize/templates/[id]` — same behaviour
- [ ] Make a change with a YAML error — button stays disabled
- [ ] Fix the error — button enables

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the save button being permanently invisible on template pages after the Monaco → CodeMirror migration, where the linter no longer runs on initial page load so `validationReady` stays `false`. The `{#if}` visibility guard is removed and the button is always rendered, relying on `disabled={!canSave}` which already encodes the same conditions (`hasChanges`, `validationReady`, no errors). The `handleSave` functions also retain their own defensive guards, so the save action remains safe.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is correct, minimal, and the save action remains properly guarded.

`canSave` already encodes all conditions that were in the removed `{#if}` guard, `handleSave` retains its own defensive checks, and the button stays inside the remote-template guard in `[id]/+page.svelte`. No logic regressions found.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: always show save button on template..."](https://github.com/getarcaneapp/arcane/commit/74c82f4784a5f9cff5f347abb9c167e240a032c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28856318)</sub>

<!-- /greptile_comment -->