### PR TITLE
fix: incorrect conversion of linux runtime identity types

### DIFF
--- a/backend/pkg/libarcane/startup/runtime_identity.go
+++ b/backend/pkg/libarcane/startup/runtime_identity.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	pkgutils "github.com/getarcaneapp/arcane/backend/pkg/utils"
@@ -21,9 +20,11 @@ const (
 )
 
 type runtimeIdentityRequest struct {
-	Enabled bool
-	UID     uint32
-	GID     uint32
+	Enabled       bool
+	UID           int
+	GID           int
+	CredentialUID uint32
+	CredentialGID uint32
 }
 
 // ApplyRequestedRuntimeIdentity switches the current process to the configured
@@ -37,8 +38,8 @@ func ApplyRequestedRuntimeIdentity(ctx context.Context) error {
 		return err
 	}
 
-	runtimeUID := int(req.UID)
-	runtimeGID := int(req.GID)
+	runtimeUID := req.UID
+	runtimeGID := req.GID
 
 	// Avoid re-execing forever when the requested runtime identity is already active,
 	// including explicit root requests such as PUID=0/PGID=0.
@@ -57,7 +58,7 @@ func ApplyRequestedRuntimeIdentity(ctx context.Context) error {
 		return fmt.Errorf("load mountpoints: %w", err)
 	}
 
-	if err := prepareWritablePathsInternal(req, mountpoints); err != nil {
+	if err := prepareWritablePathsInternal(runtimeUID, runtimeGID, mountpoints); err != nil {
 		return err
 	}
 
@@ -76,30 +77,23 @@ func loadRuntimeIdentityRequestInternal(getenv func(string) string) (runtimeIden
 		return runtimeIdentityRequest{}, "PUID and PGID must both be set to enable non-root mode; continuing with default runtime user", nil
 	}
 
-	uid, err := parseRuntimeIdentityValueInternal(puid, "PUID")
+	uid, credentialUID, err := parseRuntimeIdentityValueInternal(puid, "PUID")
 	if err != nil {
 		return runtimeIdentityRequest{}, "", fmt.Errorf("invalid PUID %q: %w", puid, err)
 	}
 
-	gid, err := parseRuntimeIdentityValueInternal(pgid, "PGID")
+	gid, credentialGID, err := parseRuntimeIdentityValueInternal(pgid, "PGID")
 	if err != nil {
 		return runtimeIdentityRequest{}, "", fmt.Errorf("invalid PGID %q: %w", pgid, err)
 	}
 
 	return runtimeIdentityRequest{
-		Enabled: true,
-		UID:     uid,
-		GID:     gid,
+		Enabled:       true,
+		UID:           uid,
+		GID:           gid,
+		CredentialUID: credentialUID,
+		CredentialGID: credentialGID,
 	}, "", nil
-}
-
-func parseRuntimeIdentityValueInternal(raw string, key string) (uint32, error) {
-	value, err := strconv.ParseUint(raw, 10, 32)
-	if err != nil {
-		return 0, fmt.Errorf("parse %s: %w", key, err)
-	}
-
-	return uint32(value), nil
 }
 
 func runtimeIdentitySupplementaryGroupsInternal(getenv func(string) string, resolveSocketGroup func(string) (uint32, bool)) []uint32 {
@@ -147,10 +141,7 @@ func dockerSocketPathInternal(raw string) (string, bool) {
 	return filepath.Clean(socketPath), true
 }
 
-func prepareWritablePathsInternal(req runtimeIdentityRequest, mountpoints map[string]struct{}) error {
-	uid := int(req.UID)
-	gid := int(req.GID)
-
+func prepareWritablePathsInternal(uid int, gid int, mountpoints map[string]struct{}) error {
 	if err := os.MkdirAll(defaultDataDirectory, pkgutils.DirPerm); err != nil {
 		return fmt.Errorf("create data directory: %w", err)
 	}

--- a/backend/pkg/libarcane/startup/runtime_identity_int_32bit.go
+++ b/backend/pkg/libarcane/startup/runtime_identity_int_32bit.go
@@ -1,0 +1,21 @@
+//go:build 386 || arm || mips || mipsle || wasm
+
+package startup
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func parseRuntimeIdentityValueInternal(raw string, key string) (int, uint32, error) {
+	value, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse %s: %w", key, err)
+	}
+
+	if value < 0 {
+		return 0, 0, fmt.Errorf("%s must be >= 0", key)
+	}
+
+	return int(value), uint32(value), nil
+}

--- a/backend/pkg/libarcane/startup/runtime_identity_int_64bit.go
+++ b/backend/pkg/libarcane/startup/runtime_identity_int_64bit.go
@@ -1,0 +1,26 @@
+//go:build amd64 || arm64 || loong64 || mips64 || mips64le || ppc64 || ppc64le || riscv64 || s390x
+
+package startup
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+)
+
+func parseRuntimeIdentityValueInternal(raw string, key string) (int, uint32, error) {
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse %s: %w", key, err)
+	}
+
+	if value < 0 {
+		return 0, 0, fmt.Errorf("%s must be >= 0", key)
+	}
+
+	if value > math.MaxUint32 {
+		return 0, 0, fmt.Errorf("%s value %d exceeds max uint32", key, value)
+	}
+
+	return value, uint32(value), nil
+}

