### PR TITLE
fix: add pagination/limits to unbounded list endpoints

### DIFF
--- a/backend/internal/common/errors.go
+++ b/backend/internal/common/errors.go
@@ -1363,6 +1363,14 @@ func (e *GitOpsSyncMappingError) Error() string {
 	return "Failed to map GitOps sync"
 }
 
+type BatchTooLargeError struct {
+	Max int
+}
+
+func (e *BatchTooLargeError) Error() string {
+	return fmt.Sprintf("Batch size exceeds maximum of %d", e.Max)
+}
+
 type VulnerabilityScanError struct {
 	Err error
 }

--- a/backend/internal/huma/handlers/image_updates.go
+++ b/backend/internal/huma/handlers/image_updates.go
@@ -203,7 +203,12 @@ func (h *ImageUpdateHandler) CheckMultipleImages(ctx context.Context, input *Che
 }
 
 func (h *ImageUpdateHandler) CheckAllImages(ctx context.Context, input *CheckAllImagesInput) (*CheckAllImagesOutput, error) {
-	results, err := h.imageUpdateService.CheckAllImages(ctx, 0, input.Body.Credentials)
+	limit := input.Body.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+
+	results, err := h.imageUpdateService.CheckAllImages(ctx, limit, input.Body.Credentials)
 	if err != nil {
 		return nil, huma.Error500InternalServerError((&common.AllImageUpdateCheckError{Err: err}).Error())
 	}

--- a/backend/internal/huma/handlers/notifications.go
+++ b/backend/internal/huma/handlers/notifications.go
@@ -23,10 +23,15 @@ type NotificationHandler struct {
 
 type GetAllNotificationSettingsInput struct {
 	EnvironmentID string `path:"id" doc:"Environment ID"`
+	Search        string `query:"search" doc:"Search query"`
+	Sort          string `query:"sort" doc:"Sort field"`
+	Order         string `query:"order" default:"asc" doc:"Sort direction"`
+	Start         int    `query:"start" default:"0" doc:"Start offset"`
+	Limit         int    `query:"limit" default:"100" doc:"Items per page"`
 }
 
 type GetAllNotificationSettingsOutput struct {
-	Body []notification.Response
+	Body base.Paginated[notification.Response]
 }
 
 type GetNotificationSettingsInput struct {
@@ -244,7 +249,48 @@ func (h *NotificationHandler) GetAllNotificationSettings(ctx context.Context, in
 		}
 	}
 
-	return &GetAllNotificationSettingsOutput{Body: responses}, nil
+	// Apply in-memory pagination with a safe default limit.
+	limit := input.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	start := input.Start
+	if start < 0 {
+		start = 0
+	}
+
+	total := int64(len(responses))
+	end := start + limit
+	if start > len(responses) {
+		start = len(responses)
+	}
+	if end > len(responses) {
+		end = len(responses)
+	}
+	paginated := responses[start:end]
+
+	totalPages := total / int64(limit)
+	if total%int64(limit) > 0 {
+		totalPages++
+	}
+	currentPage := 1
+	if limit > 0 {
+		currentPage = start/limit + 1
+	}
+
+	return &GetAllNotificationSettingsOutput{
+		Body: base.Paginated[notification.Response]{
+			Success: true,
+			Data:    paginated,
+			Pagination: base.PaginationResponse{
+				TotalPages:      totalPages,
+				TotalItems:      total,
+				CurrentPage:     currentPage,
+				ItemsPerPage:    limit,
+				GrandTotalItems: total,
+			},
+		},
+	}, nil
 }
 
 func (h *NotificationHandler) GetNotificationSettings(ctx context.Context, input *GetNotificationSettingsInput) (*GetNotificationSettingsOutput, error) {

--- a/backend/internal/huma/handlers/templates.go
+++ b/backend/internal/huma/handlers/templates.go
@@ -44,10 +44,16 @@ type ListTemplatesOutput struct {
 	Body TemplatePaginatedResponse
 }
 
-type GetAllTemplatesInput struct{}
+type GetAllTemplatesInput struct {
+	Search string `query:"search" doc:"Search query"`
+	Sort   string `query:"sort" doc:"Column to sort by"`
+	Order  string `query:"order" default:"asc" doc:"Sort direction"`
+	Start  int    `query:"start" default:"0" doc:"Start index"`
+	Limit  int    `query:"limit" default:"100" doc:"Items per page"`
+}
 
 type GetAllTemplatesOutput struct {
-	Body base.ApiResponse[[]template.Template]
+	Body TemplatePaginatedResponse
 }
 
 type GetTemplateInput struct {
@@ -420,26 +426,33 @@ func (h *TemplateHandler) ListTemplates(ctx context.Context, input *ListTemplate
 	}, nil
 }
 
-// GetAllTemplates returns all templates without pagination.
-func (h *TemplateHandler) GetAllTemplates(ctx context.Context, _ *GetAllTemplatesInput) (*GetAllTemplatesOutput, error) {
+// GetAllTemplates returns a paginated list of all templates.
+func (h *TemplateHandler) GetAllTemplates(ctx context.Context, input *GetAllTemplatesInput) (*GetAllTemplatesOutput, error) {
 	if h.templateService == nil {
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	templates, err := h.templateService.GetAllTemplates(ctx)
+	params := buildPaginationParams(0, input.Start, input.Limit, input.Sort, input.Order, input.Search)
+	if params.Limit == 0 {
+		params.Limit = 100
+	}
+
+	templates, paginationResp, err := h.templateService.GetAllTemplatesPaginated(ctx, params)
 	if err != nil {
 		return nil, huma.Error500InternalServerError((&common.TemplateListError{Err: err}).Error())
 	}
 
-	out, mapErr := mapper.MapSlice[models.ComposeTemplate, template.Template](templates)
-	if mapErr != nil {
-		return nil, huma.Error500InternalServerError((&common.TemplateMappingError{Err: mapErr}).Error())
-	}
-
 	return &GetAllTemplatesOutput{
-		Body: base.ApiResponse[[]template.Template]{
+		Body: TemplatePaginatedResponse{
 			Success: true,
-			Data:    out,
+			Data:    templates,
+			Pagination: base.PaginationResponse{
+				TotalPages:      paginationResp.TotalPages,
+				TotalItems:      paginationResp.TotalItems,
+				CurrentPage:     paginationResp.CurrentPage,
+				ItemsPerPage:    paginationResp.ItemsPerPage,
+				GrandTotalItems: paginationResp.GrandTotalItems,
+			},
 		},
 	}, nil
 }

--- a/backend/internal/huma/handlers/vulnerabilities.go
+++ b/backend/internal/huma/handlers/vulnerabilities.go
@@ -307,6 +307,8 @@ func (h *VulnerabilityHandler) ScanImage(ctx context.Context, input *ScanImageIn
 	}, nil
 }
 
+const maxScanSummariesBatchSize = 500
+
 // GetScanSummaries retrieves scan summaries for a list of image IDs.
 func (h *VulnerabilityHandler) GetScanSummaries(ctx context.Context, input *GetScanSummariesInput) (*GetScanSummariesOutput, error) {
 	if h.vulnerabilityService == nil {
@@ -323,6 +325,10 @@ func (h *VulnerabilityHandler) GetScanSummaries(ctx context.Context, input *GetS
 				},
 			},
 		}, nil
+	}
+
+	if len(imageIDs) > maxScanSummariesBatchSize {
+		return nil, huma.Error400BadRequest((&common.BatchTooLargeError{Max: maxScanSummariesBatchSize}).Error())
 	}
 
 	summaries, err := h.vulnerabilityService.GetScanSummariesByImageIDs(ctx, imageIDs)

--- a/backend/pkg/scheduler/image_polling_job.go
+++ b/backend/pkg/scheduler/image_polling_job.go
@@ -66,7 +66,7 @@ func (j *ImagePollingJob) Run(ctx context.Context) {
 		creds = nil
 	}
 
-	results, err := j.imageUpdateService.CheckAllImages(ctx, 0, creds)
+	results, err := j.imageUpdateService.CheckAllImages(ctx, 100, creds)
 	if err != nil {
 		slog.ErrorContext(ctx, "image scan failed", "err", err)
 		return

--- a/frontend/src/lib/services/image-service.ts
+++ b/frontend/src/lib/services/image-service.ts
@@ -64,9 +64,9 @@ export class ImageService extends BaseAPIService {
 		return this.handleResponse(this.api.post(`/environments/${envId}/image-updates/check/${imageId}`, {}));
 	}
 
-	async checkAllImages(): Promise<Record<string, ImageUpdateInfoDto>> {
+	async checkAllImages(limit?: number): Promise<Record<string, ImageUpdateInfoDto>> {
 		const envId = await environmentStore.getCurrentEnvironmentId();
-		return this.handleResponse(this.api.post(`/environments/${envId}/image-updates/check-all`, {}));
+		return this.handleResponse(this.api.post(`/environments/${envId}/image-updates/check-all`, { limit }));
 	}
 
 	async checkMultipleImages(imageRefs: string[]): Promise<Record<string, ImageUpdateInfoDto>> {

--- a/frontend/src/lib/services/notification-service.ts
+++ b/frontend/src/lib/services/notification-service.ts
@@ -1,11 +1,14 @@
 import BaseAPIService from './api-service';
 import type { NotificationSettings, TestNotificationResponse, AppriseSettings } from '$lib/types/notification.type';
 import { environmentStore } from '$lib/stores/environment.store.svelte';
+import type { Paginated, SearchPaginationSortRequest } from '$lib/types/pagination.type';
+import { transformPaginationParams } from '$lib/utils/params.util';
 
 export default class NotificationService extends BaseAPIService {
-	async getSettings(environmentId?: string): Promise<NotificationSettings[]> {
+	async getSettings(environmentId?: string, options?: SearchPaginationSortRequest): Promise<Paginated<NotificationSettings>> {
 		const envId = environmentId || (await environmentStore.getCurrentEnvironmentId());
-		const res = await this.api.get(`/environments/${envId}/notifications/settings`);
+		const params = transformPaginationParams(options);
+		const res = await this.api.get(`/environments/${envId}/notifications/settings`, { params });
 		return res.data;
 	}
 

--- a/frontend/src/lib/services/template-service.ts
+++ b/frontend/src/lib/services/template-service.ts
@@ -12,9 +12,10 @@ export default class TemplateService extends BaseAPIService {
 		return response.data;
 	}
 
-	async getAllTemplates(): Promise<Template[]> {
-		const response = await this.api.get('/templates/all');
-		return response.data?.data ?? [];
+	async getAllTemplates(options?: SearchPaginationSortRequest): Promise<Paginated<Template>> {
+		const params = transformPaginationParams(options);
+		const response = await this.api.get('/templates/all', { params });
+		return response.data;
 	}
 
 	async getTemplateContent(id: string): Promise<TemplateContentData> {

--- a/frontend/src/routes/(app)/customize/templates/[id]/+page.ts
+++ b/frontend/src/routes/(app)/customize/templates/[id]/+page.ts
@@ -16,7 +16,7 @@ export const load: PageLoad = async ({
 	const { queryClient } = await parent();
 
 	try {
-		const [templateData, allTemplates, globalVariables] = await Promise.all([
+		const [templateData, allTemplatesResult, globalVariables] = await Promise.all([
 			queryClient.fetchQuery({
 				queryKey: queryKeys.templates.content(params.id),
 				queryFn: () => templateService.getTemplateContent(params.id)
@@ -35,7 +35,7 @@ export const load: PageLoad = async ({
 
 		return {
 			templateData,
-			allTemplates,
+			allTemplates: allTemplatesResult.data ?? [],
 			globalVariables
 		};
 	} catch (err) {

--- a/frontend/src/routes/(app)/customize/templates/default/+page.ts
+++ b/frontend/src/routes/(app)/customize/templates/default/+page.ts
@@ -9,7 +9,7 @@ export const load: PageLoad = async ({
 }): Promise<{ composeTemplate: string; envTemplate: string; templates: Template[]; globalVariables: Variable[] }> => {
 	const { queryClient } = await parent();
 
-	const [defaultTemplates, templates, globalVariables] = await Promise.all([
+	const [defaultTemplates, allTemplatesResult, globalVariables] = await Promise.all([
 		queryClient
 			.fetchQuery({
 				queryKey: queryKeys.templates.defaults(),
@@ -26,7 +26,7 @@ export const load: PageLoad = async ({
 			})
 			.catch((err) => {
 				console.warn('Failed to load templates:', err);
-				return [];
+				return { data: [], pagination: { totalPages: 0, totalItems: 0, currentPage: 1, itemsPerPage: 100 } };
 			}),
 		queryClient
 			.fetchQuery({
@@ -42,7 +42,7 @@ export const load: PageLoad = async ({
 	return {
 		composeTemplate: defaultTemplates.composeTemplate,
 		envTemplate: defaultTemplates.envTemplate,
-		templates,
+		templates: allTemplatesResult.data ?? [],
 		globalVariables
 	};
 };

--- a/frontend/src/routes/(app)/projects/new/+page.ts
+++ b/frontend/src/routes/(app)/projects/new/+page.ts
@@ -7,7 +7,7 @@ export const load: PageLoad = async ({ url, parent }) => {
 
 	const templateId = url.searchParams.get('templateId');
 
-	const [allTemplates, defaultTemplates, selectedTemplate, globalVariables] = await Promise.all([
+	const [allTemplatesResult, defaultTemplates, selectedTemplate, globalVariables] = await Promise.all([
 		queryClient
 			.fetchQuery({
 				queryKey: queryKeys.templates.allTemplates(),
@@ -15,7 +15,7 @@ export const load: PageLoad = async ({ url, parent }) => {
 			})
 			.catch((err) => {
 				console.warn('Failed to load templates:', err);
-				return [];
+				return { data: [], pagination: { totalPages: 0, totalItems: 0, currentPage: 1, itemsPerPage: 100 } };
 			}),
 		queryClient
 			.fetchQuery({
@@ -47,6 +47,8 @@ export const load: PageLoad = async ({ url, parent }) => {
 				return [];
 			})
 	]);
+
+	const allTemplates = allTemplatesResult.data ?? [];
 
 	return {
 		composeTemplates: allTemplates,

--- a/frontend/src/routes/(app)/settings/notifications/+page.ts
+++ b/frontend/src/routes/(app)/settings/notifications/+page.ts
@@ -6,13 +6,13 @@ export const load: PageLoad = async ({ parent }) => {
 	const { queryClient } = await parent();
 
 	try {
-		const notificationSettings = await queryClient.fetchQuery({
+		const notificationSettingsResult = await queryClient.fetchQuery({
 			queryKey: queryKeys.notifications.settings(),
 			queryFn: () => notificationService.getSettings()
 		});
 
 		return {
-			notificationSettings
+			notificationSettings: notificationSettingsResult.data ?? []
 		};
 	} catch (error) {
 		console.error('Failed to load notification settings:', error);

--- a/frontend/src/routes/(app)/swarm/stacks/new/+page.ts
+++ b/frontend/src/routes/(app)/swarm/stacks/new/+page.ts
@@ -19,10 +19,10 @@ export const load: PageLoad = async ({ url }) => {
 			})
 		: Promise.resolve(null);
 
-	const [allTemplates, defaultTemplates, selectedTemplate, sourceStack, globalVariables] = await Promise.all([
+	const [allTemplatesResult, defaultTemplates, selectedTemplate, sourceStack, globalVariables] = await Promise.all([
 		templateService.getAllTemplates().catch((err) => {
 			console.warn('Failed to load templates:', err);
-			return [];
+			return { data: [], pagination: { totalPages: 0, totalItems: 0, currentPage: 1, itemsPerPage: 100 } };
 		}),
 		templateService.getDefaultTemplates().catch((err) => {
 			console.warn('Failed to load default templates:', err);
@@ -40,6 +40,8 @@ export const load: PageLoad = async ({ url }) => {
 			return [];
 		})
 	]);
+
+	const allTemplates = allTemplatesResult.data ?? [];
 
 	return {
 		composeTemplates: allTemplates,

--- a/types/imageupdate/image_update.go
+++ b/types/imageupdate/image_update.go
@@ -108,6 +108,11 @@ type BatchImageUpdateRequest struct {
 }
 
 type CheckAllImagesRequest struct {
+	// Limit caps the number of images to check. Zero or negative means default (100).
+	//
+	// Required: false
+	Limit int `json:"limit,omitempty"`
+
 	// Credentials is a list of container registry credentials for authentication.
 	//
 	// Required: false


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds pagination and batch limits to several previously unbounded list endpoints (templates, notifications, image-update check-all, vulnerability scan summaries) and updates the frontend services and page loaders to consume the new paginated responses.

- The scheduled image polling job (`image_polling_job.go`) changed from passing `0` (no limit — all images) to `100`, silently capping scheduled scans at 100 images. Any environment with more than 100 Docker images will now have incomplete update checks on every scheduled run.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge as-is; the scheduler regression will silently drop image scans for users with >100 images.

One P1 regression (scheduler hard-coded to 100 instead of unlimited) lowers the ceiling to 4 and the silent, production-impacting nature of the truncation (no warning, no log, no way for users to detect it) pulls the score down further to 3.

backend/pkg/scheduler/image_polling_job.go — limit change from 0 (unlimited) to 100 is a behavioral regression for large environments.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fmissing-template-list%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fmissing-template-list%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Fpkg%2Fscheduler%2Fimage_polling_job.go%3A69%0A**Scheduler%20silently%20truncates%20image%20scanning**%0A%0AThe%20polling%20job%20previously%20passed%20%600%60%20as%20the%20limit%20to%20%60CheckAllImages%60%2C%20which%20%60dedupeImageRefsFromSummariesInternal%60%20treats%20as%20%22no%20limit%22%20%28the%20guard%20is%20%60if%20limit%20%3E%200%20%26%26%20len%28imageRefs%29%20%3E%3D%20limit%60%29.%20Changing%20it%20to%20%60100%60%20means%20any%20environment%20with%20more%20than%20100%20Docker%20images%20will%20silently%20have%20incomplete%20update%20checks%20every%20scheduled%20run%20%E2%80%94%20images%20beyond%20position%20100%20are%20never%20scanned.%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Finternal%2Fhuma%2Fhandlers%2Fnotifications.go%3A252-278%0A**In-memory%20pagination%20provides%20no%20DB-level%20relief**%0A%0A%60GetAllSettings%60%20still%20fetches%20every%20row%20from%20the%20database%20before%20slicing%20here.%20The%20pagination%20is%20applied%20after%20the%20full%20result%20set%20is%20loaded%20into%20memory%2C%20so%20this%20doesn't%20reduce%20query%20cost%20or%20memory%20pressure%20for%20large%20datasets.%20Additionally%2C%20when%20%60total%20%3D%3D%200%60%2C%20integer%20division%20yields%20%60totalPages%20%3D%200%60%20%E2%80%94%20consumers%20expecting%20at%20least%20one%20page%20may%20behave%20unexpectedly.%20Consider%20pushing%20the%20%60LIMIT%60%2F%60OFFSET%60%20into%20the%20service%2Frepository%20layer%2C%20and%20guard%20against%20zero-item%20division%20with%20%60max%281%2C%20totalPages%29%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Fpkg%2Fscheduler%2Fimage_polling_job.go%3A69%0A**Scheduler%20silently%20truncates%20image%20scanning**%0A%0AThe%20polling%20job%20previously%20passed%20%600%60%20as%20the%20limit%20to%20%60CheckAllImages%60%2C%20which%20%60dedupeImageRefsFromSummariesInternal%60%20treats%20as%20%22no%20limit%22%20%28the%20guard%20is%20%60if%20limit%20%3E%200%20%26%26%20len%28imageRefs%29%20%3E%3D%20limit%60%29.%20Changing%20it%20to%20%60100%60%20means%20any%20environment%20with%20more%20than%20100%20Docker%20images%20will%20silently%20have%20incomplete%20update%20checks%20every%20scheduled%20run%20%E2%80%94%20images%20beyond%20position%20100%20are%20never%20scanned.%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Finternal%2Fhuma%2Fhandlers%2Fnotifications.go%3A252-278%0A**In-memory%20pagination%20provides%20no%20DB-level%20relief**%0A%0A%60GetAllSettings%60%20still%20fetches%20every%20row%20from%20the%20database%20before%20slicing%20here.%20The%20pagination%20is%20applied%20after%20the%20full%20result%20set%20is%20loaded%20into%20memory%2C%20so%20this%20doesn't%20reduce%20query%20cost%20or%20memory%20pressure%20for%20large%20datasets.%20Additionally%2C%20when%20%60total%20%3D%3D%200%60%2C%20integer%20division%20yields%20%60totalPages%20%3D%200%60%20%E2%80%94%20consumers%20expecting%20at%20least%20one%20page%20may%20behave%20unexpectedly.%20Consider%20pushing%20the%20%60LIMIT%60%2F%60OFFSET%60%20into%20the%20service%2Frepository%20layer%2C%20and%20guard%20against%20zero-item%20division%20with%20%60max%281%2C%20totalPages%29%60.%0A%0A&repo=getarcaneapp%2Farcane&pr=2466&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/scheduler/image_polling_job.go
Line: 69

Comment:
**Scheduler silently truncates image scanning**

The polling job previously passed `0` as the limit to `CheckAllImages`, which `dedupeImageRefsFromSummariesInternal` treats as "no limit" (the guard is `if limit > 0 && len(imageRefs) >= limit`). Changing it to `100` means any environment with more than 100 Docker images will silently have incomplete update checks every scheduled run — images beyond position 100 are never scanned.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/internal/huma/handlers/notifications.go
Line: 252-278

Comment:
**In-memory pagination provides no DB-level relief**

`GetAllSettings` still fetches every row from the database before slicing here. The pagination is applied after the full result set is loaded into memory, so this doesn't reduce query cost or memory pressure for large datasets. Additionally, when `total == 0`, integer division yields `totalPages = 0` — consumers expecting at least one page may behave unexpectedly. Consider pushing the `LIMIT`/`OFFSET` into the service/repository layer, and guard against zero-item division with `max(1, totalPages)`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add pagination/limits to unbounded ..."](https://github.com/getarcaneapp/arcane/commit/dd92dd9ddd636747bbc44f6150fbaac1f238f1c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30104816)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->