### PR TITLE
fix(swarm): pre-create volumes with driver_opts before stack deploy

### DIFF
--- a/backend/pkg/libarcane/swarm/stack_deploy_engine.go
+++ b/backend/pkg/libarcane/swarm/stack_deploy_engine.go
@@ -110,6 +110,10 @@ func DeployStack(ctx context.Context, dockerClient *dockerclient.Client, opts St
 		return err
 	}
 
+	if err := ensureSwarmVolumes(ctx, dockerClient, project, stackName, stackLabels); err != nil {
+		return err
+	}
+
 	configMetaByKey, err := ensureSwarmConfigs(ctx, dockerClient, project, stackName, stackLabels)
 	if err != nil {
 		return err
@@ -393,6 +397,48 @@ func ensureSwarmConfigs(ctx context.Context, dockerClient *dockerclient.Client, 
 		result[key] = meta
 	}
 	return result, nil
+}
+
+// ensureSwarmVolumes pre-creates named volumes that carry a driver or
+// driver_opts so that Swarm services pick up the correct volume configuration.
+// Without this step Docker creates a plain local volume on first use and the
+// driver options are silently ignored — the root cause of issue #2376.
+func ensureSwarmVolumes(ctx context.Context, dockerClient *dockerclient.Client, project *composegotypes.Project, stackName string, stackLabels map[string]string) error {
+	for key, cfg := range project.Volumes {
+		// External volumes must already exist; nothing to create.
+		if cfg.External {
+			continue
+		}
+		// Only act when driver or driver_opts are explicitly set.
+		if cfg.Driver == "" && len(cfg.DriverOpts) == 0 {
+			continue
+		}
+
+		name := resolveResourceName(stackName, key, cfg.Name, cfg.External)
+
+		// If the volume already exists, leave it as-is to avoid disrupting
+		// running services that may be attached to it.
+		if _, err := dockerClient.VolumeInspect(ctx, name, dockerclient.VolumeInspectOptions{}); err == nil {
+			continue
+		} else if !cerrdefs.IsNotFound(err) {
+			return fmt.Errorf("failed to inspect volume %s: %w", name, err)
+		}
+
+		driver := cfg.Driver
+		if driver == "" {
+			driver = "local"
+		}
+		labels := mergeLabels(cfg.Labels, stackLabels)
+		if _, err := dockerClient.VolumeCreate(ctx, dockerclient.VolumeCreateOptions{
+			Name:       name,
+			Driver:     driver,
+			DriverOpts: cfg.DriverOpts,
+			Labels:     labels,
+		}); err != nil {
+			return fmt.Errorf("failed to create volume %s: %w", name, err)
+		}
+	}
+	return nil
 }
 
 func ensureSwarmSecrets(ctx context.Context, dockerClient *dockerclient.Client, project *composegotypes.Project, stackName string, stackLabels map[string]string) (map[string]resourceMeta, error) {

--- a/backend/pkg/libarcane/swarm/stack_deploy_engine.go
+++ b/backend/pkg/libarcane/swarm/stack_deploy_engine.go
@@ -110,7 +110,7 @@ func DeployStack(ctx context.Context, dockerClient *dockerclient.Client, opts St
 		return err
 	}
 
-	if err := ensureSwarmVolumes(ctx, dockerClient, project, stackName, stackLabels); err != nil {
+	if err := ensureSwarmVolumesInternal(ctx, dockerClient, project, stackName, stackLabels); err != nil {
 		return err
 	}
 
@@ -399,11 +399,11 @@ func ensureSwarmConfigs(ctx context.Context, dockerClient *dockerclient.Client, 
 	return result, nil
 }
 
-// ensureSwarmVolumes pre-creates named volumes that carry a driver or
+// ensureSwarmVolumesInternal pre-creates named volumes that carry a driver or
 // driver_opts so that Swarm services pick up the correct volume configuration.
 // Without this step Docker creates a plain local volume on first use and the
 // driver options are silently ignored — the root cause of issue #2376.
-func ensureSwarmVolumes(ctx context.Context, dockerClient *dockerclient.Client, project *composegotypes.Project, stackName string, stackLabels map[string]string) error {
+func ensureSwarmVolumesInternal(ctx context.Context, dockerClient *dockerclient.Client, project *composegotypes.Project, stackName string, stackLabels map[string]string) error {
 	for key, cfg := range project.Volumes {
 		// External volumes must already exist; nothing to create.
 		if cfg.External {


### PR DESCRIPTION
## Summary

- Docker Swarm ignores `driver` and `driver_opts` on named volumes during `docker stack deploy`
- Added `ensureSwarmVolumes()` that pre-creates volumes (with correct driver/opts) before the stack is deployed, mirroring the existing `ensureSwarmNetworks()` pattern
- Volumes that already exist or have no special driver config are skipped

Closes #2376

## Test plan

- [ ] Deploy a stack with a volume using `driver_opts` (e.g. NFS mount) — volume should be created with correct options
- [ ] Re-deploy the same stack — existing volume is left untouched
- [ ] Deploy a stack with only default local volumes — no change in behaviour

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `ensureSwarmVolumes()`, which pre-creates named volumes that carry a `driver` or `driver_opts` before `docker stack deploy` runs, mirroring the existing `ensureSwarmNetworks()` pattern. The implementation is logically sound: external volumes are skipped, volumes with no special driver config are skipped, already-existing volumes are left untouched, and errors are wrapped with context. The only finding is a minor naming-convention mismatch — the new function (and its existing siblings in the file) does not carry the required `Internal` suffix for unexported functions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the only finding is a P2 naming convention violation that is consistent with the rest of the file.

All remaining findings are P2 style suggestions. The core logic correctly mirrors ensureSwarmNetworks, handles the external/no-driver-config skip cases, and propagates errors cleanly.

No files require special attention.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fswarm-stack-volume-driver-opts%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fswarm-stack-volume-driver-opts%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fpkg%2Flibarcane%2Fswarm%2Fstack_deploy_engine.go%3A406%0A**Unexported%20function%20missing%20%60Internal%60%20suffix**%0A%0APer%20the%20repo's%20naming%20convention%2C%20all%20unexported%20functions%20should%20carry%20the%20%60Internal%60%20suffix%20to%20clearly%20distinguish%20them%20from%20public%20APIs.%20%60ensureSwarmVolumes%60%20is%20unexported%20but%20lacks%20it%20%E2%80%94%20same%20pattern%20applies%20to%20the%20sibling%20functions%20introduced%20in%20this%20file%20%28%60ensureSwarmNetworks%60%2C%20%60ensureSwarmConfigs%60%2C%20%60ensureSwarmSecrets%60%29.%0A%0A%60%60%60suggestion%0Afunc%20ensureSwarmVolumesInternal%28ctx%20context.Context%2C%20dockerClient%20*dockerclient.Client%2C%20project%20*composegotypes.Project%2C%20stackName%20string%2C%20stackLabels%20map%5Bstring%5Dstring%29%20error%20%7B%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/libarcane/swarm/stack_deploy_engine.go
Line: 406

Comment:
**Unexported function missing `Internal` suffix**

Per the repo's naming convention, all unexported functions should carry the `Internal` suffix to clearly distinguish them from public APIs. `ensureSwarmVolumes` is unexported but lacks it — same pattern applies to the sibling functions introduced in this file (`ensureSwarmNetworks`, `ensureSwarmConfigs`, `ensureSwarmSecrets`).

```suggestion
func ensureSwarmVolumesInternal(ctx context.Context, dockerClient *dockerclient.Client, project *composegotypes.Project, stackName string, stackLabels map[string]string) error {
```

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(swarm): pre-create volumes with dri..."](https://github.com/getarcaneapp/arcane/commit/39344b1e353a7f772d3d361624e20011c85518de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28896196)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->