### PR TITLE
fix(vuln): fall back to user cache dir when /tmp is not writable

### DIFF
--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -2273,15 +2273,15 @@ func createTrivyLogTempFileInternal(prefix string) (*os.File, error) {
 	// per-user cache directory so Trivy scans can still run.
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create trivy temp file (primary: %v) and user cache dir unavailable: %w", primaryErr, err)
+		return nil, fmt.Errorf("failed to create trivy temp file (primary: %s) and user cache dir unavailable: %w", primaryErr.Error(), err)
 	}
 	fallbackDir := filepath.Join(cacheDir, "arcane", "trivy-tmp")
 	if err := os.MkdirAll(fallbackDir, 0o700); err != nil {
-		return nil, fmt.Errorf("failed to create trivy fallback temp dir %s (primary: %v): %w", fallbackDir, primaryErr, err)
+		return nil, fmt.Errorf("failed to create trivy fallback temp dir %s (primary: %s): %w", fallbackDir, primaryErr.Error(), err)
 	}
 	fallbackFile, err := os.CreateTemp(fallbackDir, prefix)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create trivy temp file in fallback dir %s (primary: %v): %w", fallbackDir, primaryErr, err)
+		return nil, fmt.Errorf("failed to create trivy temp file in fallback dir %s (primary: %s): %w", fallbackDir, primaryErr.Error(), err)
 	}
 	return fallbackFile, nil
 }

