### PR TITLE
refactor: consolidate helpers and dedupe boilerplate code

### DIFF
--- a/backend/internal/api/ws_handler.go
+++ b/backend/internal/api/ws_handler.go
@@ -374,6 +374,92 @@ func NewWebSocketHandler(
 }
 
 // ============================================================================
+// Shared Log Stream Helpers
+// ============================================================================
+
+// logStreamParams holds the standard query parameters shared by every WS log endpoint.
+type logStreamParams struct {
+	follow     bool
+	tail       string
+	since      string
+	timestamps bool
+	format     string
+	batched    bool
+}
+
+func parseLogStreamParamsInternal(c *gin.Context) logStreamParams {
+	tail, _ := httputil.GetQueryParam(c, "tail", false)
+	if tail == "" {
+		tail = "100"
+	}
+	since, _ := httputil.GetQueryParam(c, "since", false)
+	format, _ := httputil.GetQueryParam(c, "format", false)
+	if format == "" {
+		format = "text"
+	}
+	return logStreamParams{
+		follow:     c.DefaultQuery("follow", "true") == "true",
+		tail:       tail,
+		since:      since,
+		timestamps: c.DefaultQuery("timestamps", "false") == "true",
+		format:     format,
+		batched:    c.DefaultQuery("batched", "false") == "true",
+	}
+}
+
+// serveLogStreamInternal is the shared scaffold for all three WS log endpoints (project, container, service).
+// It performs upgrade, builds the stream key, gets-or-creates the multiplexing hub, registers metrics,
+// and serves the client. The caller-supplied hubBuilder constructs the underlying *wsLogStream
+// when no hub already exists for streamKey.
+func (h *WebSocketHandler) serveLogStreamInternal(
+	c *gin.Context,
+	kind, resourceID string,
+	params logStreamParams,
+	hubBuilder func(streamKey string, onEmpty func(*wsLogStream)) *wsLogStream,
+) {
+	conn, err := h.wsUpgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		return
+	}
+
+	streamKey := buildLogStreamKeyInternal(c.Param("id"), kind, resourceID, params.format, params.batched, params.follow, params.tail, params.since, params.timestamps)
+	stream := h.getOrCreateLogStreamInternal(streamKey, func(onEmpty func(*wsLogStream)) *wsLogStream {
+		return hubBuilder(streamKey, onEmpty)
+	})
+	connID := h.wsMetrics.RegisterConnection(buildWSConnectionInfoInternal(c, kind, resourceID))
+	// WebSocket connections use context.Background() because they are long-lived and should not
+	// be tied to the HTTP request context. Cleanup is handled via the hub's OnEmpty callback
+	// which triggers when all clients disconnect.
+	ws.ServeClientWithOnRemove(context.Background(), stream.hub, conn, func() {
+		h.wsMetrics.UnregisterConnection(connID)
+		h.releaseLogStreamInternal(streamKey, stream)
+	})
+}
+
+// broadcastLogStreamErrorInternal emits an error message to every client of a log stream.
+// resourceLabel is the human-readable noun used in slog/error text (e.g. "project log stream").
+// errorPrefix is the user-facing message prefix (e.g. "Failed to stream project logs: ").
+func broadcastLogStreamErrorInternal(resourceLabel, errorPrefix string, resourceID string, format string, err error, ls *wsLogStream) {
+	slog.Warn(resourceLabel+" failed", "resourceID", resourceID, "error", err)
+
+	if format == "json" {
+		msg := ws.LogMessage{
+			Seq:       ls.seq.Add(1),
+			Level:     "error",
+			Message:   errorPrefix + err.Error(),
+			Service:   "arcane",
+			Timestamp: ws.NowRFC3339(),
+		}
+		if b, marshalErr := json.Marshal(msg); marshalErr == nil {
+			ls.hub.Broadcast(b)
+		}
+		return
+	}
+
+	ls.hub.Broadcast([]byte(errorPrefix + err.Error()))
+}
+
+// ============================================================================
 // Project WebSocket/Streaming Endpoints
 // ============================================================================
 
@@ -398,35 +484,9 @@ func (h *WebSocketHandler) ProjectLogs(c *gin.Context) {
 		return
 	}
 
