### PR TITLE
refactor: split ws_handler and skip pagination counts when not needed

### DIFF
--- a/backend/internal/api/ws_handler.go
+++ b/backend/internal/api/ws_handler.go
@@ -1,17 +1,12 @@
 package api
 
 import (
-	"bytes"
 	"context"
-	"encoding/csv"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
-	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
@@ -24,6 +19,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/middleware"
 	"github.com/getarcaneapp/arcane/backend/internal/services"
 	docker "github.com/getarcaneapp/arcane/backend/pkg/dockerutil"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/system"
 	ws "github.com/getarcaneapp/arcane/backend/pkg/libarcane/ws"
 	httputil "github.com/getarcaneapp/arcane/backend/pkg/utils/httpx"
 	systemtypes "github.com/getarcaneapp/arcane/types/system"
@@ -35,13 +31,7 @@ import (
 	"github.com/shirou/gopsutil/v4/mem"
 )
 
-const (
-	gpuCacheDuration = 30 * time.Second
-	cgroupCacheTTL   = 30 * time.Second
-)
-
-// amdGPUSysfsPath is the base path for AMD GPU sysfs entries
-const amdGPUSysfsPath = "/sys/class/drm"
+const cgroupCacheTTL = 30 * time.Second
 
 // ============================================================================
 // WebSocket Metrics
@@ -184,33 +174,18 @@ type WebSocketHandler struct {
 		ready       chan struct{}
 		running     bool
 	}
-	cgroupCache struct {
-		sync.RWMutex
-		value     *docker.CgroupLimits
-		detected  bool
-		timestamp time.Time
-	}
+	cgroupCache *system.CgroupCache
+	gpuMonitor  *system.GPUMonitor
+
 	diskUsagePathCache struct {
 		sync.RWMutex
 		value     string
 		timestamp time.Time
 	}
-	gpuDetectionCache struct {
-		sync.RWMutex
-		detected  bool
-		timestamp time.Time
-		gpuType   string
-		toolPath  string
-	}
-	detectionDone        bool
-	detectionMutex       sync.Mutex
-	gpuMonitoringEnabled bool
-	gpuType              string
 	projectLogStreamer   func(ctx context.Context, projectID string, logsChan chan<- string, follow bool, tail, since string, timestamps bool) error
 	containerLogStreamer func(ctx context.Context, containerID string, logsChan chan<- string, follow bool, tail, since string, timestamps bool) error
 	systemStatsCollector func(ctx context.Context) systemtypes.SystemStats
 	cpuUsageReader       func(interval time.Duration) (float64, bool)
-	cgroupLimitsDetector func() (*docker.CgroupLimits, error)
 }
 
 type wsLogStream struct {
@@ -346,14 +321,14 @@ func NewWebSocketHandler(
 	cfg *config.Config,
 ) {
 	handler := &WebSocketHandler{
-		projectService:       projectService,
-		containerService:     containerService,
-		swarmService:         swarmService,
-		systemService:        systemService,
-		wsMetrics:            defaultWebSocketMetrics,
-		logStreams:           make(map[string]*wsLogStream),
-		gpuMonitoringEnabled: cfg.GPUMonitoringEnabled,
-		gpuType:              cfg.GPUType,
+		projectService:   projectService,
+		containerService: containerService,
+		swarmService:     swarmService,
+		systemService:    systemService,
+		wsMetrics:        defaultWebSocketMetrics,
+		logStreams:       make(map[string]*wsLogStream),
+		cgroupCache:      system.NewCgroupCache(cgroupCacheTTL),
+		gpuMonitor:       system.NewGPUMonitor(cfg.GPUMonitoringEnabled, cfg.GPUType),
 		wsUpgrader: websocket.Upgrader{
 			CheckOrigin:       httputil.ValidateWebSocketOrigin(cfg.GetAppURL()),
 			ReadBufferSize:    32 * 1024,
@@ -1273,10 +1248,10 @@ func (h *WebSocketHandler) getHostname() string {
 
 // getGPUInfo returns GPU statistics if monitoring is enabled.
 func (h *WebSocketHandler) getGPUInfo(ctx context.Context) ([]systemtypes.GPUStats, int) {
-	if !h.gpuMonitoringEnabled {
+	if h.gpuMonitor == nil || !h.gpuMonitor.Enabled() {
 		return nil, 0
 	}
-	gpuData, err := h.getGPUStats(ctx)
+	gpuData, err := h.gpuMonitor.Stats(ctx)
 	if err != nil {
 		return nil, 0
 	}
@@ -1336,47 +1311,10 @@ func (h *WebSocketHandler) storeCPUCacheValueInternal(value float64) {
 }
 
 func (h *WebSocketHandler) getCachedCgroupLimitsInternal() *docker.CgroupLimits {
-	h.cgroupCache.RLock()
-	value := h.cgroupCache.value
-	detected := h.cgroupCache.detected
-	fresh := time.Since(h.cgroupCache.timestamp) < cgroupCacheTTL
-	h.cgroupCache.RUnlock()
-	if fresh {
-		if detected {
-			return value
-		}
+	if h.cgroupCache == nil {
 		return nil
 	}
-
-	h.cgroupCache.Lock()
-	defer h.cgroupCache.Unlock()
-
-	if time.Since(h.cgroupCache.timestamp) < cgroupCacheTTL {
-		if h.cgroupCache.detected {
-			return h.cgroupCache.value
-		}
-		return nil
-	}
-
-	detect := h.cgroupLimitsDetector
-	if detect == nil {
-		detect = docker.DetectCgroupLimits
-	}
-
-	limits, err := detect()
-	h.cgroupCache.timestamp = time.Now()
-	if err != nil {
-		h.cgroupCache.value = nil
-		h.cgroupCache.detected = false
-	} else {
-		h.cgroupCache.value = limits
-		h.cgroupCache.detected = true
-	}
-	if !h.cgroupCache.detected {
-		return nil
-	}
-
-	return h.cgroupCache.value
+	return h.cgroupCache.Get()
 }
 
 // SystemStats streams system stats over WebSocket.
@@ -1510,326 +1448,4 @@ func (h *WebSocketHandler) getDiskUsagePath(ctx context.Context) string {
 	h.diskUsagePathCache.Unlock()
 
 	return path
-}
-
-// ============================================================================
-// GPU Monitoring
-// ============================================================================
-
-// getGPUStats collects and returns GPU statistics for all available GPUs
-func (h *WebSocketHandler) getGPUStats(ctx context.Context) ([]systemtypes.GPUStats, error) {
-	h.detectionMutex.Lock()
-	done := h.detectionDone
-	h.detectionMutex.Unlock()
-
-	if !done {
-		if err := h.detectGPUs(ctx); err != nil {
-			return nil, err
-		}
-	}
-
-	h.gpuDetectionCache.RLock()
-	if h.gpuDetectionCache.detected && time.Since(h.gpuDetectionCache.timestamp) < gpuCacheDuration {
-		gpuType := h.gpuDetectionCache.gpuType
-		h.gpuDetectionCache.RUnlock()
-
-		switch gpuType {
-		case "nvidia":
-			return h.getNvidiaStats(ctx)
-		case "amd":
-			return h.getAMDStats(ctx)
-		case "intel":
-			return h.getIntelStats(ctx)
-		}
-	}
-	h.gpuDetectionCache.RUnlock()
-
-	if err := h.detectGPUs(ctx); err != nil {
-		return nil, err
-	}
-
-	h.gpuDetectionCache.RLock()
-	gpuType := h.gpuDetectionCache.gpuType
-	h.gpuDetectionCache.RUnlock()
-
-	switch gpuType {
-	case "nvidia":
-		return h.getNvidiaStats(ctx)
-	case "amd":
-		return h.getAMDStats(ctx)
-	case "intel":
-		return h.getIntelStats(ctx)
-	default:
-		return nil, fmt.Errorf("no supported GPU found")
-	}
-}
-
-// detectGPUs detects available GPU management tools
-func (h *WebSocketHandler) detectGPUs(ctx context.Context) error {
-	h.detectionMutex.Lock()
-	defer h.detectionMutex.Unlock()
-
-	if h.gpuType != "" && h.gpuType != "auto" {
-		switch h.gpuType {
-		case "nvidia":
-			if path, err := exec.LookPath("nvidia-smi"); err == nil {
-				h.gpuDetectionCache.Lock()
-				h.gpuDetectionCache.detected = true
-				h.gpuDetectionCache.gpuType = "nvidia"
-				h.gpuDetectionCache.toolPath = path
-				h.gpuDetectionCache.timestamp = time.Now()
-				h.gpuDetectionCache.Unlock()
-				h.detectionDone = true
-				slog.InfoContext(ctx, "Using configured GPU type", "type", "nvidia")
-				return nil
-			}
-			return fmt.Errorf("nvidia-smi not found but GPU_TYPE set to nvidia")
-
-		case "amd":
-			if hasAMDGPUInternal() {
-				h.gpuDetectionCache.Lock()
-				h.gpuDetectionCache.detected = true
-				h.gpuDetectionCache.gpuType = "amd"
-				h.gpuDetectionCache.toolPath = amdGPUSysfsPath
-				h.gpuDetectionCache.timestamp = time.Now()
-				h.gpuDetectionCache.Unlock()
-				h.detectionDone = true
-				slog.InfoContext(ctx, "Using configured GPU type", "type", "amd")
-				return nil
-			}
-			return fmt.Errorf("AMD GPU not found in sysfs but GPU_TYPE set to amd")
-
-		case "intel":
-			if path, err := exec.LookPath("intel_gpu_top"); err == nil {
-				h.gpuDetectionCache.Lock()
-				h.gpuDetectionCache.detected = true
-				h.gpuDetectionCache.gpuType = "intel"
-				h.gpuDetectionCache.toolPath = path
-				h.gpuDetectionCache.timestamp = time.Now()
-				h.gpuDetectionCache.Unlock()
-				h.detectionDone = true
-				slog.InfoContext(ctx, "Using configured GPU type", "type", "intel")
-				return nil
-			}
-			return fmt.Errorf("intel_gpu_top not found but GPU_TYPE set to intel")
-
-		default:
-			slog.WarnContext(ctx, "Invalid GPU_TYPE specified, falling back to auto-detection", "gpu_type", h.gpuType)
-		}
-	}
-
-	if path, err := exec.LookPath("nvidia-smi"); err == nil {
-		h.gpuDetectionCache.Lock()
-		h.gpuDetectionCache.detected = true
-		h.gpuDetectionCache.gpuType = "nvidia"
-		h.gpuDetectionCache.toolPath = path
-		h.gpuDetectionCache.timestamp = time.Now()
-		h.gpuDetectionCache.Unlock()
-		h.detectionDone = true
-		slog.InfoContext(ctx, "NVIDIA GPU detected", "tool", "nvidia-smi", "path", path)
-		return nil
-	}
-
-	if hasAMDGPUInternal() {
-		h.gpuDetectionCache.Lock()
-		h.gpuDetectionCache.detected = true
-		h.gpuDetectionCache.gpuType = "amd"
-		h.gpuDetectionCache.toolPath = amdGPUSysfsPath
-		h.gpuDetectionCache.timestamp = time.Now()
-		h.gpuDetectionCache.Unlock()
-		h.detectionDone = true
-		slog.InfoContext(ctx, "AMD GPU detected", "method", "sysfs", "path", amdGPUSysfsPath)
-		return nil
-	}
-
-	if path, err := exec.LookPath("intel_gpu_top"); err == nil {
-		h.gpuDetectionCache.Lock()
-		h.gpuDetectionCache.detected = true
-		h.gpuDetectionCache.gpuType = "intel"
-		h.gpuDetectionCache.toolPath = path
-		h.gpuDetectionCache.timestamp = time.Now()
-		h.gpuDetectionCache.Unlock()
-		h.detectionDone = true
-		slog.InfoContext(ctx, "Intel GPU detected", "tool", "intel_gpu_top", "path", path)
-		return nil
-	}
-
-	h.detectionDone = true
-	return fmt.Errorf("no supported GPU found")
-}
-
-// getNvidiaStats collects NVIDIA GPU statistics using nvidia-smi
-func (h *WebSocketHandler) getNvidiaStats(ctx context.Context) ([]systemtypes.GPUStats, error) {
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "nvidia-smi",
-		"--query-gpu=index,name,memory.used,memory.total",
-		"--format=csv,noheader,nounits")
-
-	output, err := cmd.Output()
-	if err != nil {
-		slog.WarnContext(ctx, "Failed to execute nvidia-smi", "error", err)
-		return nil, fmt.Errorf("nvidia-smi execution failed: %w", err)
-	}
-
-	reader := csv.NewReader(bytes.NewReader(output))
-	reader.TrimLeadingSpace = true
-
-	records, err := reader.ReadAll()
-	if err != nil {
-		slog.WarnContext(ctx, "Failed to parse nvidia-smi CSV output", "error", err)
-		return nil, fmt.Errorf("failed to parse nvidia-smi output: %w", err)
-	}
-
-	var stats []systemtypes.GPUStats
-	for _, record := range records {
-		if len(record) < 4 {
-			continue
-		}
-
-		index, err := strconv.Atoi(strings.TrimSpace(record[0]))
-		if err != nil {
-			slog.WarnContext(ctx, "Failed to parse GPU index", "value", record[0])
-			continue
-		}
-
-		name := strings.TrimSpace(record[1])
-
-		memUsed, err := strconv.ParseFloat(strings.TrimSpace(record[2]), 64)
-		if err != nil {
-			slog.WarnContext(ctx, "Failed to parse memory used", "value", record[2])
-			continue
-		}
-
-		memTotal, err := strconv.ParseFloat(strings.TrimSpace(record[3]), 64)
-		if err != nil {
-			slog.WarnContext(ctx, "Failed to parse memory total", "value", record[3])
-			continue
-		}
-
-		stats = append(stats, systemtypes.GPUStats{
-			Name:        name,
-			Index:       index,
-			MemoryUsed:  memUsed * 1024 * 1024,
-			MemoryTotal: memTotal * 1024 * 1024,
-		})
-	}
-
-	if len(stats) == 0 {
-		return nil, fmt.Errorf("no GPU data parsed from nvidia-smi")
-	}
-
-	slog.DebugContext(ctx, "Collected NVIDIA GPU stats", "gpu_count", len(stats))
-	return stats, nil
-}
-
-// getAMDStats collects AMD GPU statistics using sysfs
-func (h *WebSocketHandler) getAMDStats(ctx context.Context) ([]systemtypes.GPUStats, error) {
-	var stats []systemtypes.GPUStats
-
-	// Find AMD GPU cards by looking for mem_info_vram_total in /sys/class/drm/card*/device/
-	entries, err := os.ReadDir(amdGPUSysfsPath)
-	if err != nil {
-		slog.WarnContext(ctx, "Failed to read DRM sysfs directory", "error", err)
-		return nil, fmt.Errorf("failed to read sysfs: %w", err)
-	}
-
-	index := 0
-	for _, entry := range entries {
-		name := entry.Name()
-		// Only check card* entries (card0, card1, etc.) - skip renderD* and connector entries
-		if !strings.HasPrefix(name, "card") {
-			continue
-		}
-		// Skip connector entries like card0-DP-1, card0-HDMI-A-1
-		if strings.Contains(name, "-") {
-			continue
-		}
-
-		devicePath := fmt.Sprintf("%s/%s/device", amdGPUSysfsPath, name)
-
-		// Check if this is an AMD GPU by looking for VRAM info files
-		memTotalPath := fmt.Sprintf("%s/mem_info_vram_total", devicePath)
-		memUsedPath := fmt.Sprintf("%s/mem_info_vram_used", devicePath)
-
-		memTotalBytes, err := readSysfsValueInternal(memTotalPath)
-		if err != nil {
-			// Not an AMD GPU or doesn't have VRAM info
-			continue
-		}
-
-		memUsedBytes, err := readSysfsValueInternal(memUsedPath)
-		if err != nil {
-			slog.WarnContext(ctx, "Failed to read AMD GPU memory used", "card", name, "error", err)
-			continue
-		}
-
-		stats = append(stats, systemtypes.GPUStats{
-			Name:        fmt.Sprintf("AMD GPU %d", index),
-			Index:       index,
-			MemoryUsed:  float64(memUsedBytes),
-			MemoryTotal: float64(memTotalBytes),
-		})
-		index++
-	}
-
-	if len(stats) == 0 {
-		return nil, fmt.Errorf("no AMD GPU data found in sysfs")
-	}
-
-	slog.DebugContext(ctx, "Collected AMD GPU stats", "gpu_count", len(stats))
-	return stats, nil
-}
-
-// readSysfsValueInternal reads a numeric value from a sysfs file
-func readSysfsValueInternal(path string) (uint64, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return 0, err
-	}
-	return strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
-}
-
-// hasAMDGPUInternal checks if an AMD GPU is present by looking for VRAM info in sysfs
-func hasAMDGPUInternal() bool {
-	entries, err := os.ReadDir(amdGPUSysfsPath)
-	if err != nil {
-		return false
-	}
-
-	for _, entry := range entries {
-		name := entry.Name()
-		// Only check card* entries (card0, card1, etc.) - skip card0-DP-1 style entries
-		if !strings.HasPrefix(name, "card") {
-			continue
-		}
-		// Skip connector entries like card0-DP-1, card0-HDMI-A-1
-		if strings.Contains(name, "-") {
-			continue
-		}
-
-		// Check if this card has AMD VRAM info
-		memTotalPath := fmt.Sprintf("%s/%s/device/mem_info_vram_total", amdGPUSysfsPath, name)
-		if _, err := os.Stat(memTotalPath); err == nil {
-			return true
-		}
-	}
-
-	return false
-}
-
-// getIntelStats collects Intel GPU statistics using intel_gpu_top
-func (h *WebSocketHandler) getIntelStats(ctx context.Context) ([]systemtypes.GPUStats, error) {
-	stats := []systemtypes.GPUStats{
-		{
-			Name:        "Intel GPU",
-			Index:       0,
-			MemoryUsed:  0,
-			MemoryTotal: 0,
-		},
-	}
-
-	slog.DebugContext(ctx, "Intel GPU detected but detailed stats not yet implemented")
-	return stats, nil
 }

--- a/backend/internal/api/ws_handler_test.go
+++ b/backend/internal/api/ws_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	docker "github.com/getarcaneapp/arcane/backend/pkg/dockerutil"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/system"
 	ws "github.com/getarcaneapp/arcane/backend/pkg/libarcane/ws"
 	systemtypes "github.com/getarcaneapp/arcane/types/system"
 	"github.com/gin-gonic/gin"
@@ -105,8 +106,10 @@ func newTestWSPairInternal(t *testing.T) (clientConn *websocket.Conn, serverConn
 
 func newTestWebSocketHandler() *WebSocketHandler {
 	return &WebSocketHandler{
-		wsMetrics:  NewWebSocketMetrics(),
-		logStreams: make(map[string]*wsLogStream),
+		wsMetrics:   NewWebSocketMetrics(),
+		logStreams:  make(map[string]*wsLogStream),
+		cgroupCache: system.NewCgroupCache(cgroupCacheTTL),
+		gpuMonitor:  system.NewGPUMonitor(false, ""),
 		wsUpgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool { return true },
 		},
@@ -575,17 +578,18 @@ func TestWebSocketHandler_LogStream_CancelsOnlyOnce(t *testing.T) {
 
 func TestWebSocketHandler_GetCachedCgroupLimitsInternal_DeduplicatesRefresh(t *testing.T) {
 	handler := newTestWebSocketHandler()
-	handler.cgroupCache.timestamp = time.Now().Add(-2 * cgroupCacheTTL)
 
 	var calls atomic.Int32
 	start := make(chan struct{})
 	release := make(chan struct{})
-	handler.cgroupLimitsDetector = func() (*docker.CgroupLimits, error) {
+	// A fresh cache has a zero timestamp, so the first Get takes the refresh path
+	// and subsequent concurrent Gets dedupe behind the write lock.
+	handler.cgroupCache = system.NewCgroupCacheWithDetector(cgroupCacheTTL, func() (*docker.CgroupLimits, error) {
 		calls.Add(1)
 		close(start)
 		<-release
 		return &docker.CgroupLimits{CPUCount: 2}, nil
-	}
+	})
 
 	const goroutines = 8
 	results := make(chan *docker.CgroupLimits, goroutines)

--- a/backend/pkg/libarcane/system/cgroup.go
+++ b/backend/pkg/libarcane/system/cgroup.go
@@ -1,0 +1,70 @@
+// Package system encapsulates host-level resource probing used by the WebSocket system stats
+// endpoint: cgroup limits and GPU detection/stats. The types here own their own caching and
+// synchronization so handlers can hold them as plain fields.
+package system
+
+import (
+	"sync"
+	"time"
+
+	docker "github.com/getarcaneapp/arcane/backend/pkg/dockerutil"
+)
+
+// CgroupCache memoizes the result of cgroup limit detection for a configurable TTL.
+// A single in-flight refresh is shared across concurrent callers (singleflight semantics
+// via the write lock), so a stampede of system-stats samplers never duplicates the work.
+type CgroupCache struct {
+	mu        sync.RWMutex
+	value     *docker.CgroupLimits
+	detected  bool
+	timestamp time.Time
+	ttl       time.Duration
+	detector  func() (*docker.CgroupLimits, error)
+}
+
+// NewCgroupCache returns a cache that caches detection results for ttl using the
+// default docker.DetectCgroupLimits detector.
+func NewCgroupCache(ttl time.Duration) *CgroupCache {
+	return NewCgroupCacheWithDetector(ttl, docker.DetectCgroupLimits)
+}
+
+// NewCgroupCacheWithDetector returns a cache backed by a custom detector. Useful when
+// callers (e.g. tests) need to control detection behaviour or simulate failures.
+func NewCgroupCacheWithDetector(ttl time.Duration, detector func() (*docker.CgroupLimits, error)) *CgroupCache {
+	return &CgroupCache{ttl: ttl, detector: detector}
+}
+
+// Get returns the cached cgroup limits, refreshing if the entry is older than the TTL.
+// Returns nil when no cgroup limits have been detected (host is not running under cgroups).
+func (c *CgroupCache) Get() *docker.CgroupLimits {
+	c.mu.RLock()
+	value, detected, fresh := c.value, c.detected, time.Since(c.timestamp) < c.ttl
+	c.mu.RUnlock()
+	if fresh {
+		if detected {
+			return value
+		}
+		return nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if time.Since(c.timestamp) < c.ttl {
+		if c.detected {
+			return c.value
+		}
+		return nil
+	}
+
+	limits, err := c.detector()
+	c.timestamp = time.Now()
+	if err != nil {
+		c.value = nil
+		c.detected = false
+		return nil
+	}
+	c.value = limits
+	c.detected = true
+	return c.value
+}

--- a/backend/pkg/libarcane/system/gpu.go
+++ b/backend/pkg/libarcane/system/gpu.go
@@ -1,0 +1,301 @@
+package system
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	systemtypes "github.com/getarcaneapp/arcane/types/system"
+)
+
+// AMDGPUSysfsPath is the sysfs base used to discover AMD GPUs.
+const AMDGPUSysfsPath = "/sys/class/drm"
+
+// gpuDetectionTTL bounds how long a successful detection result is reused before re-detecting.
+const gpuDetectionTTL = 30 * time.Second
+
+// GPUMonitor probes for an attached GPU (NVIDIA / AMD / Intel) and reports VRAM usage.
+// Detection is cached for gpuDetectionTTL; once a vendor is detected, subsequent Stats
+// calls invoke the vendor-specific tool directly.
+type GPUMonitor struct {
+	enabled        bool
+	configuredType string
+
+	detectionMu   sync.Mutex
+	detectionDone bool
+
+	cacheMu   sync.RWMutex
+	detected  bool
+	timestamp time.Time
+	gpuType   string
+	toolPath  string
+}
+
+// NewGPUMonitor creates a monitor. enabled gates Stats; when false, Stats returns
+// (nil, nil). configuredType is the user-pinned vendor ("nvidia"|"amd"|"intel"|"auto"|"")
+// — anything else falls back to auto-detection.
+func NewGPUMonitor(enabled bool, configuredType string) *GPUMonitor {
+	return &GPUMonitor{enabled: enabled, configuredType: configuredType}
+}
+
+// Enabled reports whether GPU monitoring is on.
+func (m *GPUMonitor) Enabled() bool { return m.enabled }
+
+// Stats returns per-GPU VRAM stats. Returns (nil, 0, nil) when monitoring is disabled
+// or no GPU is detected; vendor-specific errors are propagated otherwise.
+func (m *GPUMonitor) Stats(ctx context.Context) ([]systemtypes.GPUStats, error) {
+	if !m.enabled {
+		return nil, nil
+	}
+
+	m.detectionMu.Lock()
+	done := m.detectionDone
+	m.detectionMu.Unlock()
+	if !done {
+		if err := m.detectInternal(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	m.cacheMu.RLock()
+	if m.detected && time.Since(m.timestamp) < gpuDetectionTTL {
+		t := m.gpuType
+		m.cacheMu.RUnlock()
+		return m.statsForTypeInternal(ctx, t)
+	}
+	m.cacheMu.RUnlock()
+
+	if err := m.detectInternal(ctx); err != nil {
+		return nil, err
+	}
+
+	m.cacheMu.RLock()
+	t := m.gpuType
+	m.cacheMu.RUnlock()
+	if t == "" {
+		return nil, fmt.Errorf("no supported GPU found")
+	}
+	return m.statsForTypeInternal(ctx, t)
+}
+
+func (m *GPUMonitor) statsForTypeInternal(ctx context.Context, gpuType string) ([]systemtypes.GPUStats, error) {
+	switch gpuType {
+	case "nvidia":
+		return getNvidiaStatsInternal(ctx)
+	case "amd":
+		return getAMDStatsInternal(ctx)
+	case "intel":
+		return getIntelStatsInternal(ctx)
+	default:
+		return nil, fmt.Errorf("no supported GPU found")
+	}
+}
+
+// markDetected records a successful detection. Caller must NOT hold cacheMu.
+func (m *GPUMonitor) markDetectedInternal(gpuType, toolPath string) {
+	m.cacheMu.Lock()
+	m.detected = true
+	m.gpuType = gpuType
+	m.toolPath = toolPath
+	m.timestamp = time.Now()
+	m.cacheMu.Unlock()
+	m.detectionDone = true
+}
+
+// detect runs vendor probing under detectionMu. The configuredType pin is honored when set
+// to a known vendor; otherwise vendors are tried in order: nvidia → amd → intel.
+func (m *GPUMonitor) detectInternal(ctx context.Context) error {
+	m.detectionMu.Lock()
+	defer m.detectionMu.Unlock()
+
+	if t := m.configuredType; t != "" && t != "auto" {
+		switch t {
+		case "nvidia":
+			if path, err := exec.LookPath("nvidia-smi"); err == nil {
+				m.markDetectedInternal("nvidia", path)
+				slog.InfoContext(ctx, "Using configured GPU type", "type", "nvidia")
+				return nil
+			}
+			return fmt.Errorf("nvidia-smi not found but GPU_TYPE set to nvidia")
+		case "amd":
+			if HasAMDGPU() {
+				m.markDetectedInternal("amd", AMDGPUSysfsPath)
+				slog.InfoContext(ctx, "Using configured GPU type", "type", "amd")
+				return nil
+			}
+			return fmt.Errorf("AMD GPU not found in sysfs but GPU_TYPE set to amd")
+		case "intel":
+			if path, err := exec.LookPath("intel_gpu_top"); err == nil {
+				m.markDetectedInternal("intel", path)
+				slog.InfoContext(ctx, "Using configured GPU type", "type", "intel")
+				return nil
+			}
+			return fmt.Errorf("intel_gpu_top not found but GPU_TYPE set to intel")
+		default:
+			slog.WarnContext(ctx, "Invalid GPU_TYPE specified, falling back to auto-detection", "gpu_type", t)
+		}
+	}
+
+	if path, err := exec.LookPath("nvidia-smi"); err == nil {
+		m.markDetectedInternal("nvidia", path)
+		slog.InfoContext(ctx, "NVIDIA GPU detected", "tool", "nvidia-smi", "path", path)
+		return nil
+	}
+	if HasAMDGPU() {
+		m.markDetectedInternal("amd", AMDGPUSysfsPath)
+		slog.InfoContext(ctx, "AMD GPU detected", "method", "sysfs", "path", AMDGPUSysfsPath)
+		return nil
+	}
+	if path, err := exec.LookPath("intel_gpu_top"); err == nil {
+		m.markDetectedInternal("intel", path)
+		slog.InfoContext(ctx, "Intel GPU detected", "tool", "intel_gpu_top", "path", path)
+		return nil
+	}
+
+	m.detectionDone = true
+	return fmt.Errorf("no supported GPU found")
+}
+
+// HasAMDGPU reports whether a card with mem_info_vram_total exists under AMDGPUSysfsPath.
+func HasAMDGPU() bool {
+	entries, err := os.ReadDir(AMDGPUSysfsPath)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, "card") || strings.Contains(name, "-") {
+			continue
+		}
+		if _, err := os.Stat(fmt.Sprintf("%s/%s/device/mem_info_vram_total", AMDGPUSysfsPath, name)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// readSysfsValueInternal parses a numeric value from a sysfs file.
+func readSysfsValueInternal(path string) (uint64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+}
+
+func getNvidiaStatsInternal(ctx context.Context) ([]systemtypes.GPUStats, error) {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "nvidia-smi",
+		"--query-gpu=index,name,memory.used,memory.total",
+		"--format=csv,noheader,nounits")
+
+	output, err := cmd.Output()
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to execute nvidia-smi", "error", err)
+		return nil, fmt.Errorf("nvidia-smi execution failed: %w", err)
+	}
+
+	reader := csv.NewReader(bytes.NewReader(output))
+	reader.TrimLeadingSpace = true
+	records, err := reader.ReadAll()
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to parse nvidia-smi CSV output", "error", err)
+		return nil, fmt.Errorf("failed to parse nvidia-smi output: %w", err)
+	}
+
+	var stats []systemtypes.GPUStats
+	for _, record := range records {
+		if len(record) < 4 {
+			continue
+		}
+		index, err := strconv.Atoi(strings.TrimSpace(record[0]))
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to parse GPU index", "value", record[0])
+			continue
+		}
+		memUsed, err := strconv.ParseFloat(strings.TrimSpace(record[2]), 64)
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to parse memory used", "value", record[2])
+			continue
+		}
+		memTotal, err := strconv.ParseFloat(strings.TrimSpace(record[3]), 64)
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to parse memory total", "value", record[3])
+			continue
+		}
+		stats = append(stats, systemtypes.GPUStats{
+			Name:        strings.TrimSpace(record[1]),
+			Index:       index,
+			MemoryUsed:  memUsed * 1024 * 1024,
+			MemoryTotal: memTotal * 1024 * 1024,
+		})
+	}
+
+	if len(stats) == 0 {
+		return nil, fmt.Errorf("no GPU data parsed from nvidia-smi")
+	}
+
+	slog.DebugContext(ctx, "Collected NVIDIA GPU stats", "gpu_count", len(stats))
+	return stats, nil
+}
+
+func getAMDStatsInternal(ctx context.Context) ([]systemtypes.GPUStats, error) {
+	entries, err := os.ReadDir(AMDGPUSysfsPath)
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to read DRM sysfs directory", "error", err)
+		return nil, fmt.Errorf("failed to read sysfs: %w", err)
+	}
+
+	var stats []systemtypes.GPUStats
+	index := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, "card") || strings.Contains(name, "-") {
+			continue
+		}
+
+		devicePath := fmt.Sprintf("%s/%s/device", AMDGPUSysfsPath, name)
+		memTotalBytes, err := readSysfsValueInternal(fmt.Sprintf("%s/mem_info_vram_total", devicePath))
+		if err != nil {
+			continue
+		}
+		memUsedBytes, err := readSysfsValueInternal(fmt.Sprintf("%s/mem_info_vram_used", devicePath))
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to read AMD GPU memory used", "card", name, "error", err)
+			continue
+		}
+
+		stats = append(stats, systemtypes.GPUStats{
+			Name:        fmt.Sprintf("AMD GPU %d", index),
+			Index:       index,
+			MemoryUsed:  float64(memUsedBytes),
+			MemoryTotal: float64(memTotalBytes),
+		})
+		index++
+	}
+
+	if len(stats) == 0 {
+		return nil, fmt.Errorf("no AMD GPU data found in sysfs")
+	}
+
+	slog.DebugContext(ctx, "Collected AMD GPU stats", "gpu_count", len(stats))
+	return stats, nil
+}
+
+func getIntelStatsInternal(ctx context.Context) ([]systemtypes.GPUStats, error) {
+	stats := []systemtypes.GPUStats{
+		{Name: "Intel GPU", Index: 0, MemoryUsed: 0, MemoryTotal: 0},
+	}
+	slog.DebugContext(ctx, "Intel GPU detected but detailed stats not yet implemented")
+	return stats, nil
+}

--- a/backend/pkg/pagination/pagination.go
+++ b/backend/pkg/pagination/pagination.go
@@ -3,7 +3,15 @@ package pagination
 type PaginationParams struct {
 	Start int
 	Limit int
+	// SkipCount opts out of the COUNT(*) query that backs TotalItems/TotalPages.
+	// When true, paginated DB helpers return UnknownTotal (-1) for both fields and
+	// the response is suitable for infinite-scroll UIs that don't render page numbers.
+	// Default (false) preserves the historical behaviour for all existing callers.
+	SkipCount bool
 }
+
+// UnknownTotal is the sentinel returned in TotalItems/TotalPages when SkipCount is set.
+const UnknownTotal int64 = -1
 
 func paginateItemsFunction[T any](items []T, params PaginationParams) []T {
 	if params.Limit <= 0 {

--- a/backend/pkg/pagination/reflect.go
+++ b/backend/pkg/pagination/reflect.go
@@ -35,7 +35,7 @@ func PaginateAndSortDB(params QueryParams, query *gorm.DB, result any) (Response
 	limit := params.Limit
 	// limit = -1 means "show all" - skip pagination
 	if limit == -1 {
-		return paginateDBAll(query, result)
+		return paginateDBAll(query, result, params.SkipCount)
 	}
 	if limit <= 0 {
 		limit = 20
@@ -48,18 +48,31 @@ func PaginateAndSortDB(params QueryParams, query *gorm.DB, result any) (Response
 		page = (params.Start / limit) + 1
 	}
 
-	return paginateDB(page, limit, query, result)
+	return paginateDB(page, limit, query, result, params.SkipCount)
 }
 
-// paginateDBAll returns all results without pagination limits
-func paginateDBAll(query *gorm.DB, result any) (Response, error) {
+// paginateDBAll returns all results without pagination limits.
+// When skipCount is true the COUNT(*) is elided and TotalItems/TotalPages are returned as UnknownTotal.
+// Count runs before Find so it sees a clean session (Find sets Statement.Dest in GORM v2).
+func paginateDBAll(query *gorm.DB, result any, skipCount bool) (Response, error) {
 	var totalItems int64
-	if err := query.Count(&totalItems).Error; err != nil {
-		return Response{}, err
+	if !skipCount {
+		if err := query.Count(&totalItems).Error; err != nil {
+			return Response{}, err
+		}
 	}
 
 	if err := query.Find(result).Error; err != nil {
 		return Response{}, err
+	}
+
+	if skipCount {
+		return Response{
+			TotalPages:   UnknownTotal,
+			TotalItems:   UnknownTotal,
+			CurrentPage:  1,
+			ItemsPerPage: 0,
+		}, nil
 	}
 
 	return Response{
@@ -70,7 +83,10 @@ func paginateDBAll(query *gorm.DB, result any) (Response, error) {
 	}, nil
 }
 
-func paginateDB(page int, pageSize int, query *gorm.DB, result any) (Response, error) {
+// paginateDB applies offset/limit pagination. When skipCount is true the COUNT(*) is elided
+// and TotalItems/TotalPages are returned as UnknownTotal.
+// Count runs before Find so it sees a clean session (Find sets Statement.Dest in GORM v2).
+func paginateDB(page int, pageSize int, query *gorm.DB, result any, skipCount bool) (Response, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -78,12 +94,23 @@ func paginateDB(page int, pageSize int, query *gorm.DB, result any) (Response, e
 	offset := (page - 1) * pageSize
 
 	var totalItems int64
-	if err := query.Count(&totalItems).Error; err != nil {
-		return Response{}, err
+	if !skipCount {
+		if err := query.Count(&totalItems).Error; err != nil {
+			return Response{}, err
+		}
 	}
 
 	if err := query.Offset(offset).Limit(pageSize).Find(result).Error; err != nil {
 		return Response{}, err
+	}
+
+	if skipCount {
+		return Response{
+			TotalPages:   UnknownTotal,
+			TotalItems:   UnknownTotal,
+			CurrentPage:  page,
+			ItemsPerPage: pageSize,
+		}, nil
 	}
 
 	totalPages := (totalItems + int64(pageSize) - 1) / int64(pageSize)

--- a/backend/pkg/pagination/skipcount_test.go
+++ b/backend/pkg/pagination/skipcount_test.go
@@ -1,0 +1,70 @@
+package pagination
+
+import (
+	"testing"
+
+	glsqlite "github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+type widget struct {
+	ID   string `gorm:"primaryKey"`
+	Name string `sortable:"true"`
+}
+
+func newSkipCountTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(glsqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&widget{}))
+	for i := range 5 {
+		require.NoError(t, db.Create(&widget{ID: string(rune('a' + i)), Name: string(rune('A' + i))}).Error)
+	}
+	return db
+}
+
+func TestPaginateAndSortDB_SkipCountReturnsUnknownTotals(t *testing.T) {
+	db := newSkipCountTestDB(t)
+
+	var got []widget
+	resp, err := PaginateAndSortDB(QueryParams{
+		PaginationParams: PaginationParams{Start: 0, Limit: 2, SkipCount: true},
+		SortParams:       SortParams{Sort: "Name", Order: SortOrder("asc")},
+	}, db.Model(&widget{}), &got)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Equal(t, UnknownTotal, resp.TotalItems)
+	require.Equal(t, UnknownTotal, resp.TotalPages)
+	require.Equal(t, 1, resp.CurrentPage)
+	require.Equal(t, 2, resp.ItemsPerPage)
+}
+
+func TestPaginateAndSortDB_DefaultStillCounts(t *testing.T) {
+	db := newSkipCountTestDB(t)
+
+	var got []widget
+	resp, err := PaginateAndSortDB(QueryParams{
+		PaginationParams: PaginationParams{Start: 0, Limit: 2},
+		SortParams:       SortParams{Sort: "Name", Order: SortOrder("asc")},
+	}, db.Model(&widget{}), &got)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Equal(t, int64(5), resp.TotalItems)
+	require.Equal(t, int64(3), resp.TotalPages)
+}
+
+func TestPaginateAndSortDB_SkipCountShowAll(t *testing.T) {
+	db := newSkipCountTestDB(t)
+
+	var got []widget
+	resp, err := PaginateAndSortDB(QueryParams{
+		PaginationParams: PaginationParams{Start: 0, Limit: -1, SkipCount: true},
+		SortParams:       SortParams{Sort: "Name", Order: SortOrder("asc")},
+	}, db.Model(&widget{}), &got)
+	require.NoError(t, err)
+	require.Len(t, got, 5)
+	require.Equal(t, UnknownTotal, resp.TotalItems)
+	require.Equal(t, UnknownTotal, resp.TotalPages)
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors `ws_handler.go` by extracting GPU-monitoring logic into `backend/pkg/libarcane/system/gpu.go` and cgroup-cache logic into `cgroup.go`, giving each a clean exported API (`GPUMonitor`, `CgroupCache`). It also adds a `SkipCount bool` option to `PaginationParams` that suppresses the `COUNT(*)` query for pagination callers (e.g. infinite-scroll UIs), returning `UnknownTotal` (-1) sentinels for `TotalItems`/`TotalPages`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge; the refactoring is behaviorally equivalent and all previously flagged concerns (naming convention, COUNT/Find ordering) have been addressed.

All unexported functions in the new gpu.go and cgroup.go correctly carry the Internal suffix as required by the naming rule. The COUNT query correctly runs before Find in both paginateDB and paginateDBAll, resolving the GORM session-state concern from the previous review thread. The SkipCount logic is well-tested. No new bugs or regressions found.

No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/pkg/libarcane/system/gpu.go`, line 719-795 ([link](https://github.com/getarcaneapp/arcane/blob/006bc424d36f75448512b9ffbf8c27e90a56522e/backend/pkg/libarcane/system/gpu.go#L719-L795)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unexported functions/methods missing "Internal" suffix**

   Per the project's naming convention, all unexported functions must carry the `Internal` suffix. The new `gpu.go` file introduces several that don't follow the rule: the package-level functions `readSysfsValue`, `getNvidiaStats`, `getAMDStats`, `getIntelStats`, and the `GPUMonitor` methods `detect`, `markDetected`, and `statsForType`. For comparison, the existing handler code in `ws_handler.go` correctly names similar helpers `getCachedCgroupLimitsInternal`, `storeCPUCacheValueInternal`, etc., and the functions moved out of that file previously had names like `readSysfsValueInternal` and `hasAMDGPUInternal`.

   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/pkg/libarcane/system/gpu.go
   Line: 719-795
   
   Comment:
   **Unexported functions/methods missing "Internal" suffix**
   
   Per the project's naming convention, all unexported functions must carry the `Internal` suffix. The new `gpu.go` file introduces several that don't follow the rule: the package-level functions `readSysfsValue`, `getNvidiaStats`, `getAMDStats`, `getIntelStats`, and the `GPUMonitor` methods `detect`, `markDetected`, and `statsForType`. For comparison, the existing handler code in `ws_handler.go` correctly names similar helpers `getCachedCgroupLimitsInternal`, `storeCPUCacheValueInternal`, etc., and the functions moved out of that file previously had names like `readSysfsValueInternal` and `hasAMDGPUInternal`.
   
   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22refactor%2Fclean-pt2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fclean-pt2%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Flibarcane%2Fsystem%2Fgpu.go%0ALine%3A%20719-795%0A%0AComment%3A%0A**Unexported%20functions%2Fmethods%20missing%20%22Internal%22%20suffix**%0A%0APer%20the%20project's%20naming%20convention%2C%20all%20unexported%20functions%20must%20carry%20the%20%60Internal%60%20suffix.%20The%20new%20%60gpu.go%60%20file%20introduces%20several%20that%20don't%20follow%20the%20rule%3A%20the%20package-level%20functions%20%60readSysfsValue%60%2C%20%60getNvidiaStats%60%2C%20%60getAMDStats%60%2C%20%60getIntelStats%60%2C%20and%20the%20%60GPUMonitor%60%20methods%20%60detect%60%2C%20%60markDetected%60%2C%20and%20%60statsForType%60.%20For%20comparison%2C%20the%20existing%20handler%20code%20in%20%60ws_handler.go%60%20correctly%20names%20similar%20helpers%20%60getCachedCgroupLimitsInternal%60%2C%20%60storeCPUCacheValueInternal%60%2C%20etc.%2C%20and%20the%20functions%20moved%20out%20of%20that%20file%20previously%20had%20names%20like%20%60readSysfsValueInternal%60%20and%20%60hasAMDGPUInternal%60.%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor: split ws\_handler and skip pagi..."](https://github.com/getarcaneapp/arcane/commit/ae32c0a7f591fa2533c7c4814bfe205eb41ed8d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29685138)</sub>

<!-- /greptile_comment -->