### PR TITLE
fix: skip image update checks for services with build config

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -227,6 +227,9 @@ func resolveServiceImagePullMode(svc composetypes.ServiceConfig) imagePullMode {
 func buildProjectImagePullPlan(services composetypes.Services) map[string]imagePullMode {
 	plan := map[string]imagePullMode{}
 	for _, svc := range services {
+		if svc.Build != nil {
+			continue
+		}
 		img := strings.TrimSpace(svc.Image)
 		if img == "" {
 			continue
@@ -1401,6 +1404,9 @@ func (s *ProjectService) PullProjectImages(ctx context.Context, projectID string
 
 	images := map[string]struct{}{}
 	for _, svc := range compProj.Services {
+		if svc.Build != nil {
+			continue
+		}
 		img := strings.TrimSpace(svc.Image)
 		if img == "" {
 			continue


### PR DESCRIPTION
## Summary

- Services with a `build:` key in compose files (local Dockerfile) have no remote registry image to check — Arcane was still attempting registry lookups and failing
- Added `if svc.Build != nil { continue }` in both `buildProjectImagePullPlan()` and `PullProjectImages()` in `project_service.go`

Fixes #2373

## Test plan
- [ ] Create a project with a compose file that has a `build:` service alongside `image:` services
- [ ] Trigger image update polling — no registry error for the build service
- [ ] Pull project images — only `image:` services are pulled, build services are skipped
- [ ] Projects with only `image:` services continue to work as before

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `if svc.Build != nil { continue }` guards in `buildProjectImagePullPlan()` and `PullProjectImages()` so that services using a local `build:` directive are skipped during registry lookups and explicit image pulls. The fix is correct and minimal — the two changed paths are the right ones to guard, and the existing logic for `image:` / `pull_policy:` services is unaffected.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, correct guard applied consistently in both relevant code paths.

Both hunks are symmetric one-liner guards that prevent registry lookups for build-only services. The surrounding logic (image deduplication, pull-policy resolution, timeout handling) is untouched. The only finding is a P2 test-coverage gap for the new branch in TestBuildProjectImagePullPlan.

No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/internal/services/project_service.go`, line 450-478 ([link](https://github.com/getarcaneapp/arcane/blob/6be456058c94ba55a7a8aed71689e0fe33cb07fa/backend/internal/services/project_service.go#L450-L478)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing test case for build-only service**

   `TestBuildProjectImagePullPlan` doesn't include a service with `Build != nil`, so the new skip path introduced in this PR is not exercised. A quick addition would close the gap:

   ```go
   "build-only": {
       Name:  "build-only",
       Image: "myapp:latest",
       Build: &composetypes.BuildConfig{Context: "."},
   },
   ```

   and asserting that `"myapp:latest"` is absent from the returned plan.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/project_service.go
   Line: 450-478

   Comment:
   **Missing test case for build-only service**

   `TestBuildProjectImagePullPlan` doesn't include a service with `Build != nil`, so the new skip path introduced in this PR is not exercised. A quick addition would close the gap:

   ```go
   "build-only": {
       Name:  "build-only",
       Image: "myapp:latest",
       Build: &composetypes.BuildConfig{Context: "."},
   },
   ```

   and asserting that `"myapp:latest"` is absent from the returned plan.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fskip-image-update-for-build-services%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fskip-image-update-for-build-services%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fproject_service.go%0ALine%3A%20450-478%0A%0AComment%3A%0A**Missing%20test%20case%20for%20build-only%20service**%0A%0A%60TestBuildProjectImagePullPlan%60%20doesn't%20include%20a%20service%20with%20%60Build%20!%3D%20nil%60%2C%20so%20the%20new%20skip%20path%20introduced%20in%20this%20PR%20is%20not%20exercised.%20A%20quick%20addition%20would%20close%20the%20gap%3A%0A%0A%60%60%60go%0A%22build-only%22%3A%20%7B%0A%20%20%20%20Name%3A%20%20%22build-only%22%2C%0A%20%20%20%20Image%3A%20%22myapp%3Alatest%22%2C%0A%20%20%20%20Build%3A%20%26composetypes.BuildConfig%7BContext%3A%20%22.%22%7D%2C%0A%7D%2C%0A%60%60%60%0A%0Aand%20asserting%20that%20%60%22myapp%3Alatest%22%60%20is%20absent%20from%20the%20returned%20plan.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fskip-image-update-for-build-services%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fskip-image-update-for-build-services%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A450-478%0A**Missing%20test%20case%20for%20build-only%20service**%0A%0A%60TestBuildProjectImagePullPlan%60%20doesn't%20include%20a%20service%20with%20%60Build%20!%3D%20nil%60%2C%20so%20the%20new%20skip%20path%20introduced%20in%20this%20PR%20is%20not%20exercised.%20A%20quick%20addition%20would%20close%20the%20gap%3A%0A%0A%60%60%60go%0A%22build-only%22%3A%20%7B%0A%20%20%20%20Name%3A%20%20%22build-only%22%2C%0A%20%20%20%20Image%3A%20%22myapp%3Alatest%22%2C%0A%20%20%20%20Build%3A%20%26composetypes.BuildConfig%7BContext%3A%20%22.%22%7D%2C%0A%7D%2C%0A%60%60%60%0A%0Aand%20asserting%20that%20%60%22myapp%3Alatest%22%60%20is%20absent%20from%20the%20returned%20plan.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/project_service.go
Line: 450-478

Comment:
**Missing test case for build-only service**

`TestBuildProjectImagePullPlan` doesn't include a service with `Build != nil`, so the new skip path introduced in this PR is not exercised. A quick addition would close the gap:

```go
"build-only": {
    Name:  "build-only",
    Image: "myapp:latest",
    Build: &composetypes.BuildConfig{Context: "."},
},
```

and asserting that `"myapp:latest"` is absent from the returned plan.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: skip image update checks for servic..."](https://github.com/getarcaneapp/arcane/commit/6be456058c94ba55a7a8aed71689e0fe33cb07fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28856322)</sub>

<!-- /greptile_comment -->