### PR TITLE
fix: include files not created with new projects

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -2618,8 +2618,12 @@ func (s *ProjectService) validateComposeContentForUpdate(ctx context.Context, pr
 		Environment: composetypes.Mapping(fullEnvMap),
 	}
 
+	missingIncludeLoader := &missingIncludeStubResourceLoaderInternal{projectPath: projectPath}
+	defer missingIncludeLoader.cleanupInternal()
+
 	err = withTransientValidationEnvFile(projectPath, effectiveEnvContent, func() error {
 		_, loadErr := loader.LoadWithContext(ctx, cfg, func(opts *loader.Options) {
+			opts.ResourceLoaders = append([]loader.ResourceLoader{missingIncludeLoader}, opts.ResourceLoaders...)
 			if validationProjectName != "" {
 				opts.SetProjectName(validationProjectName, true)
 			}
@@ -2628,6 +2632,79 @@ func (s *ProjectService) validateComposeContentForUpdate(ctx context.Context, pr
 	})
 
 	return err
+}
+
+type missingIncludeStubResourceLoaderInternal struct {
+	projectPath string
+	tempDir     string
+	stubs       map[string]string
+}
+
+func (l *missingIncludeStubResourceLoaderInternal) Accept(path string) bool {
+	_, ok := l.resolveMissingIncludeInternal(path)
+	return ok
+}
+
+func (l *missingIncludeStubResourceLoaderInternal) Load(_ context.Context, path string) (string, error) {
+	validatedPath, ok := l.resolveMissingIncludeInternal(path)
+	if !ok {
+		return "", fmt.Errorf("include file is not eligible for validation stub: %s", path)
+	}
+
+	if l.stubs == nil {
+		l.stubs = make(map[string]string)
+	}
+	if stubPath, ok := l.stubs[validatedPath]; ok {
+		return stubPath, nil
+	}
+
+	if l.tempDir == "" {
+		tempDir, err := os.MkdirTemp("", "arcane-compose-include-*")
+		if err != nil {
+			return "", fmt.Errorf("create validation include temp dir: %w", err)
+		}
+		l.tempDir = tempDir
+	}
+
+	relPath, err := filepath.Rel(l.projectPath, validatedPath)
+	if err != nil || strings.HasPrefix(relPath, "..") || filepath.IsAbs(relPath) {
+		relPath = filepath.Base(validatedPath)
+	}
+	stubPath := filepath.Join(l.tempDir, relPath)
+	if err := os.MkdirAll(filepath.Dir(stubPath), 0o755); err != nil {
+		return "", fmt.Errorf("create validation include directory: %w", err)
+	}
+	if err := os.WriteFile(stubPath, []byte("services: {}\n"), 0o600); err != nil {
+		return "", fmt.Errorf("write validation include stub: %w", err)
+	}
+
+	l.stubs[validatedPath] = stubPath
+	return stubPath, nil
+}
+
+func (l *missingIncludeStubResourceLoaderInternal) Dir(path string) string {
+	return filepath.Dir(path)
+}
+
+func (l *missingIncludeStubResourceLoaderInternal) resolveMissingIncludeInternal(path string) (string, bool) {
+	validatedPath, err := projects.ValidateIncludePathForWrite(l.projectPath, path)
+	if err != nil {
+		return "", false
+	}
+
+	if _, err := os.Stat(validatedPath); err == nil {
+		return "", false
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", false
+	}
+
+	return validatedPath, true
+}
+
+func (l *missingIncludeStubResourceLoaderInternal) cleanupInternal() {
+	if l.tempDir != "" {
+		_ = os.RemoveAll(l.tempDir)
+	}
 }
 
 func buildComposeValidationEnvironment(projectsDirectory, projectPath string, effectiveEnvContent *string) (projects.EnvMap, error) {

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -1093,6 +1093,114 @@ func TestProjectService_UpdateProject_AllowsMissingEnvFileDuringComposeValidatio
 	require.NoError(t, statErr)
 }
 
+func TestProjectService_UpdateProject_AllowsMissingLocalIncludeDuringComposeValidation(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, config.Load())
+
+	dirName := "include-new"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-missing-include"},
+		Name:      "include-new",
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	compose := `include:
+  - metadata.yaml
+services:
+  app:
+    image: nginx:alpine
+`
+
+	updated, err := svc.UpdateProject(ctx, project.ID, nil, ptr(compose), nil, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	includePath := filepath.Join(projectPath, "metadata.yaml")
+	assert.NoFileExists(t, includePath)
+
+	details, err := svc.GetProjectDetails(ctx, project.ID)
+	require.NoError(t, err)
+	require.Len(t, details.IncludeFiles, 1)
+	assert.Equal(t, "metadata.yaml", details.IncludeFiles[0].RelativePath)
+
+	includeFile, err := svc.GetProjectFileContent(ctx, project.ID, "metadata.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, "metadata.yaml", includeFile.RelativePath)
+	assert.Contains(t, includeFile.Content, "This file will be created when you save changes")
+
+	includeContent := "services: {}\n"
+	require.NoError(t, svc.UpdateProjectIncludeFile(ctx, project.ID, "metadata.yaml", includeContent, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	}))
+
+	writtenContent, err := os.ReadFile(includePath)
+	require.NoError(t, err)
+	assert.Equal(t, includeContent, string(writtenContent))
+}
+
+func TestProjectService_UpdateProject_RejectsMissingExternalIncludeDuringComposeValidation(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, config.Load())
+
+	dirName := "include-external"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-external-include"},
+		Name:      "include-external",
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	compose := `include:
+  - ../metadata.yaml
+services:
+  app:
+    image: nginx:alpine
+`
+
+	updated, err := svc.UpdateProject(ctx, project.ID, nil, ptr(compose), nil, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.Error(t, err)
+	assert.Nil(t, updated)
+	assert.Contains(t, err.Error(), "invalid compose file")
+	assert.NoFileExists(t, filepath.Join(projectsDir, "metadata.yaml"))
+	assert.NoFileExists(t, filepath.Join(projectPath, "compose.yaml"))
+}
+
 func TestProjectService_UpdateProject_UsesExistingEnvFileDuringComposeValidation(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2460

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an issue where new projects referencing include files that don't yet exist on disk would fail compose validation. It introduces `missingIncludeStubResourceLoaderInternal`, a custom `loader.ResourceLoader` that intercepts missing-but-within-project include paths during validation and serves them as empty `services: {}` stubs written to a temporary directory. The temp directory is cleaned up via `defer` after validation completes. Two tests are added: one verifying that a missing local include passes validation and that the file can subsequently be written, and one verifying that a path escaping the project directory (`../metadata.yaml`) is correctly rejected.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is well-scoped, uses the existing ValidateIncludePathForWrite security boundary, cleans up after itself, and is covered by focused tests.

No blocking issues found. The path-traversal guard is correctly delegated to the existing ValidateIncludePathForWrite function. Temp-dir cleanup is guarded by defer. The stub content (services: {}
) is a valid minimal compose file. Tests cover both the happy path and the external-path rejection case.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: include files not created with new ..."](https://github.com/getarcaneapp/arcane/commit/8e3315954fdca5c1774409fc3d7d8b31c08f5c4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30067510)</sub>

<!-- /greptile_comment -->