--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -2263,11 +2264,21 @@ func addTrivyTempFileMounts(hostConfig *containertypes.HostConfig, tempFiles []s
 }
 
 func createTrivyLogTempFileInternal(prefix string) (*os.File, error) {
-	file, err := os.CreateTemp("", prefix)
-	if err != nil {
-		return nil, err
+	// Try the default system temp dir first.
+	if file, err := os.CreateTemp("", prefix); err == nil {
+		return file, nil
 	}
-	return file, nil
+	// /tmp is not writable (e.g. hardened container). Fall back to a
+	// per-user cache directory so Trivy scans can still run.
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create trivy temp file and user cache dir unavailable: %w", err)
+	}
+	fallbackDir := filepath.Join(cacheDir, "arcane", "trivy-tmp")
+	if err := os.MkdirAll(fallbackDir, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create trivy fallback temp dir %s: %w", fallbackDir, err)
+	}
+	return os.CreateTemp(fallbackDir, prefix)
 }
 
 func cleanupTrivyLogTempFilesInternal(ctx context.Context, files ...*os.File) {

--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -2265,20 +2265,25 @@ func addTrivyTempFileMounts(hostConfig *containertypes.HostConfig, tempFiles []s
 
 func createTrivyLogTempFileInternal(prefix string) (*os.File, error) {
 	// Try the default system temp dir first.
-	if file, err := os.CreateTemp("", prefix); err == nil {
+	file, primaryErr := os.CreateTemp("", prefix)
+	if primaryErr == nil {
 		return file, nil
 	}
 	// /tmp is not writable (e.g. hardened container). Fall back to a
 	// per-user cache directory so Trivy scans can still run.
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create trivy temp file and user cache dir unavailable: %w", err)
+		return nil, fmt.Errorf("failed to create trivy temp file (primary: %v) and user cache dir unavailable: %w", primaryErr, err)
 	}
 	fallbackDir := filepath.Join(cacheDir, "arcane", "trivy-tmp")
 	if err := os.MkdirAll(fallbackDir, 0o700); err != nil {
-		return nil, fmt.Errorf("failed to create trivy fallback temp dir %s: %w", fallbackDir, err)
+		return nil, fmt.Errorf("failed to create trivy fallback temp dir %s (primary: %v): %w", fallbackDir, primaryErr, err)
 	}
-	return os.CreateTemp(fallbackDir, prefix)
+	fallbackFile, err := os.CreateTemp(fallbackDir, prefix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create trivy temp file in fallback dir %s (primary: %v): %w", fallbackDir, primaryErr, err)
+	}
+	return fallbackFile, nil
 }
 
 func cleanupTrivyLogTempFilesInternal(ctx context.Context, files ...*os.File) {


### PR DESCRIPTION
## Summary

- Trivy scan failed with `permission denied` when creating temp files in `/tmp` inside hardened containers
- `createTrivyLogTempFileInternal` now falls back to `os.UserCacheDir()/arcane/trivy-tmp/` if the default `os.CreateTemp("", ...)` fails
- Directory is created on demand with `0700` permissions

Closes #2406

## Test plan

- [ ] Run vulnerability scan in a container where `/tmp` is mounted `noexec`/read-only — scan should complete without error
- [ ] Run vulnerability scan normally — should use `/tmp` as before (no regression)

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a fallback to `os.UserCacheDir()/arcane/trivy-tmp/` in `createTrivyLogTempFileInternal` when the default `os.CreateTemp("", …)` call fails, allowing Trivy scans to run in hardened containers where `/tmp` is read-only or `noexec`. The logic and directory-creation approach are sound; two minor error-handling improvements are called out inline.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the fix is correct and the remaining findings are minor style suggestions that don't affect runtime behaviour.

All findings are P2 (error context / wrapping style); the functional change is small, clearly scoped, and backward-compatible. No correctness, security, or data-integrity issues found.

No files require special attention.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Ftrivy-tmp-permission%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftrivy-tmp-permission%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Finternal%2Fservices%2Fvulnerability_service.go%3A2268-2270%0A**Original%20error%20silently%20discarded**%0A%0AThe%20error%20from%20the%20first%20%60os.CreateTemp%28%22%22%2C%20prefix%29%60%20call%20is%20thrown%20away.%20If%20the%20fallback%20path%20also%20fails%2C%20the%20final%20error%20message%20gives%20no%20hint%20as%20to%20why%20%60%2Ftmp%60%20was%20unusable%20in%20the%20first%20place%2C%20making%20diagnosis%20harder.%20Consider%20capturing%20and%20including%20it%20in%20downstream%20error%20messages.%0A%0A%60%60%60go%0Afile%2C%20primaryErr%20%3A%3D%20os.CreateTemp%28%22%22%2C%20prefix%29%0Aif%20primaryErr%20%3D%3D%20nil%20%7B%0A%20%20%20%20return%20file%2C%20nil%0A%7D%0A%2F%2F%20%2Ftmp%20is%20not%20writable%20%28e.g.%20hardened%20container%29.%20Fall%20back%20to%20a%0A%2F%2F%20per-user%20cache%20directory%20so%20Trivy%20scans%20can%20still%20run.%0A%60%60%60%0A%0AThen%20thread%20%60primaryErr%60%20into%20the%20error%20context%20if%20the%20fallback%20also%20fails%20%28e.g.%20%60fmt.Errorf%28%22...%20%28primary%20err%3A%20%25v%29%3A%20%25w%22%2C%20primaryErr%2C%20err%29%60%29.%0A%0A**Rule%20Used%3A**%20%23%20Go%20Development%20Patterns%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Finternal%2Fservices%2Fvulnerability_service.go%3A2281%0A**Fallback%20%60CreateTemp%60%20error%20not%20wrapped**%0A%0AThe%20raw%20OS%20error%20from%20the%20final%20%60os.CreateTemp%60%20is%20returned%20unwrapped%2C%20so%20callers%20see%20something%20like%20%60open%20%2Fhome%2Fuser%2F.cache%2Farcane%2Ftrivy-tmp%2F...%3A%20permission%20denied%60%20with%20no%20context%20about%20which%20code%20path%20produced%20it.%20Per%20the%20project's%20Go%20patterns%2C%20errors%20should%20carry%20context.%0A%0A%60%60%60suggestion%0A%09file%2C%20err%20%3A%3D%20os.CreateTemp%28fallbackDir%2C%20prefix%29%0A%09if%20err%20!%3D%20nil%20%7B%0A%09%09return%20nil%2C%20fmt.Errorf%28%22failed%20to%20create%20trivy%20temp%20file%20in%20fallback%20dir%20%25s%3A%20%25w%22%2C%20fallbackDir%2C%20err%29%0A%09%7D%0A%09return%20file%2C%20nil%0A%60%60%60%0A%0A**Rule%20Used%3A**%20%23%20Go%20Development%20Patterns%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/services/vulnerability_service.go
Line: 2268-2270

Comment:
**Original error silently discarded**

The error from the first `os.CreateTemp("", prefix)` call is thrown away. If the fallback path also fails, the final error message gives no hint as to why `/tmp` was unusable in the first place, making diagnosis harder. Consider capturing and including it in downstream error messages.

```go
file, primaryErr := os.CreateTemp("", prefix)
if primaryErr == nil {
    return file, nil
}
// /tmp is not writable (e.g. hardened container). Fall back to a
// per-user cache directory so Trivy scans can still run.
```

Then thread `primaryErr` into the error context if the fallback also fails (e.g. `fmt.Errorf("... (primary err: %v): %w", primaryErr, err)`).

**Rule Used:** # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/services/vulnerability_service.go
Line: 2281

Comment:
**Fallback `CreateTemp` error not wrapped**

The raw OS error from the final `os.CreateTemp` is returned unwrapped, so callers see something like `open /home/user/.cache/arcane/trivy-tmp/...: permission denied` with no context about which code path produced it. Per the project's Go patterns, errors should carry context.

```suggestion
	file, err := os.CreateTemp(fallbackDir, prefix)
	if err != nil {
		return nil, fmt.Errorf("failed to create trivy temp file in fallback dir %s: %w", fallbackDir, err)
	}
	return file, nil
```

**Rule Used:** # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: trivy scan falls back to user cache..."](https://github.com/getarcaneapp/arcane/commit/31038999568fbae1e533d8722234de21e135dc2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28896198)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

<!-- /greptile_comment -->