### PR TITLE
fix(swarm): scope named volume sources to stack in service mounts

### DIFF
--- a/backend/pkg/libarcane/swarm/stack_deploy_engine.go
+++ b/backend/pkg/libarcane/swarm/stack_deploy_engine.go
@@ -878,7 +878,7 @@ func convertServiceMounts(volumes []composegotypes.ServiceVolumeConfig, stackNam
 		// Without this, Docker creates a plain local volume and silently
 		// ignores driver/driver_opts — the root cause of issue #2376.
 		if mountType == mount.TypeVolume && source != "" {
-			if volCfg, ok := projectVolumes[source]; ok && !bool(volCfg.External) {
+			if volCfg, ok := projectVolumes[source]; ok && !bool(volCfg.External) && (volCfg.Driver != "" || len(volCfg.DriverOpts) > 0) {
 				source = resolveResourceName(stackName, source, volCfg.Name, volCfg.External)
 			}
 		}

--- a/backend/pkg/libarcane/swarm/stack_deploy_engine.go
+++ b/backend/pkg/libarcane/swarm/stack_deploy_engine.go
@@ -873,10 +873,10 @@ func convertServiceMounts(volumes []composegotypes.ServiceVolumeConfig, stackNam
 	for _, vol := range volumes {
 		mountType := mapVolumeType(vol.Type)
 		source := vol.Source
-		// Named volumes must use the stack-scoped name so that services
-		// reference the volume pre-created by ensureSwarmVolumesInternal.
-		// Without this, Docker creates a plain local volume and silently
-		// ignores driver/driver_opts — the root cause of issue #2376.
+		// Driver-configured named volumes must use the stack-scoped name so
+		// services reference the volume pre-created by ensureSwarmVolumesInternal.
+		// Without this, Docker creates a plain local volume and silently ignores
+		// driver/driver_opts — the root cause of issue #2376.
 		if mountType == mount.TypeVolume && source != "" {
 			if volCfg, ok := projectVolumes[source]; ok && !bool(volCfg.External) && (volCfg.Driver != "" || len(volCfg.DriverOpts) > 0) {
 				source = resolveResourceName(stackName, source, volCfg.Name, volCfg.External)

--- a/backend/pkg/libarcane/swarm/stack_deploy_engine.go
+++ b/backend/pkg/libarcane/swarm/stack_deploy_engine.go
@@ -185,7 +185,7 @@ func reconcileStackServices(
 		if service.Name == "" {
 			service.Name = key
 		}
-		spec, err := buildServiceSpec(service, stackName, stackLabels, networkNameByKey, configMetaByKey, secretMetaByKey)
+		spec, err := buildServiceSpec(service, stackName, stackLabels, networkNameByKey, configMetaByKey, secretMetaByKey, project.Volumes)
 		if err != nil {
 			return nil, err
 		}
@@ -572,6 +572,7 @@ func buildServiceSpec(
 	networkNameByKey map[string]string,
 	configMetaByKey map[string]resourceMeta,
 	secretMetaByKey map[string]resourceMeta,
+	projectVolumes composegotypes.Volumes,
 ) (swarm.ServiceSpec, error) {
 	serviceName := stackScopedName(stackName, service.Name)
 	serviceLabels := mergeLabels(nil, stackLabels)
@@ -604,7 +605,7 @@ func buildServiceSpec(
 				TTY:             service.Tty,
 				OpenStdin:       service.StdinOpen,
 				Labels:          mergeLabels(service.Labels, stackLabels),
-				Mounts:          convertServiceMounts(service.Volumes),
+				Mounts:          convertServiceMounts(service.Volumes, stackName, projectVolumes),
 				Secrets:         convertServiceSecretRefs(service.Secrets, secretMetaByKey),
 				Configs:         convertServiceConfigRefs(service.Configs, configMetaByKey),
 			},
@@ -864,16 +865,26 @@ func buildServiceNetworks(service composegotypes.ServiceConfig, networkNameByKey
 	return attachments
 }
 
-func convertServiceMounts(volumes []composegotypes.ServiceVolumeConfig) []mount.Mount {
+func convertServiceMounts(volumes []composegotypes.ServiceVolumeConfig, stackName string, projectVolumes composegotypes.Volumes) []mount.Mount {
 	if len(volumes) == 0 {
 		return nil
 	}
 	result := make([]mount.Mount, 0, len(volumes))
 	for _, vol := range volumes {
 		mountType := mapVolumeType(vol.Type)
+		source := vol.Source
+		// Named volumes must use the stack-scoped name so that services
+		// reference the volume pre-created by ensureSwarmVolumesInternal.
+		// Without this, Docker creates a plain local volume and silently
+		// ignores driver/driver_opts — the root cause of issue #2376.
+		if mountType == mount.TypeVolume && source != "" {
+			if volCfg, ok := projectVolumes[source]; ok && !bool(volCfg.External) {
+				source = resolveResourceName(stackName, source, volCfg.Name, volCfg.External)
+			}
+		}
 		entry := mount.Mount{
 			Type:        mountType,
-			Source:      vol.Source,
+			Source:      source,
 			Target:      vol.Target,
 			ReadOnly:    vol.ReadOnly,
 			Consistency: mount.Consistency(vol.Consistency),

--- a/backend/pkg/libarcane/swarm/stack_deploy_engine_test.go
+++ b/backend/pkg/libarcane/swarm/stack_deploy_engine_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	composegotypes "github.com/compose-spec/compose-go/v2/types"
+	"github.com/moby/moby/api/types/mount"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,4 +23,29 @@ func TestResolvePathWithinWorkingDirInternal_RejectsEscapingPaths(t *testing.T) 
 	_, err := resolvePathWithinWorkingDirInternal(workingDir, filepath.Join("..", "..", "etc", "shadow"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "escapes the working directory")
+}
+
+func TestConvertServiceMountsScopesOnlyConfiguredNamedVolumes(t *testing.T) {
+	mounts := convertServiceMounts(
+		[]composegotypes.ServiceVolumeConfig{
+			{Type: "volume", Source: "plain", Target: "/plain"},
+			{Type: "volume", Source: "driver", Target: "/driver"},
+			{Type: "volume", Source: "opts", Target: "/opts"},
+			{Type: "volume", Source: "external", Target: "/external"},
+		},
+		"stack",
+		composegotypes.Volumes{
+			"plain":    {},
+			"driver":   {Driver: "local"},
+			"opts":     {Name: "custom", DriverOpts: map[string]string{"type": "nfs"}},
+			"external": {External: true},
+		},
+	)
+
+	require.Len(t, mounts, 4)
+	require.Equal(t, mount.TypeVolume, mounts[0].Type)
+	require.Equal(t, "plain", mounts[0].Source)
+	require.Equal(t, "stack_driver", mounts[1].Source)
+	require.Equal(t, "stack_custom", mounts[2].Source)
+	require.Equal(t, "external", mounts[3].Source)
 }


### PR DESCRIPTION
## Summary

- `ensureSwarmVolumesInternal` pre-creates volumes with the stack-scoped name (e.g. `actualbudget_actualbudget`) and the correct driver/driver_opts
- But `convertServiceMounts` was setting `Source` from the raw compose key (`actualbudget`), so Docker created a **second** plain local volume with that bare name — silently ignoring the pre-created one and its NFS options
- Fix: for named non-external volumes, resolve the mount `Source` with the same `resolveResourceName` logic so the service references the pre-created stack-scoped volume

Fixes #2376

## Root cause

When `docker stack deploy` is used natively, Docker internally scopes volume references in service mounts to the stack name. Arcane's custom deploy engine pre-creates the volume correctly as `<stack>_<volume>` but left the service mount source as the bare compose key. Docker then created a fresh plain local volume on first use, bypassing all driver options.

## Test plan
- [ ] Deploy a stack with a named volume using NFS `driver_opts`
- [ ] Inspect the volume on the swarm node — `Options` should contain the NFS parameters
- [ ] Confirm services can read/write the NFS share
- [ ] Confirm volumes without `driver`/`driver_opts` are unaffected
- [ ] Confirm `external: true` volumes are still referenced by their original name

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes issue #2376 by passing `project.Volumes` into `convertServiceMounts` so that named volume sources are resolved with `resolveResourceName`, matching the stack-scoped name pre-created by `ensureSwarmVolumesInternal`.

- The fix correctly addresses the NFS `driver_opts` case: the service mount source now matches the pre-created `<stack>_<volume>` name instead of the bare compose key.
- However, the scoping condition applies to **all** named non-external volumes, not only those with `driver`/`driver_opts`. For existing deployments with plain volumes, the mount source changes from `volumeKey` to `stackName_volumeKey`, causing Docker to create a new empty volume and silently ignoring the data in the old bare-named volume. The test-plan item \"Confirm volumes without `driver`/`driver_opts` are unaffected\" is at odds with this behavior.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The fix is correct for new deployments, but has a silent data-loss risk for existing stacks with plain named volumes — the scoping is broader than intended per the test plan.

There is one P1 finding: the scoping in convertServiceMounts applies to all non-external named volumes, not just those with driver/driver_opts. For existing deployments with plain volumes, this changes the referenced volume name on re-deploy, causing Docker to create a fresh empty volume while the original data remains inaccessible in the old bare-named volume. This deserves clarification and/or a migration note before merging.

backend/pkg/libarcane/swarm/stack_deploy_engine.go — specifically the convertServiceMounts scoping guard (lines 880-883).
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fswarm-volume-mount-scoping%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fswarm-volume-mount-scoping%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fpkg%2Flibarcane%2Fswarm%2Fstack_deploy_engine.go%3A880-883%0A**Scoping%20applies%20to%20all%20named%20volumes%2C%20not%20just%20those%20with%20driver%2Fdriver_opts**%0A%0AThe%20condition%20scopes%20every%20named%20non-external%20volume%2C%20but%20%60ensureSwarmVolumesInternal%60%20only%20pre-creates%20volumes%20that%20have%20a%20%60driver%60%20or%20%60driver_opts%60.%20For%20plain%20volumes%20%28no%20special%20driver%20settings%29%2C%20Docker%20will%20lazily%20create%20%60stackName_volumeKey%60%20on%20the%20first%20container%20start%20%E2%80%94%20which%20is%20fine%20for%20fresh%20deployments.%0A%0AThe%20problem%20is%20**existing%20deployments**%3A%20any%20plain%20named%20volume%20was%20previously%20mounted%20as%20the%20bare%20key%20%28e.g.%20%60mydata%60%29.%20After%20this%20fix%20the%20service%20suddenly%20references%20%60stackname_mydata%60%2C%20Docker%20creates%20a%20new%20empty%20volume%20under%20that%20name%2C%20and%20the%20service%20sees%20no%20prior%20data.%20The%20test-plan%20item%20%22Confirm%20volumes%20without%20%60driver%60%2F%60driver_opts%60%20are%20unaffected%22%20is%20directly%20at%20odds%20with%20this%20code%20path.%0A%0AIf%20plain%20volumes%20should%20also%20be%20scoped%20%28matching%20native%20%60docker%20stack%20deploy%60%20semantics%29%2C%20that%20is%20correct%20but%20should%20be%20called%20out%20as%20a%20**breaking%20change%20for%20existing%20stacks**%20and%20migration%20guidance%20should%20be%20provided.%20If%20only%20driver-configured%20volumes%20need%20scoping%20to%20address%20%232376%2C%20the%20guard%20should%20mirror%20%60ensureSwarmVolumesInternal%60%3A%0A%0A%60%60%60go%0Aif%20mountType%20%3D%3D%20mount.TypeVolume%20%26%26%20source%20!%3D%20%22%22%20%7B%0A%20%20%20%20if%20volCfg%2C%20ok%20%3A%3D%20projectVolumes%5Bsource%5D%3B%20ok%20%26%26%20!volCfg.External%20%26%26%20%28volCfg.Driver%20!%3D%20%22%22%20%7C%7C%20len%28volCfg.DriverOpts%29%20%3E%200%29%20%7B%0A%20%20%20%20%20%20%20%20source%20%3D%20resolveResourceName%28stackName%2C%20source%2C%20volCfg.Name%2C%20volCfg.External%29%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/libarcane/swarm/stack_deploy_engine.go
Line: 880-883

Comment:
**Scoping applies to all named volumes, not just those with driver/driver_opts**

The condition scopes every named non-external volume, but `ensureSwarmVolumesInternal` only pre-creates volumes that have a `driver` or `driver_opts`. For plain volumes (no special driver settings), Docker will lazily create `stackName_volumeKey` on the first container start — which is fine for fresh deployments.

The problem is **existing deployments**: any plain named volume was previously mounted as the bare key (e.g. `mydata`). After this fix the service suddenly references `stackname_mydata`, Docker creates a new empty volume under that name, and the service sees no prior data. The test-plan item "Confirm volumes without `driver`/`driver_opts` are unaffected" is directly at odds with this code path.

If plain volumes should also be scoped (matching native `docker stack deploy` semantics), that is correct but should be called out as a **breaking change for existing stacks** and migration guidance should be provided. If only driver-configured volumes need scoping to address #2376, the guard should mirror `ensureSwarmVolumesInternal`:

```go
if mountType == mount.TypeVolume && source != "" {
    if volCfg, ok := projectVolumes[source]; ok && !volCfg.External && (volCfg.Driver != "" || len(volCfg.DriverOpts) > 0) {
        source = resolveResourceName(stackName, source, volCfg.Name, volCfg.External)
    }
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(swarm): scope named volume sources t..."](https://github.com/getarcaneapp/arcane/commit/3ba88008ae54d2d781322522ee22c0119565a5e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29568199)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->