-	follow := c.DefaultQuery("follow", "true") == "true"
-	tail, _ := httputil.GetQueryParam(c, "tail", false)
-	if tail == "" {
-		tail = "100"
-	}
-	since, _ := httputil.GetQueryParam(c, "since", false)
-	timestamps := c.DefaultQuery("timestamps", "false") == "true"
-	format, _ := httputil.GetQueryParam(c, "format", false)
-	if format == "" {
-		format = "text"
-	}
-	batched := c.DefaultQuery("batched", "false") == "true"
-
-	conn, err := h.wsUpgrader.Upgrade(c.Writer, c.Request, nil)
-	if err != nil {
-		return
-	}
-
-	streamKey := buildLogStreamKeyInternal(c.Param("id"), systemtypes.WSKindProjectLogs, projectID, format, batched, follow, tail, since, timestamps)
-	stream := h.getOrCreateLogStreamInternal(streamKey, func(onEmpty func(*wsLogStream)) *wsLogStream {
-		return h.startProjectLogHub(streamKey, projectID, format, batched, follow, tail, since, timestamps, onEmpty)
-	})
-	connID := h.wsMetrics.RegisterConnection(buildWSConnectionInfoInternal(c, systemtypes.WSKindProjectLogs, projectID))
-	// WebSocket connections use context.Background() because they are long-lived and should not
-	// be tied to the HTTP request context. Cleanup is handled via the hub's OnEmpty callback
-	// which triggers when all clients disconnect.
-	ws.ServeClientWithOnRemove(context.Background(), stream.hub, conn, func() {
-		h.wsMetrics.UnregisterConnection(connID)
-		h.releaseLogStreamInternal(streamKey, stream)
+	params := parseLogStreamParamsInternal(c)
+	h.serveLogStreamInternal(c, systemtypes.WSKindProjectLogs, projectID, params, func(streamKey string, onEmpty func(*wsLogStream)) *wsLogStream {
+		return h.startProjectLogHub(streamKey, projectID, params.format, params.batched, params.follow, params.tail, params.since, params.timestamps, onEmpty)
 	})
 }
 
@@ -488,23 +548,7 @@ func waitForLogStreamSubscriberInternal(ctx context.Context, firstSubscriber <-c
 }
 
 func (h *WebSocketHandler) broadcastProjectLogStreamErrorInternal(projectID, format string, err error, ls *wsLogStream) {
-	slog.Warn("project log stream failed", "projectID", projectID, "error", err)
-
-	if format == "json" {
-		msg := ws.LogMessage{
-			Seq:       ls.seq.Add(1),
-			Level:     "error",
-			Message:   "Failed to stream project logs: " + err.Error(),
-			Service:   "arcane",
-			Timestamp: ws.NowRFC3339(),
-		}
-		if b, marshalErr := json.Marshal(msg); marshalErr == nil {
-			ls.hub.Broadcast(b)
-		}
-		return
-	}
-
-	ls.hub.Broadcast([]byte("Failed to stream project logs: " + err.Error()))
+	broadcastLogStreamErrorInternal("project log stream", "Failed to stream project logs: ", projectID, format, err, ls)
 }
 
 func startProjectLogForwardersInternal(ctx context.Context, format string, batched bool, lines <-chan string, ls *wsLogStream) {
@@ -599,35 +643,9 @@ func (h *WebSocketHandler) ContainerLogs(c *gin.Context) {
 		return
 	}
 
-	follow := c.DefaultQuery("follow", "true") == "true"
-	tail, _ := httputil.GetQueryParam(c, "tail", false)
-	if tail == "" {
-		tail = "100"
-	}
-	since, _ := httputil.GetQueryParam(c, "since", false)
-	timestamps := c.DefaultQuery("timestamps", "false") == "true"
-	format, _ := httputil.GetQueryParam(c, "format", false)
-	if format == "" {
-		format = "text"
-	}
-	batched := c.DefaultQuery("batched", "false") == "true"
-
-	conn, err := h.wsUpgrader.Upgrade(c.Writer, c.Request, nil)
-	if err != nil {
-		return
-	}
-
-	streamKey := buildLogStreamKeyInternal(c.Param("id"), systemtypes.WSKindContainerLogs, containerID, format, batched, follow, tail, since, timestamps)
-	stream := h.getOrCreateLogStreamInternal(streamKey, func(onEmpty func(*wsLogStream)) *wsLogStream {
-		return h.startContainerLogHub(streamKey, containerID, format, batched, follow, tail, since, timestamps, onEmpty)
-	})
-	connID := h.wsMetrics.RegisterConnection(buildWSConnectionInfoInternal(c, systemtypes.WSKindContainerLogs, containerID))
-	// WebSocket connections use context.Background() because they are long-lived and should not
-	// be tied to the HTTP request context. Cleanup is handled via the hub's OnEmpty callback
-	// which triggers when all clients disconnect.
-	ws.ServeClientWithOnRemove(context.Background(), stream.hub, conn, func() {
-		h.wsMetrics.UnregisterConnection(connID)
-		h.releaseLogStreamInternal(streamKey, stream)
+	params := parseLogStreamParamsInternal(c)
+	h.serveLogStreamInternal(c, systemtypes.WSKindContainerLogs, containerID, params, func(streamKey string, onEmpty func(*wsLogStream)) *wsLogStream {
+		return h.startContainerLogHub(streamKey, containerID, params.format, params.batched, params.follow, params.tail, params.since, params.timestamps, onEmpty)
 	})
 }
 
@@ -695,23 +713,7 @@ func (h *WebSocketHandler) startContainerLogHub(key, containerID, format string,
 }
 
 func (h *WebSocketHandler) broadcastContainerLogStreamErrorInternal(containerID, format string, err error, ls *wsLogStream) {
-	slog.Warn("container log stream failed", "containerID", containerID, "error", err)
-
-	if format == "json" {
-		msg := ws.LogMessage{
-			Seq:       ls.seq.Add(1),
-			Level:     "error",
-			Message:   "Failed to stream container logs: " + err.Error(),
-			Service:   "arcane",
-			Timestamp: ws.NowRFC3339(),
-		}
-		if b, marshalErr := json.Marshal(msg); marshalErr == nil {
-			ls.hub.Broadcast(b)
-		}
-		return
-	}
-
-	ls.hub.Broadcast([]byte("Failed to stream container logs: " + err.Error()))
+	broadcastLogStreamErrorInternal("container log stream", "Failed to stream container logs: ", containerID, format, err, ls)
 }
 
 // ============================================================================
@@ -733,42 +735,15 @@ func (h *WebSocketHandler) broadcastContainerLogStreamErrorInternal(containerID,
 //	@Param			batched		query	bool	false	"Batch log messages"			default(false)
 //	@Router			/api/environments/{id}/ws/swarm/services/{serviceId}/logs [get]
 func (h *WebSocketHandler) ServiceLogs(c *gin.Context) {
-	environmentID := c.Param("id")
 	serviceID := c.Param("serviceId")
 	if strings.TrimSpace(serviceID) == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Service ID is required"})
 		return
 	}
 
-	follow := c.DefaultQuery("follow", "true") == "true"
-	tail, _ := httputil.GetQueryParam(c, "tail", false)
-	if tail == "" {
-		tail = "100"
-	}
-	since, _ := httputil.GetQueryParam(c, "since", false)
-	timestamps := c.DefaultQuery("timestamps", "false") == "true"
-	format, _ := httputil.GetQueryParam(c, "format", false)
-	if format == "" {
-		format = "text"
-	}
-	batched := c.DefaultQuery("batched", "false") == "true"
-
-	conn, err := h.wsUpgrader.Upgrade(c.Writer, c.Request, nil)
-	if err != nil {
-		return
-	}
-
-	streamKey := buildLogStreamKeyInternal(environmentID, systemtypes.WSKindServiceLogs, serviceID, format, batched, follow, tail, since, timestamps)
-	connID := h.wsMetrics.RegisterConnection(buildWSConnectionInfoInternal(c, systemtypes.WSKindServiceLogs, serviceID))
-	stream := h.getOrCreateLogStreamInternal(streamKey, func(onEmpty func(*wsLogStream)) *wsLogStream {
-		return h.startServiceLogHub(streamKey, serviceID, format, batched, follow, tail, since, timestamps, onEmpty)
-	})
-	// WebSocket connections use context.Background() because they are long-lived and should not
-	// be tied to the HTTP request context. Cleanup is handled via the hub's OnEmpty callback
-	// which triggers when all clients disconnect.
-	ws.ServeClientWithOnRemove(context.Background(), stream.hub, conn, func() {
-		h.wsMetrics.UnregisterConnection(connID)
-		h.releaseLogStreamInternal(streamKey, stream)
+	params := parseLogStreamParamsInternal(c)
+	h.serveLogStreamInternal(c, systemtypes.WSKindServiceLogs, serviceID, params, func(streamKey string, onEmpty func(*wsLogStream)) *wsLogStream {
+		return h.startServiceLogHub(streamKey, serviceID, params.format, params.batched, params.follow, params.tail, params.since, params.timestamps, onEmpty)
 	})
 }
 
@@ -836,23 +811,7 @@ func (h *WebSocketHandler) startServiceLogHub(key, serviceID, format string, bat
 }
 
 func (h *WebSocketHandler) broadcastServiceLogStreamErrorInternal(serviceID, format string, err error, ls *wsLogStream) {
-	slog.Warn("service log stream failed", "serviceID", serviceID, "error", err)
-
-	if format == "json" {
-		msg := ws.LogMessage{
-			Seq:       ls.seq.Add(1),
-			Level:     "error",
-			Message:   "Failed to stream service logs: " + err.Error(),
-			Service:   "arcane",
-			Timestamp: ws.NowRFC3339(),
-		}
-		if b, marshalErr := json.Marshal(msg); marshalErr == nil {
-			ls.hub.Broadcast(b)
-		}
-		return
-	}
-
-	ls.hub.Broadcast([]byte("Failed to stream service logs: " + err.Error()))
+	broadcastLogStreamErrorInternal("service log stream", "Failed to stream service logs: ", serviceID, format, err, ls)
 }
 
 // ContainerStats streams container stats over WebSocket.

--- a/backend/internal/bootstrap/services_bootstrap.go
+++ b/backend/internal/bootstrap/services_bootstrap.go
@@ -89,6 +89,7 @@ func initializeServices(ctx context.Context, db *database.DB, cfg *config.Config
 		svcs.Docker,
 		svcs.Container,
 		svcs.Project,
+		svcs.Image,
 		svcs.Settings,
 		svcs.Vulnerability,
 		svcs.Environment,

--- a/backend/internal/huma/handlers/dashboard_test.go
+++ b/backend/internal/huma/handlers/dashboard_test.go
@@ -111,7 +111,7 @@ func TestDashboardHandlerGetDashboardReturnsSnapshot(t *testing.T) {
 
 	dockerSvc := newDashboardHandlerTestDockerService(t, settingsSvc, containers, images)
 	handler := &DashboardHandler{
-		dashboardService: services.NewDashboardService(db, dockerSvc, nil, nil, settingsSvc, nil, nil, nil),
+		dashboardService: services.NewDashboardService(db, dockerSvc, nil, nil, nil, settingsSvc, nil, nil, nil),
 	}
 
 	output, err := handler.GetDashboard(context.Background(), &GetDashboardInput{EnvironmentID: "0"})
@@ -146,6 +146,7 @@ func TestDashboardHandlerGetEnvironmentsOverviewReturnsAggregateSummary(t *testi
 	handler := &DashboardHandler{
 		dashboardService: services.NewDashboardService(
 			db,
+			nil,
 			nil,
 			nil,
 			nil,

--- a/backend/internal/models/project.go
+++ b/backend/internal/models/project.go
@@ -13,7 +13,7 @@ const (
 )
 
 type Project struct {
-	Name               string        `json:"name" sortable:"true"`
+	Name               string        `json:"name" sortable:"true" gorm:"index:idx_projects_name"`
 	DirName            *string       `json:"dir_name"`
 	Path               string        `json:"path" sortable:"true" gorm:"uniqueIndex"`
 	Status             ProjectStatus `json:"status" sortable:"true"`

--- a/backend/internal/services/dashboard_service.go
+++ b/backend/internal/services/dashboard_service.go
@@ -35,6 +35,7 @@ type DashboardService struct {
 	dockerService        *DockerClientService
 	containerService     *ContainerService
 	projectService       *ProjectService
+	imageService         *ImageService
 	settingsService      *SettingsService
 	vulnerabilityService *VulnerabilityService
 	environmentService   *EnvironmentService
@@ -50,6 +51,7 @@ func NewDashboardService(
 	dockerService *DockerClientService,
 	containerService *ContainerService,
 	projectService *ProjectService,
+	imageService *ImageService,
 	settingsService *SettingsService,
 	vulnerabilityService *VulnerabilityService,
 	environmentService *EnvironmentService,
@@ -60,6 +62,7 @@ func NewDashboardService(
 		dockerService:        dockerService,
 		containerService:     containerService,
 		projectService:       projectService,
+		imageService:         imageService,
 		settingsService:      settingsService,
 		vulnerabilityService: vulnerabilityService,
 		environmentService:   environmentService,
@@ -132,7 +135,12 @@ func (s *DashboardService) GetSnapshot(ctx context.Context, options DashboardAct
 	})
 	containerPage := limitDashboardItemsInternal(containerItems, dashboardSnapshotPreloadLimit)
 
-	projectIDByName := buildProjectIDMapInternal(ctx, s.db, filteredContainers)
+	var projectIDByName map[string]string
+	if s.imageService != nil {
+		projectIDByName = s.imageService.BuildProjectIDMap(ctx, filteredContainers)
+	} else {
+		projectIDByName = map[string]string{}
+	}
 	imageUsageMap := buildUsageMapInternal(filteredContainers, projectIDByName)
 	imageItems := mapDockerImagesToDTOs(dockerImages, imageUsageMap, nil, nil)
 	sort.Slice(imageItems, func(i, j int) bool {

--- a/backend/internal/services/dashboard_service_test.go
+++ b/backend/internal/services/dashboard_service_test.go
@@ -100,7 +100,7 @@ func newDashboardTestVersionServiceInternal() *VersionService {
 
 func TestDashboardService_GetActionItems_IncludesExpiringAPIKeys(t *testing.T) {
 	db, settingsSvc := setupDashboardServiceTestDB(t)
-	svc := NewDashboardService(db, nil, nil, nil, settingsSvc, nil, nil, nil)
+	svc := NewDashboardService(db, nil, nil, nil, nil, settingsSvc, nil, nil, nil)
 
 	now := time.Now()
 	createDashboardTestAPIKey(t, db, models.ApiKey{
@@ -144,7 +144,7 @@ func TestDashboardService_GetActionItems_IncludesExpiringAPIKeys(t *testing.T) {
 
 func TestDashboardService_GetActionItems_DebugAllGoodReturnsNoItems(t *testing.T) {
 	db, settingsSvc := setupDashboardServiceTestDB(t)
-	svc := NewDashboardService(db, nil, nil, nil, settingsSvc, nil, nil, nil)
+	svc := NewDashboardService(db, nil, nil, nil, nil, settingsSvc, nil, nil, nil)
 
 	createDashboardTestAPIKey(t, db, models.ApiKey{
 		Name:      "expiring-soon",
@@ -234,7 +234,7 @@ func TestDashboardService_GetSnapshot_ReturnsDashboardSnapshot(t *testing.T) {
 		Status:    models.ProjectStatusStopped,
 	}).Error)
 	projectSvc := NewProjectService(db, settingsSvc, nil, &ImageService{db: db}, nil, nil, config.Load())
-	svc := NewDashboardService(db, dockerSvc, nil, projectSvc, settingsSvc, nil, nil, nil)
+	svc := NewDashboardService(db, dockerSvc, nil, projectSvc, nil, settingsSvc, nil, nil, nil)
 
 	snapshot, err := svc.GetSnapshot(context.Background(), DashboardActionItemsOptions{})
 	require.NoError(t, err)
@@ -284,7 +284,7 @@ func TestDashboardService_GetSnapshot_DebugAllGoodOnlyClearsActionItems(t *testi
 	createDashboardTestImageUpdateRecord(t, db, models.ImageUpdateRecord{ID: "sha256:image-b", HasUpdate: true})
 
 	dockerSvc := newDashboardTestDockerService(t, settingsSvc, containers, images)
-	svc := NewDashboardService(db, dockerSvc, nil, nil, settingsSvc, nil, nil, nil)
+	svc := NewDashboardService(db, dockerSvc, nil, nil, nil, settingsSvc, nil, nil, nil)
 
 	snapshot, err := svc.GetSnapshot(context.Background(), DashboardActionItemsOptions{DebugAllGood: true})
 	require.NoError(t, err)
@@ -381,7 +381,7 @@ func TestDashboardService_GetEnvironmentsOverview_ReturnsLocalAndRemoteSummaries
 
 	dockerSvc := newDashboardTestDockerService(t, settingsSvc, containers, images)
 	envSvc := NewEnvironmentService(db, remoteServer.Client(), nil, nil, settingsSvc, nil)
-	svc := NewDashboardService(db, dockerSvc, nil, nil, settingsSvc, nil, envSvc, newDashboardTestVersionServiceInternal())
+	svc := NewDashboardService(db, dockerSvc, nil, nil, nil, settingsSvc, nil, envSvc, newDashboardTestVersionServiceInternal())
 
 	overview, err := svc.GetEnvironmentsOverview(context.Background(), DashboardActionItemsOptions{})
 	require.NoError(t, err)
@@ -427,7 +427,7 @@ func TestDashboardService_GetEnvironmentsOverview_HandlesRemoteSnapshotFailure(t
 	})
 
 	envSvc := NewEnvironmentService(db, http.DefaultClient, nil, nil, settingsSvc, nil)
-	svc := NewDashboardService(db, nil, nil, nil, settingsSvc, nil, envSvc, newDashboardTestVersionServiceInternal())
+	svc := NewDashboardService(db, nil, nil, nil, nil, settingsSvc, nil, envSvc, newDashboardTestVersionServiceInternal())
 
 	overview, err := svc.GetEnvironmentsOverview(context.Background(), DashboardActionItemsOptions{})
 	require.NoError(t, err)
@@ -493,7 +493,7 @@ func TestDashboardService_GetEnvironmentsOverview_OmitsVersionInfoWhenFetchFails
 	})
 
 	envSvc := NewEnvironmentService(db, remoteServer.Client(), nil, nil, settingsSvc, nil)
-	svc := NewDashboardService(db, nil, nil, nil, settingsSvc, nil, envSvc, newDashboardTestVersionServiceInternal())
+	svc := NewDashboardService(db, nil, nil, nil, nil, settingsSvc, nil, envSvc, newDashboardTestVersionServiceInternal())
 
 	overview, err := svc.GetEnvironmentsOverview(context.Background(), DashboardActionItemsOptions{})
 	require.NoError(t, err)
@@ -554,7 +554,7 @@ func TestDashboardService_GetActionItems_CountsAffectedResources(t *testing.T) {
 
 	dockerSvc := newDashboardTestDockerService(t, settingsSvc, containers, images)
 	projectSvc := NewProjectService(db, settingsSvc, nil, &ImageService{db: db}, nil, nil, config.Load())
-	svc := NewDashboardService(db, dockerSvc, nil, projectSvc, settingsSvc, nil, nil, nil)
+	svc := NewDashboardService(db, dockerSvc, nil, projectSvc, nil, settingsSvc, nil, nil, nil)
 
 	actionItems, err := svc.GetActionItems(ctx, DashboardActionItemsOptions{})
 	require.NoError(t, err)

--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/startup"
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/pkg/projects"
+	"github.com/getarcaneapp/arcane/backend/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils/mapper"
 	"github.com/getarcaneapp/arcane/types/gitops"
 	"github.com/getarcaneapp/arcane/types/swarm"
@@ -110,15 +111,10 @@ func (s *GitOpsSyncService) getEnvironmentSyncLimits(ctx context.Context) (int, 
 		return defaultMaxSyncFiles, defaultMaxSyncTotalSize, defaultMaxSyncBinarySize
 	}
 
-	maxFiles := normalizeSyncLimitSetting(s.settingsService.GetIntSetting(ctx, "gitSyncMaxFiles", defaultMaxSyncFiles), defaultMaxSyncFiles)
-	maxTotalSizeMB := normalizeSyncLimitSetting(
-		s.settingsService.GetIntSetting(ctx, "gitSyncMaxTotalSizeMb", defaultMaxSyncTotalSizeMB),
-		defaultMaxSyncTotalSizeMB,
-	)
-	maxBinarySizeMB := normalizeSyncLimitSetting(
-		s.settingsService.GetIntSetting(ctx, "gitSyncMaxBinarySizeMb", defaultMaxSyncBinarySizeMB),
-		defaultMaxSyncBinarySizeMB,
-	)
+	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
+	maxFiles := normalizeSyncLimitSetting(utils.IntOrDefault(cfg.GitSyncMaxFiles.Value, defaultMaxSyncFiles), defaultMaxSyncFiles)
+	maxTotalSizeMB := normalizeSyncLimitSetting(utils.IntOrDefault(cfg.GitSyncMaxTotalSizeMb.Value, defaultMaxSyncTotalSizeMB), defaultMaxSyncTotalSizeMB)
+	maxBinarySizeMB := normalizeSyncLimitSetting(utils.IntOrDefault(cfg.GitSyncMaxBinarySizeMb.Value, defaultMaxSyncBinarySizeMB), defaultMaxSyncBinarySizeMB)
 
 	return maxFiles, megabytesToBytes(maxTotalSizeMB), megabytesToBytes(maxBinarySizeMB)
 }

--- a/backend/internal/services/image_service.go
+++ b/backend/internal/services/image_service.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
@@ -33,6 +35,16 @@ type ImageService struct {
 	registryService      *ContainerRegistryService
 	vulnerabilityService *VulnerabilityService
 	eventService         *EventService
+
+	projectIDCache projectIDNameCache
+}
+
+// projectIDNameCache memoizes the (project name → project ID) map used to enrich image
+// usage data with the owning project. The TTL bounds staleness; see projectIDCacheTTL.
+type projectIDNameCache struct {
+	mu      sync.RWMutex
+	byName  map[string]string
+	expires time.Time
 }
 
 func NewImageService(db *database.DB, dockerService *DockerClientService, registryService *ContainerRegistryService, imageUpdateService *ImageUpdateService, vulnerabilityService *VulnerabilityService, eventService *EventService) *ImageService {
@@ -603,7 +615,7 @@ func (s *ImageService) ListImagesPaginated(ctx context.Context, params paginatio
 		}
 	}
 
-	projectIDByName := buildProjectIDMapInternal(ctx, s.db, containers)
+	projectIDByName := s.BuildProjectIDMap(ctx, containers)
 	usageMap := buildUsageMapInternal(containers, projectIDByName)
 	updateMap := buildUpdateMap(updateRecords)
 
@@ -745,9 +757,49 @@ func (s *ImageService) GetTotalImageSize(ctx context.Context) (int64, error) {
 	return total, nil
 }
 
-func buildProjectIDMapInternal(ctx context.Context, db *database.DB, containers []container.Summary) map[string]string {
+// projectIDCacheTTL bounds how long a snapshot of all (name → id) project rows is reused.
+// Dashboard polls frequently; the projects table changes rarely, so a short TTL is safe.
+const projectIDCacheTTL = 5 * time.Second
+
+func (s *ImageService) loadProjectIDByNameCachedInternal(ctx context.Context) map[string]string {
+	s.projectIDCache.mu.RLock()
+	if cached := s.projectIDCache.byName; cached != nil && time.Now().Before(s.projectIDCache.expires) {
+		s.projectIDCache.mu.RUnlock()
+		return cached
+	}
+	s.projectIDCache.mu.RUnlock()
+
+	s.projectIDCache.mu.Lock()
+	defer s.projectIDCache.mu.Unlock()
+	if cached := s.projectIDCache.byName; cached != nil && time.Now().Before(s.projectIDCache.expires) {
+		return cached
+	}
+
+	var projects []models.Project
+	if err := s.db.WithContext(ctx).Select("id", "name").Find(&projects).Error; err != nil {
+		slog.WarnContext(ctx, "failed to load project ID map", "error", err)
+		// Return last cached value if any; otherwise an empty map (don't store, so we retry next call).
+		if s.projectIDCache.byName != nil {
+			return s.projectIDCache.byName
+		}
+		return map[string]string{}
+	}
+
+	byName := make(map[string]string, len(projects))
+	for _, p := range projects {
+		byName[p.Name] = p.ID
+	}
+	s.projectIDCache.byName = byName
+	s.projectIDCache.expires = time.Now().Add(projectIDCacheTTL)
+	return byName
+}
+
+// BuildProjectIDMap returns a map of compose project name → project ID for any
+// containers that carry the com.docker.compose.project label. The lookup uses a
+// short-TTL cache shared across all callers of this ImageService instance.
+func (s *ImageService) BuildProjectIDMap(ctx context.Context, containers []container.Summary) map[string]string {
 	projectIDs := make(map[string]string)
-	if db == nil {
+	if s.db == nil {
 		return projectIDs
 	}
 
@@ -764,20 +816,12 @@ func buildProjectIDMapInternal(ctx context.Context, db *database.DB, containers 
 		return projectIDs
 	}
 
-	projectNames := make([]string, 0, len(projectNameSet))
+	all := s.loadProjectIDByNameCachedInternal(ctx)
 	for name := range projectNameSet {
-		projectNames = append(projectNames, name)
+		if id, ok := all[name]; ok {
+			projectIDs[name] = id
+		}
 	}
-
-	var projects []models.Project
-	if err := db.WithContext(ctx).Where("name IN ?", projectNames).Find(&projects).Error; err != nil {
-		slog.WarnContext(ctx, "failed to resolve project IDs for image usage", "error", err)
-		return projectIDs
-	}
-	for _, project := range projects {
-		projectIDs[project.Name] = project.ID
-	}
-
 	return projectIDs
 }
 

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -449,8 +449,8 @@ func (s *ProjectService) loadComposeProjectForProjectInternal(ctx context.Contex
 		return nil, "", err
 	}
 
-	projectsDirSetting := s.settingsService.GetStringSetting(ctx, "projectsDirectory", "/app/data/projects")
-	projectsDirectory, pdErr := projects.GetProjectsDirectory(ctx, strings.TrimSpace(projectsDirSetting))
+	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
+	projectsDirectory, pdErr := projects.GetProjectsDirectory(ctx, strings.TrimSpace(cfg.ProjectsDirectory.Value))
 	if pdErr != nil {
 		slog.WarnContext(ctx, "unable to determine projects directory; using default", "error", pdErr)
 		projectsDirectory = "/app/data/projects"
@@ -461,8 +461,7 @@ func (s *ProjectService) loadComposeProjectForProjectInternal(ctx context.Contex
 		slog.WarnContext(ctx, "failed to create path mapper, continuing without translation", "error", pmErr)
 	}
 
-	autoInjectEnv := s.settingsService.GetBoolSetting(ctx, "autoInjectEnv", false)
-	composeProject, loadErr := projects.LoadComposeProject(ctx, composeFileFullPath, normalizeComposeProjectName(proj.Name), projectsDirectory, autoInjectEnv, pathMapper)
+	composeProject, loadErr := projects.LoadComposeProject(ctx, composeFileFullPath, normalizeComposeProjectName(proj.Name), projectsDirectory, utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false), pathMapper)
 	if loadErr != nil {
 		return nil, "", loadErr
 	}
@@ -830,10 +829,9 @@ func (s *ProjectService) GetProjectFileContent(ctx context.Context, projectID, r
 
 	composeFile, detectErr := s.resolveProjectComposeFileInternal(ctx, proj)
 	if detectErr == nil {
-		projectsDirSetting := s.settingsService.GetStringSetting(ctx, "projectsDirectory", "/app/data/projects")
-		projectsDirectory, _ := projects.GetProjectsDirectory(ctx, strings.TrimSpace(projectsDirSetting))
-		autoInjectEnv := s.settingsService.GetBoolSetting(ctx, "autoInjectEnv", false)
-		envLoader := projects.NewEnvLoader(projectsDirectory, filepath.Dir(composeFile), autoInjectEnv)
+		cfg := s.settingsService.GetSettingsOrDefaults(ctx)
+		projectsDirectory, _ := projects.GetProjectsDirectory(ctx, strings.TrimSpace(cfg.ProjectsDirectory.Value))
+		envLoader := projects.NewEnvLoader(projectsDirectory, filepath.Dir(composeFile), utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false))
 		envMap, _, _ := envLoader.LoadEnvironment(ctx)
 
 		includes, parseErr := projects.ParseIncludes(composeFile, envMap, true)
@@ -901,10 +899,9 @@ func (s *ProjectService) enrichWithIncludeFiles(ctx context.Context, composeFile
 	}
 
 	// Load environment variables so that include paths with ${VAR} references are expanded
-	projectsDirSetting := s.settingsService.GetStringSetting(ctx, "projectsDirectory", "/app/data/projects")
-	projectsDirectory, _ := projects.GetProjectsDirectory(ctx, strings.TrimSpace(projectsDirSetting))
-	autoInjectEnv := s.settingsService.GetBoolSetting(ctx, "autoInjectEnv", false)
-	envLoader := projects.NewEnvLoader(projectsDirectory, filepath.Dir(composeFile), autoInjectEnv)
+	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
+	projectsDirectory, _ := projects.GetProjectsDirectory(ctx, strings.TrimSpace(cfg.ProjectsDirectory.Value))
+	envLoader := projects.NewEnvLoader(projectsDirectory, filepath.Dir(composeFile), utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false))
 	envMap, _, _ := envLoader.LoadEnvironment(ctx)
 
 	includes, parseErr := projects.ParseIncludes(composeFile, envMap, false)
@@ -1185,16 +1182,15 @@ func (s *ProjectService) enrichWithGitOpsInfo(ctx context.Context, proj *models.
 }
 
 func (s *ProjectService) enrichWithComposeServiceConfigs(ctx context.Context, proj *models.Project, composeFile string, resp *project.Details) {
-	projectsDirSetting := s.settingsService.GetStringSetting(ctx, "projectsDirectory", "/app/data/projects")
-	projectsDirectory, _ := projects.GetProjectsDirectory(ctx, strings.TrimSpace(projectsDirSetting))
+	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
+	projectsDirectory, _ := projects.GetProjectsDirectory(ctx, strings.TrimSpace(cfg.ProjectsDirectory.Value))
 
 	pathMapper, pmErr := s.getPathMapper(ctx)
 	if pmErr != nil {
 		slog.WarnContext(ctx, "failed to create path mapper, continuing without translation", "error", pmErr)
 	}
 
-	autoInjectEnv := s.settingsService.GetBoolSetting(ctx, "autoInjectEnv", false)
-	composeProj, loadErr := projects.LoadComposeProject(ctx, composeFile, normalizeComposeProjectName(proj.Name), projectsDirectory, autoInjectEnv, pathMapper)
+	composeProj, loadErr := projects.LoadComposeProject(ctx, composeFile, normalizeComposeProjectName(proj.Name), projectsDirectory, utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false), pathMapper)
 	if loadErr != nil {
 		slog.WarnContext(ctx, "failed to load compose service configs", "path", composeFile, "error", loadErr)
 		return
@@ -2358,8 +2354,8 @@ func (s *ProjectService) RestartProject(ctx context.Context, projectID string, u
 	}
 
 	// Get configured projects directory from settings
-	projectsDirSetting := s.settingsService.GetStringSetting(ctx, "projectsDirectory", "/app/data/projects")
-	projectsDirectory, pdErr := projects.GetProjectsDirectory(ctx, strings.TrimSpace(projectsDirSetting))
+	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
+	projectsDirectory, pdErr := projects.GetProjectsDirectory(ctx, strings.TrimSpace(cfg.ProjectsDirectory.Value))
 	if pdErr != nil {
 		slog.WarnContext(ctx, "unable to determine projects directory; using default", "error", pdErr)
 		projectsDirectory = "/app/data/projects"
@@ -2370,8 +2366,7 @@ func (s *ProjectService) RestartProject(ctx context.Context, projectID string, u
 		slog.WarnContext(ctx, "failed to create path mapper, continuing without translation", "error", pmErr)
 	}
 
-	autoInjectEnv := s.settingsService.GetBoolSetting(ctx, "autoInjectEnv", false)
-	compProj, _, lerr := projects.LoadComposeProjectFromDir(ctx, proj.Path, normalizeComposeProjectName(proj.Name), projectsDirectory, autoInjectEnv, pathMapper)
+	compProj, _, lerr := projects.LoadComposeProjectFromDir(ctx, proj.Path, normalizeComposeProjectName(proj.Name), projectsDirectory, utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false), pathMapper)
 	if lerr != nil {
 		_ = s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusRunning)
 		return fmt.Errorf("failed to load compose project: %w", lerr)
@@ -3482,8 +3477,8 @@ func (s *ProjectService) countServicesFromCompose(ctx context.Context, p models.
 // and once for the project name).
 // The effective name is nil when it matches the normalized directory name.
 func (s *ProjectService) loadComposeMetadataForSyncInternal(ctx context.Context, dirPath, dirName string) (serviceCount int, composeProjectName *string, err error) {
-	projectsDirSetting := s.settingsService.GetStringSetting(ctx, "projectsDirectory", "/app/data/projects")
-	projectsDirectory, pErr := projects.GetProjectsDirectory(ctx, strings.TrimSpace(projectsDirSetting))
+	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
+	projectsDirectory, pErr := projects.GetProjectsDirectory(ctx, strings.TrimSpace(cfg.ProjectsDirectory.Value))
 	if pErr != nil {
 		return 0, nil, pErr
 	}
@@ -3494,7 +3489,7 @@ func (s *ProjectService) loadComposeMetadataForSyncInternal(ctx context.Context,
 	}
 
 	normName := normalizeComposeProjectName(dirName)
-	autoInjectEnv := s.settingsService.GetBoolSetting(ctx, "autoInjectEnv", false)
+	autoInjectEnv := utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false)
 
 	// First, try loading without forcing a project name so compose-go can
 	// resolve COMPOSE_PROJECT_NAME from the .env file. If this fails (e.g.

--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -506,6 +506,21 @@ func (s *SettingsService) GetSettings(ctx context.Context) (*models.Settings, er
 	return settings, nil
 }
 
+// GetSettingsOrDefaults is a convenience for hot paths that need a snapshot but cannot
+// meaningfully recover from a settings load failure. It logs any error and guarantees a
+// non-nil *Settings (defaults: a zero-valued struct, which the SettingVariable helpers
+// like utils.BoolOrDefault treat as "use the caller's default").
+func (s *SettingsService) GetSettingsOrDefaults(ctx context.Context) *models.Settings {
+	cfg, err := s.GetSettings(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to load settings, falling back to defaults", "error", err)
+	}
+	if cfg == nil {
+		return &models.Settings{}
+	}
+	return cfg
+}
+
 func (s *SettingsService) getEffectiveSettingsConfig(ctx context.Context) *models.Settings {
 	settings := s.GetSettingsConfig().Clone()
 	s.applyEnvOverrides(ctx, settings)

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
+	"github.com/getarcaneapp/arcane/backend/pkg/utils/dbutil"
 	"github.com/getarcaneapp/arcane/types/user"
 )
 
@@ -132,7 +133,7 @@ func (s *UserService) validateArgon2Password(encodedHash, password string) error
 }
 
 func (s *UserService) CreateUser(ctx context.Context, user *models.User) (*models.User, error) {
-	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err := dbutil.WithTx(ctx, s.db.DB, func(tx *gorm.DB) error {
 		if err := tx.Create(user).Error; err != nil {
 			return fmt.Errorf("failed to create user: %w", err)
 		}
@@ -145,51 +146,23 @@ func (s *UserService) CreateUser(ctx context.Context, user *models.User) (*model
 }
 
 func (s *UserService) GetUserByUsername(ctx context.Context, username string) (*models.User, error) {
-	var user models.User
-	if err := s.db.WithContext(ctx).Where("username = ?", username).First(&user).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrUserNotFound
-		}
-		return nil, fmt.Errorf("failed to get user: %w", err)
-	}
-	return &user, nil
+	return dbutil.FirstWhere[models.User](ctx, s.db.DB, ErrUserNotFound, "username = ?", username)
 }
 
 func (s *UserService) GetUserByID(ctx context.Context, id string) (*models.User, error) {
-	var user models.User
-	if err := s.db.WithContext(ctx).Where("id = ?", id).First(&user).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrUserNotFound
-		}
-		return nil, fmt.Errorf("failed to get user: %w", err)
-	}
-	return &user, nil
+	return dbutil.FirstWhere[models.User](ctx, s.db.DB, ErrUserNotFound, "id = ?", id)
 }
 
 func (s *UserService) GetUserByOidcSubjectId(ctx context.Context, subjectId string) (*models.User, error) {
-	var user models.User
-	if err := s.db.WithContext(ctx).Where("oidc_subject_id = ?", subjectId).First(&user).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrUserNotFound
-		}
-		return nil, fmt.Errorf("failed to get user: %w", err)
-	}
-	return &user, nil
+	return dbutil.FirstWhere[models.User](ctx, s.db.DB, ErrUserNotFound, "oidc_subject_id = ?", subjectId)
 }
 
 func (s *UserService) GetUserByEmail(ctx context.Context, email string) (*models.User, error) {
-	var user models.User
-	if err := s.db.WithContext(ctx).Where("email = ?", email).First(&user).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrUserNotFound
-		}
-		return nil, fmt.Errorf("failed to get user by email: %w", err)
-	}
-	return &user, nil
+	return dbutil.FirstWhere[models.User](ctx, s.db.DB, ErrUserNotFound, "email = ?", email)
 }
 
 func (s *UserService) UpdateUser(ctx context.Context, user *models.User) (*models.User, error) {
-	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err := dbutil.WithTx(ctx, s.db.DB, func(tx *gorm.DB) error {
 		var existing models.User
 		if err := tx.
 			Clauses(clause.Locking{Strength: "UPDATE"}).
@@ -231,7 +204,7 @@ func (s *UserService) UpdateUser(ctx context.Context, user *models.User) (*model
 // This MUST be done inside a transaction to ensure the lock is held until the update is committed.
 func (s *UserService) AttachOidcSubjectTransactional(ctx context.Context, userID string, subject string, updateFn func(u *models.User)) (*models.User, error) {
 	var out *models.User
-	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err := dbutil.WithTx(ctx, s.db.DB, func(tx *gorm.DB) error {
 		var u models.User
 		if err := tx.
 			Clauses(clause.Locking{Strength: "UPDATE"}).
@@ -278,7 +251,7 @@ func (s *UserService) CreateDefaultAdmin(ctx context.Context) error {
 		return fmt.Errorf("failed to hash default admin password: %w", err)
 	}
 
-	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	return dbutil.WithTx(ctx, s.db.DB, func(tx *gorm.DB) error {
 		var count int64
 		if err := tx.Model(&models.User{}).Count(&count).Error; err != nil {
 			return fmt.Errorf("failed to count users: %w", err)
@@ -314,7 +287,7 @@ func (s *UserService) CreateDefaultAdmin(ctx context.Context) error {
 }
 
 func (s *UserService) DeleteUser(ctx context.Context, id string) error {
-	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	return dbutil.WithTx(ctx, s.db.DB, func(tx *gorm.DB) error {
 		var existing models.User
 		if err := tx.
 			Clauses(clause.Locking{Strength: "UPDATE"}).
@@ -357,7 +330,7 @@ func (s *UserService) UpgradePasswordHash(ctx context.Context, userID, password 
 		return fmt.Errorf("failed to create new hash: %w", err)
 	}
 
-	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	return dbutil.WithTx(ctx, s.db.DB, func(tx *gorm.DB) error {
 		if err := tx.Model(&models.User{}).
 			Where("id = ?", userID).
 			Update("password_hash", newHash).Error; err != nil {

--- a/backend/pkg/dockerutil/volume_utils.go
+++ b/backend/pkg/dockerutil/volume_utils.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/volume"
 	"github.com/moby/moby/client"
@@ -67,13 +68,9 @@ func InvalidateVolumeUsageCache() {
 	volumeUsageCacheTime = time.Time{}
 }
 
-func GetContainersUsingVolume(ctx context.Context, dockerClient *client.Client, volumeName string) ([]string, error) {
-	containerList, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: true})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list containers: %w", err)
-	}
-	containers := containerList.Items
-
+// FilterContainersUsingVolume returns the IDs of containers in the provided slice that mount the named volume.
+// Use this when checking many volumes in a row — list containers once and reuse the slice.
+func FilterContainersUsingVolume(containers []container.Summary, volumeName string) []string {
 	containerIDs := make([]string, 0)
 	for _, c := range containers {
 		for _, m := range c.Mounts {
@@ -83,8 +80,19 @@ func GetContainersUsingVolume(ctx context.Context, dockerClient *client.Client, 
 			}
 		}
 	}
+	return containerIDs
+}
 
+// GetContainersUsingVolume lists all containers and returns IDs that mount the named volume.
+// For batch checks (multiple volumes), prefer listing containers once via dockerClient.ContainerList
+// and calling FilterContainersUsingVolume per volume.
+func GetContainersUsingVolume(ctx context.Context, dockerClient *client.Client, volumeName string) ([]string, error) {
+	containerList, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: true})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list containers: %w", err)
+	}
+
+	containerIDs := FilterContainersUsingVolume(containerList.Items, volumeName)
 	slog.DebugContext(ctx, "found containers using volume", "volume", volumeName, "container_count", len(containerIDs))
-
 	return containerIDs, nil
 }

--- a/backend/pkg/utils/dbutil/dbutil.go
+++ b/backend/pkg/utils/dbutil/dbutil.go
@@ -1,0 +1,35 @@
+// Package dbutil provides small generic helpers around GORM that consolidate
+// repetitive single-row lookup and transaction boilerplate found across services.
+package dbutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// FirstWhere fetches a single row of T matching the provided WHERE clause.
+// It maps gorm.ErrRecordNotFound to notFound (when non-nil) and otherwise wraps
+// the error with a generic "failed to query <T>" prefix.
+//
+// Example:
+//
+//	user, err := dbutil.FirstWhere[models.User](ctx, s.db.DB, ErrUserNotFound, "username = ?", username)
+func FirstWhere[T any](ctx context.Context, db *gorm.DB, notFound error, where string, args ...any) (*T, error) {
+	var out T
+	if err := db.WithContext(ctx).Where(where, args...).First(&out).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) && notFound != nil {
+			return nil, notFound
+		}
+		return nil, fmt.Errorf("failed to query %T: %w", out, err)
+	}
+	return &out, nil
+}
+
+// WithTx runs fn inside a GORM transaction bound to ctx. Equivalent to
+// db.WithContext(ctx).Transaction(fn) but tightens the surface area at call sites.
+func WithTx(ctx context.Context, db *gorm.DB, fn func(tx *gorm.DB) error) error {
+	return db.WithContext(ctx).Transaction(fn)
+}

--- a/backend/pkg/utils/dbutil/dbutil_test.go
+++ b/backend/pkg/utils/dbutil/dbutil_test.go
@@ -1,0 +1,79 @@
+package dbutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	glsqlite "github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+type widget struct {
+	ID   string `gorm:"primaryKey"`
+	Name string
+}
+
+var errWidgetNotFound = errors.New("widget not found")
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(glsqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&widget{}))
+	return db
+}
+
+func TestFirstWhereFound(t *testing.T) {
+	db := newTestDB(t)
+	require.NoError(t, db.Create(&widget{ID: "w-1", Name: "alpha"}).Error)
+
+	got, err := FirstWhere[widget](context.Background(), db, errWidgetNotFound, "name = ?", "alpha")
+	require.NoError(t, err)
+	require.Equal(t, "w-1", got.ID)
+}
+
+func TestFirstWhereNotFoundReturnsSentinel(t *testing.T) {
+	db := newTestDB(t)
+
+	_, err := FirstWhere[widget](context.Background(), db, errWidgetNotFound, "name = ?", "missing")
+	require.ErrorIs(t, err, errWidgetNotFound)
+}
+
+func TestFirstWhereNotFoundWithNilSentinel(t *testing.T) {
+	db := newTestDB(t)
+
+	_, err := FirstWhere[widget](context.Background(), db, nil, "name = ?", "missing")
+	require.Error(t, err)
+	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
+func TestWithTxCommit(t *testing.T) {
+	db := newTestDB(t)
+
+	err := WithTx(context.Background(), db, func(tx *gorm.DB) error {
+		return tx.Create(&widget{ID: "w-1", Name: "alpha"}).Error
+	})
+	require.NoError(t, err)
+
+	got, err := FirstWhere[widget](context.Background(), db, errWidgetNotFound, "id = ?", "w-1")
+	require.NoError(t, err)
+	require.Equal(t, "alpha", got.Name)
+}
+
+func TestWithTxRollback(t *testing.T) {
+	db := newTestDB(t)
+	boom := errors.New("boom")
+
+	err := WithTx(context.Background(), db, func(tx *gorm.DB) error {
+		if err := tx.Create(&widget{ID: "w-1", Name: "alpha"}).Error; err != nil {
+			return err
+		}
+		return boom
+	})
+	require.ErrorIs(t, err, boom)
+
+	_, err = FirstWhere[widget](context.Background(), db, errWidgetNotFound, "id = ?", "w-1")
+	require.ErrorIs(t, err, errWidgetNotFound)
+}

--- a/backend/pkg/utils/string_util.go
+++ b/backend/pkg/utils/string_util.go
@@ -1,6 +1,9 @@
 package utils
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 // StringOrDefault returns the trimmed value if non-empty, otherwise defaultValue.
 func StringOrDefault(value, defaultValue string) string {
@@ -9,4 +12,28 @@ func StringOrDefault(value, defaultValue string) string {
 		return defaultValue
 	}
 	return value
+}
+
+// BoolOrDefault parses value as a bool, falling back to defaultValue when empty or unparseable.
+func BoolOrDefault(value string, defaultValue bool) bool {
+	if value == "" {
+		return defaultValue
+	}
+	v, err := strconv.ParseBool(value)
+	if err != nil {
+		return defaultValue
+	}
+	return v
+}
+
+// IntOrDefault parses value as an int, falling back to defaultValue when empty or unparseable.
+func IntOrDefault(value string, defaultValue int) int {
+	if value == "" {
+		return defaultValue
+	}
+	v, err := strconv.Atoi(value)
+	if err != nil {
+		return defaultValue
+	}
+	return v
 }

--- a/backend/resources/migrations/postgres/049_add_projects_name_index.down.sql
+++ b/backend/resources/migrations/postgres/049_add_projects_name_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_projects_name;

--- a/backend/resources/migrations/postgres/049_add_projects_name_index.up.sql
+++ b/backend/resources/migrations/postgres/049_add_projects_name_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_projects_name ON projects (name);

--- a/backend/resources/migrations/sqlite/049_add_projects_name_index.down.sql
+++ b/backend/resources/migrations/sqlite/049_add_projects_name_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_projects_name;

--- a/backend/resources/migrations/sqlite/049_add_projects_name_index.up.sql
+++ b/backend/resources/migrations/sqlite/049_add_projects_name_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_projects_name ON projects (name);


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates three near-identical WebSocket log-stream handlers into a single `serveLogStreamInternal` scaffold, extracts DB boilerplate into a new typed `dbutil` package, replaces ad-hoc settings getters with `GetSettingsOrDefaults`, moves the project-ID cache from package-level global state to an `ImageService` instance field (addressing a previous review concern), and adds a non-unique index on `projects.name` backed by matching migrations for both Postgres and SQLite. The refactors are mechanical and well-tested; no functional behaviour changes were observed.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only P2 style findings, no logic or security issues introduced.

All changes are mechanical consolidation of existing behaviour. The new dbutil helpers are covered by unit tests. The caching fix (instance field vs. global) is correct. Only finding is a minor structured-log key name change, which is P2 and non-blocking.

No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `backend/internal/api/ws_handler.go`, line 83 ([link](https://github.com/getarcaneapp/arcane/blob/52589c0401da05e6f49cdf3d0b36ca002e2a6783/backend/internal/api/ws_handler.go#L83)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unexported functions missing `Internal` suffix**

   Both `broadcastLogStreamError` (line 83) and `serveLogStream` (line 54) are unexported but don't carry the required `Internal` suffix. Per the project's naming convention all unexported functions/methods must end with `Internal`. The newly added `parseLogStreamParamsInternal` in this same PR correctly follows the pattern.

   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/api/ws_handler.go
   Line: 83
   
   Comment:
   **Unexported functions missing `Internal` suffix**
   
   Both `broadcastLogStreamError` (line 83) and `serveLogStream` (line 54) are unexported but don't carry the required `Internal` suffix. Per the project's naming convention all unexported functions/methods must end with `Internal`. The newly added `parseLogStreamParamsInternal` in this same PR correctly follows the pattern.
   
   
   
   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22refactor%2Fbackenup-clean%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fbackenup-clean%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fapi%2Fws_handler.go%0ALine%3A%2083%0A%0AComment%3A%0A**Unexported%20functions%20missing%20%60Internal%60%20suffix**%0A%0ABoth%20%60broadcastLogStreamError%60%20%28line%2083%29%20and%20%60serveLogStream%60%20%28line%2054%29%20are%20unexported%20but%20don't%20carry%20the%20required%20%60Internal%60%20suffix.%20Per%20the%20project's%20naming%20convention%20all%20unexported%20functions%2Fmethods%20must%20end%20with%20%60Internal%60.%20The%20newly%20added%20%60parseLogStreamParamsInternal%60%20in%20this%20same%20PR%20correctly%20follows%20the%20pattern.%0A%0A%60%60%60suggestion%0Afunc%20broadcastLogStreamErrorInternal%28resourceLabel%2C%20errorPrefix%20string%2C%20resourceID%20string%2C%20format%20string%2C%20err%20error%2C%20ls%20*wsLogStream%29%20%7B%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `backend/internal/api/ws_handler.go`, line 54 ([link](https://github.com/getarcaneapp/arcane/blob/52589c0401da05e6f49cdf3d0b36ca002e2a6783/backend/internal/api/ws_handler.go#L54)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unexported method missing `Internal` suffix**

   `serveLogStream` is an unexported method but does not end with `Internal`, violating the same naming rule. The existing unexported methods in this file (`broadcastProjectLogStreamErrorInternal`, `broadcastContainerLogStreamErrorInternal`, etc.) all follow the convention.

   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/api/ws_handler.go
   Line: 54
   
   Comment:
   **Unexported method missing `Internal` suffix**
   
   `serveLogStream` is an unexported method but does not end with `Internal`, violating the same naming rule. The existing unexported methods in this file (`broadcastProjectLogStreamErrorInternal`, `broadcastContainerLogStreamErrorInternal`, etc.) all follow the convention.
   
   
   
   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22refactor%2Fbackenup-clean%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fbackenup-clean%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fapi%2Fws_handler.go%0ALine%3A%2054%0A%0AComment%3A%0A**Unexported%20method%20missing%20%60Internal%60%20suffix**%0A%0A%60serveLogStream%60%20is%20an%20unexported%20method%20but%20does%20not%20end%20with%20%60Internal%60%2C%20violating%20the%20same%20naming%20rule.%20The%20existing%20unexported%20methods%20in%20this%20file%20%28%60broadcastProjectLogStreamErrorInternal%60%2C%20%60broadcastContainerLogStreamErrorInternal%60%2C%20etc.%29%20all%20follow%20the%20convention.%0A%0A%60%60%60suggestion%0Afunc%20%28h%20*WebSocketHandler%29%20serveLogStreamInternal%28%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

3. `backend/internal/services/image_service.go`, line 345-349 ([link](https://github.com/getarcaneapp/arcane/blob/52589c0401da05e6f49cdf3d0b36ca002e2a6783/backend/internal/services/image_service.go#L345-L349)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Package-level global mutable state**

   `projectIDCache` is a package-level variable with a mutable `sync.RWMutex` and map. The project's Go Development Patterns rule explicitly flags "Global mutable state" as bad practice. Beyond convention, this cache is shared across all `ImageService` instances (and across environments in tests), so stale or cross-tenant data can linger for up to 5 s even after the TTL is reduced. Consider holding the cache on `ImageService` itself so its lifetime is tied to the service instance.

   **Rule Used:** # Go Development Patterns
   
   **What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/image_service.go
   Line: 345-349
   
   Comment:
   **Package-level global mutable state**
   
   `projectIDCache` is a package-level variable with a mutable `sync.RWMutex` and map. The project's Go Development Patterns rule explicitly flags "Global mutable state" as bad practice. Beyond convention, this cache is shared across all `ImageService` instances (and across environments in tests), so stale or cross-tenant data can linger for up to 5 s even after the TTL is reduced. Consider holding the cache on `ImageService` itself so its lifetime is tied to the service instance.
   
   **Rule Used:** # Go Development Patterns
   
   **What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22refactor%2Fbackenup-clean%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fbackenup-clean%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fimage_service.go%0ALine%3A%20345-349%0A%0AComment%3A%0A**Package-level%20global%20mutable%20state**%0A%0A%60projectIDCache%60%20is%20a%20package-level%20variable%20with%20a%20mutable%20%60sync.RWMutex%60%20and%20map.%20The%20project's%20Go%20Development%20Patterns%20rule%20explicitly%20flags%20%22Global%20mutable%20state%22%20as%20bad%20practice.%20Beyond%20convention%2C%20this%20cache%20is%20shared%20across%20all%20%60ImageService%60%20instances%20%28and%20across%20environments%20in%20tests%29%2C%20so%20stale%20or%20cross-tenant%20data%20can%20linger%20for%20up%20to%205%20s%20even%20after%20the%20TTL%20is%20reduced.%20Consider%20holding%20the%20cache%20on%20%60ImageService%60%20itself%20so%20its%20lifetime%20is%20tied%20to%20the%20service%20instance.%0A%0A**Rule%20Used%3A**%20%23%20Go%20Development%20Patterns%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

4. `backend/internal/services/project_service.go`, line 422-423 ([link](https://github.com/getarcaneapp/arcane/blob/52589c0401da05e6f49cdf3d0b36ca002e2a6783/backend/internal/services/project_service.go#L422-L423)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Error silently discarded with `_`**

   `cfg, _ := s.settingsService.GetSettings(ctx)` ignores the returned error. While `GetSettings` currently always returns `nil` for the error, discarding it with `_` violates the project's Go rule ("Ignore errors – avoid `_` assignment without justification") and hides future regressions if the implementation changes. This pattern appears in 6+ places across `project_service.go` and `gitops_sync_service.go`. Consider logging the error or at minimum using a named blank identifier with a comment explaining why it's safe to ignore.

   **Rule Used:** # Go Development Patterns
   
   **What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/project_service.go
   Line: 422-423
   
   Comment:
   **Error silently discarded with `_`**
   
   `cfg, _ := s.settingsService.GetSettings(ctx)` ignores the returned error. While `GetSettings` currently always returns `nil` for the error, discarding it with `_` violates the project's Go rule ("Ignore errors – avoid `_` assignment without justification") and hides future regressions if the implementation changes. This pattern appears in 6+ places across `project_service.go` and `gitops_sync_service.go`. Consider logging the error or at minimum using a named blank identifier with a comment explaining why it's safe to ignore.
   
   **Rule Used:** # Go Development Patterns
   
   **What:** Code should p... ([source](https://app.greptile.com/review/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22refactor%2Fbackenup-clean%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fbackenup-clean%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fproject_service.go%0ALine%3A%20422-423%0A%0AComment%3A%0A**Error%20silently%20discarded%20with%20%60_%60**%0A%0A%60cfg%2C%20_%20%3A%3D%20s.settingsService.GetSettings%28ctx%29%60%20ignores%20the%20returned%20error.%20While%20%60GetSettings%60%20currently%20always%20returns%20%60nil%60%20for%20the%20error%2C%20discarding%20it%20with%20%60_%60%20violates%20the%20project's%20Go%20rule%20%28%22Ignore%20errors%20%E2%80%93%20avoid%20%60_%60%20assignment%20without%20justification%22%29%20and%20hides%20future%20regressions%20if%20the%20implementation%20changes.%20This%20pattern%20appears%20in%206%2B%20places%20across%20%60project_service.go%60%20and%20%60gitops_sync_service.go%60.%20Consider%20logging%20the%20error%20or%20at%20minimum%20using%20a%20named%20blank%20identifier%20with%20a%20comment%20explaining%20why%20it's%20safe%20to%20ignore.%0A%0A**Rule%20Used%3A**%20%23%20Go%20Development%20Patterns%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22refactor%2Fbackenup-clean%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fbackenup-clean%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fapi%2Fws_handler.go%3A101%0A**Generic%20slog%20key%20drops%20domain%20context**%0A%0AThe%20unified%20%60broadcastLogStreamErrorInternal%60%20uses%20%60%22resourceID%22%60%20for%20all%20three%20stream%20kinds%2C%20replacing%20the%20original%20type-specific%20keys%20%28%60%22projectID%22%60%2C%20%60%22containerID%22%60%2C%20%60%22serviceID%22%60%29.%20Structured%20log%20queries%20that%20previously%20filtered%20on%20these%20specific%20field%20names%20%28e.g.%20%60projectID%3D%22abc%22%60%29%20will%20no%20longer%20match%20these%20log%20lines.%20Consider%20keeping%20a%20%60kind%60%20field%20alongside%20%60resourceID%60%20so%20callers%20can%20distinguish%20log%20events%20by%20resource%20type%20without%20losing%20filtering%20ability.%0A%0A%60%60%60suggestion%0A%09slog.Warn%28resourceLabel%2B%22%20failed%22%2C%20%22kind%22%2C%20resourceLabel%2C%20%22resourceID%22%2C%20resourceID%2C%20%22error%22%2C%20err%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/internal/api/ws_handler.go
Line: 101

Comment:
**Generic slog key drops domain context**

The unified `broadcastLogStreamErrorInternal` uses `"resourceID"` for all three stream kinds, replacing the original type-specific keys (`"projectID"`, `"containerID"`, `"serviceID"`). Structured log queries that previously filtered on these specific field names (e.g. `projectID="abc"`) will no longer match these log lines. Consider keeping a `kind` field alongside `resourceID` so callers can distinguish log events by resource type without losing filtering ability.

```suggestion
	slog.Warn(resourceLabel+" failed", "kind", resourceLabel, "resourceID", resourceID, "error", err)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["refactor: consolidate helpers and dedupe..."](https://github.com/getarcaneapp/arcane/commit/85164a4f4c7a7e8f049bd4fd6cc3f08bd6e202a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29682336)</sub>

<!-- /greptile_comment -->