### PR TITLE
fix: tables are laggy when lots of rows are rendered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,9 @@ frontend/build
 build
 data/
 dist/
-arcane
-arcane-*
+/arcane
+/arcane-*
+.bin/
 
 # Claude
 CLAUDE.md

--- a/frontend/src/lib/components/arcane-table/arcane-table-desktop-view.svelte
+++ b/frontend/src/lib/components/arcane-table/arcane-table-desktop-view.svelte
@@ -66,8 +66,9 @@
 		return '';
 	}
 
-	const stickyActionsClasses = 'sticky right-0 z-10 transition-colors';
-	const stickySelectClasses = 'w-0 pr-6!';
+	const stickyCellSurfaceClasses = 'bg-background/95';
+	const stickyActionsClasses = `sticky right-0 z-10 transition-colors ${stickyCellSurfaceClasses}`;
+	const stickySelectClasses = `w-0 pr-6! ${stickyCellSurfaceClasses}`;
 
 	function shouldIgnoreRowClick(event: MouseEvent): boolean {
 		const target = event.target as HTMLElement | null;

--- a/frontend/src/lib/components/arcane-table/arcane-table.svelte
+++ b/frontend/src/lib/components/arcane-table/arcane-table.svelte
@@ -674,7 +674,7 @@
 			</div>
 		{/if}
 
-		<div class="hidden h-full min-h-0 flex-1 overflow-auto md:block">
+		<div class="[isolation:isolate] hidden h-full min-h-0 flex-1 overflow-auto md:block">
 			<ArcaneTableDesktopView
 				{table}
 				{selectedIds}
@@ -694,7 +694,7 @@
 			/>
 		</div>
 
-		<div class="block flex-1 overflow-auto md:hidden">
+		<div class="[isolation:isolate] block flex-1 overflow-auto md:hidden">
 			<div class="divide-border/40 divide-y">
 				<ArcaneTableMobileView
 					{table}
@@ -735,7 +735,7 @@
 			</div>
 		{/if}
 
-		<div class="hidden h-full min-h-0 flex-1 overflow-auto md:block">
+		<div class="bg-background/80 [isolation:isolate] hidden h-full min-h-0 flex-1 overflow-auto md:block">
 			<ArcaneTableDesktopView
 				{table}
 				{selectedIds}
@@ -754,7 +754,7 @@
 			/>
 		</div>
 
-		<div class="block flex-1 overflow-auto md:hidden">
+		<div class="bg-background/80 [isolation:isolate] block flex-1 overflow-auto md:hidden">
 			<ArcaneTableMobileView
 				{table}
 				{mobileCard}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes table scroll lag by adding `[isolation:isolate]` to scrollable table containers (creating contained stacking contexts that can improve compositor performance) and adding `bg-background/95` to sticky `select` and `actions` cells so the browser has opaque surfaces to composite against rather than needing to repaint through transparent elements. The `.gitignore` is also tightened to anchor `arcane`/`arcane-*` to the repo root and ignore `.bin/`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; changes are scoped to CSS compositing hints and sticky-cell backgrounds with no logic regressions.

Only P2 findings — a potential visual inconsistency in `unstyled` mode. No functional or correctness bugs were found.

arcane-table-desktop-view.svelte — verify `unstyled` prop behaviour with the new sticky-cell background
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Frender-lag%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Frender-lag%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Flib%2Fcomponents%2Farcane-table%2Farcane-table-desktop-view.svelte%3A69-71%0A**Sticky%20cell%20background%20leaks%20into%20%60unstyled%60%20mode**%0A%0A%60bg-background%2F95%60%20is%20now%20baked%20into%20%60stickyCellSurfaceClasses%60%20and%20applied%20unconditionally%20to%20sticky%20%60select%60%20and%20%60actions%60%20cells.%20The%20%60unstyled%60%20override%20class%20string%20%28line%20116%29%20targets%20%60tr%60%2C%20%60thead%60%2C%20and%20%60td%60%20on%20hover%2Fselected%20states%2C%20but%20it%20has%20no%20rule%20that%20clears%20a%20static%20background%20on%20%60th%60%20or%20idle%20%60td%60%20elements.%20Previously%20these%20cells%20had%20no%20background%2C%20so%20%60unstyled%60%20tables%20would%20render%20them%20transparently.%20After%20this%20PR%2C%20%60unstyled%60%20sticky%20cells%20will%20show%20%60bg-background%2F95%60%20regardless%20of%20context.%0A%0AIf%20%60unstyled%60%20tables%20need%20this%20to%20look%20correct%2C%20consider%20applying%20%60stickyCellSurfaceClasses%60%20conditionally%3A%0A%0A%60%60%60%0Aconst%20stickyCellSurfaceClasses%20%3D%20unstyled%20%3F%20''%20%3A%20'bg-background%2F95'%3B%0A%60%60%60%0A%0A**Rule%20Used%3A**%20svelte-core-bestpractices%0A%0A---%0Aname%3A%20svelte-core-b...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dfa55c3c6-c41e-4994-8aad-254aaf9ba60d%29%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Flib%2Fcomponents%2Farcane-table%2Farcane-table-desktop-view.svelte%3A69-71%0A**Sticky%20cell%20background%20leaks%20into%20%60unstyled%60%20mode**%0A%0A%60bg-background%2F95%60%20is%20now%20baked%20into%20%60stickyCellSurfaceClasses%60%20and%20applied%20unconditionally%20to%20sticky%20%60select%60%20and%20%60actions%60%20cells.%20The%20%60unstyled%60%20override%20class%20string%20%28line%20116%29%20targets%20%60tr%60%2C%20%60thead%60%2C%20and%20%60td%60%20on%20hover%2Fselected%20states%2C%20but%20it%20has%20no%20rule%20that%20clears%20a%20static%20background%20on%20%60th%60%20or%20idle%20%60td%60%20elements.%20Previously%20these%20cells%20had%20no%20background%2C%20so%20%60unstyled%60%20tables%20would%20render%20them%20transparently.%20After%20this%20PR%2C%20%60unstyled%60%20sticky%20cells%20will%20show%20%60bg-background%2F95%60%20regardless%20of%20context.%0A%0AIf%20%60unstyled%60%20tables%20need%20this%20to%20look%20correct%2C%20consider%20applying%20%60stickyCellSurfaceClasses%60%20conditionally%3A%0A%0A%60%60%60%0Aconst%20stickyCellSurfaceClasses%20%3D%20unstyled%20%3F%20''%20%3A%20'bg-background%2F95'%3B%0A%60%60%60%0A%0A**Rule%20Used%3A**%20svelte-core-bestpractices%0A%0A---%0Aname%3A%20svelte-core-b...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dfa55c3c6-c41e-4994-8aad-254aaf9ba60d%29%29%0A%0A&repo=getarcaneapp%2Farcane&pr=2468&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/lib/components/arcane-table/arcane-table-desktop-view.svelte
Line: 69-71

Comment:
**Sticky cell background leaks into `unstyled` mode**

`bg-background/95` is now baked into `stickyCellSurfaceClasses` and applied unconditionally to sticky `select` and `actions` cells. The `unstyled` override class string (line 116) targets `tr`, `thead`, and `td` on hover/selected states, but it has no rule that clears a static background on `th` or idle `td` elements. Previously these cells had no background, so `unstyled` tables would render them transparently. After this PR, `unstyled` sticky cells will show `bg-background/95` regardless of context.

If `unstyled` tables need this to look correct, consider applying `stickyCellSurfaceClasses` conditionally:

```
const stickyCellSurfaceClasses = unstyled ? '' : 'bg-background/95';
```

**Rule Used:** svelte-core-bestpractices

---
name: svelte-core-b... ([source](https://app.greptile.com/review/custom-context?memory=fa55c3c6-c41e-4994-8aad-254aaf9ba60d))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: tables are laggy when lots of rows ..."](https://github.com/getarcaneapp/arcane/commit/250398a136ecc0ad7785299bf08635eec2433b4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30110554)</sub>

**Context used:**

- Rule used - svelte-core-bestpractices

---
name: svelte-core-b... ([source](https://app.greptile.com/review/custom-context?memory=fa55c3c6-c41e-4994-8aad-254aaf9ba60d))

<!-- /greptile_comment -->