--- a/backend/pkg/libarcane/startup/runtime_identity_linux.go
+++ b/backend/pkg/libarcane/startup/runtime_identity_linux.go
@@ -27,8 +27,8 @@ func reexecWithRuntimeIdentityInternal(ctx context.Context, req runtimeIdentityR
 	cmd.Stderr = os.Stderr
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Credential: &syscall.Credential{
-			Uid:    req.UID,
-			Gid:    req.GID,
+			Uid:    req.CredentialUID,
+			Gid:    req.CredentialGID,
 			Groups: groups,
 		},
 	}

--- a/backend/pkg/libarcane/startup/runtime_identity_test.go
+++ b/backend/pkg/libarcane/startup/runtime_identity_test.go
@@ -67,8 +67,21 @@ func TestLoadRuntimeIdentityRequest(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, warning)
 		require.True(t, req.Enabled)
-		require.Equal(t, uint32(1001), req.UID)
-		require.Equal(t, uint32(2001), req.GID)
+		require.Equal(t, 1001, req.UID)
+		require.Equal(t, 2001, req.GID)
+		require.Equal(t, uint32(1001), req.CredentialUID)
+		require.Equal(t, uint32(2001), req.CredentialGID)
+	})
+
+	t.Run("error when value is negative", func(t *testing.T) {
+		_, _, err := loadRuntimeIdentityRequestInternal(func(key string) string {
+			if key == "PUID" {
+				return "-1"
+			}
+			return "1001"
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid PUID")
 	})
 }
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent integer overflow bug in the Linux runtime identity feature: the old code parsed UID/GID as `uint32` then cast to `int`, which on 32-bit systems would silently yield a negative value for any UID/GID > `MaxInt32` (e.g. PUID=2147483648 → -2147483648), causing incorrect `chown`/re-exec behaviour. The fix splits parsing into architecture-specific files that produce both a native `int` (for `os.Chown` & `os.Getuid` comparisons) and a `uint32` for the `syscall.Credential`, with explicit range validation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix correctly eliminates a silent integer overflow and all standard Go architectures are covered by the build-tag pair.

No P0 or P1 issues found. Both new architecture-specific files cover all known Go target architectures, the range checks are correct, the separation of the native int field from the credential uint32 field is clean, and the new negative-value test closes a coverage gap.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: incorrect conversion of linux runti..."](https://github.com/getarcaneapp/arcane/commit/a2c3c41c320593aa3a4d05b53d05e0bdb3f4efef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28933791)</sub>

<!-- /greptile_comment -->