### PR TITLE
fix: buildkit not using the image exporter

### DIFF
--- a/backend/internal/bootstrap/services_bootstrap.go
+++ b/backend/internal/bootstrap/services_bootstrap.go
@@ -80,7 +80,7 @@ func initializeServices(ctx context.Context, db *database.DB, cfg *config.Config
 	svcs.ImageUpdate = services.NewImageUpdateService(db, svcs.Settings, svcs.ContainerRegistry, svcs.Docker, svcs.Event, svcs.Notification)
 	svcs.Image = services.NewImageService(db, svcs.Docker, svcs.ContainerRegistry, svcs.ImageUpdate, svcs.Vulnerability, svcs.Event)
 	svcs.GitRepository = services.NewGitRepositoryService(db, cfg.GitWorkDir, svcs.Event, svcs.Settings)
-	svcs.Build = services.NewBuildService(db, svcs.Settings, svcs.Docker, svcs.ContainerRegistry, svcs.GitRepository)
+	svcs.Build = services.NewBuildService(db, svcs.Settings, svcs.Docker, svcs.ContainerRegistry, svcs.GitRepository, svcs.Event)
 	svcs.BuildWorkspace = services.NewBuildWorkspaceService(svcs.Settings)
 	svcs.Project = services.NewProjectService(db, svcs.Settings, svcs.Event, svcs.Image, svcs.Docker, svcs.Build, cfg)
 	svcs.Container = services.NewContainerService(db, svcs.Event, svcs.Docker, svcs.Image, svcs.Settings, svcs.Project)

--- a/backend/internal/services/build_service.go
+++ b/backend/internal/services/build_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,6 +30,7 @@ type BuildService struct {
 	dockerService   *DockerClientService
 	registryService *ContainerRegistryService
 	gitRepository   *GitRepositoryService
+	eventService    *EventService
 	builder         buildtypes.Builder
 	gitProbeFn      func(context.Context, string, buildgit.AuthConfig) error
 	gitCloneFn      func(context.Context, string, string, buildgit.AuthConfig) (string, error)
@@ -43,6 +45,7 @@ func NewBuildService(
 	dockerService *DockerClientService,
 	registryService *ContainerRegistryService,
 	gitRepository *GitRepositoryService,
+	eventService *EventService,
 ) *BuildService {
 	svc := &BuildService{
 		db:              db,
@@ -50,6 +53,7 @@ func NewBuildService(
 		dockerService:   dockerService,
 		registryService: registryService,
 		gitRepository:   gitRepository,
+		eventService:    eventService,
 	}
 	svc.builder = libbuild.NewBuilder(svc, dockerService, svc)
 
@@ -136,7 +140,7 @@ func (s *BuildService) BuildImage(ctx context.Context, environmentID string, req
 			outputPtr = &output
 		}
 
-		provider := req.Provider
+		provider := s.effectiveBuildProviderInternal(req.Provider)
 		var digest *string
 		if result != nil {
 			if result.Provider != "" {
@@ -151,15 +155,107 @@ func (s *BuildService) BuildImage(ctx context.Context, environmentID string, req
 		var errMsg *string
 		if err != nil {
 			status = models.ImageBuildStatusFailed
-			errMsg = new(err.Error())
+			errorText := err.Error()
+			errMsg = &errorText
 		}
 
-		if updateErr := s.completeBuildRecord(ctx, buildRecordID, status, outputPtr, logCapture.Truncated(), errMsg, digest, provider, completedAt, new(completedAt.Sub(startedAt).Milliseconds())); updateErr != nil {
+		durationMs := completedAt.Sub(startedAt).Milliseconds()
+		if updateErr := s.completeBuildRecord(ctx, buildRecordID, status, outputPtr, logCapture.Truncated(), errMsg, digest, provider, completedAt, &durationMs); updateErr != nil {
 			slog.WarnContext(ctx, "failed to update build history record", "error", updateErr)
 		}
 	}
 
+	if err != nil {
+		s.logBuildFailureEventInternal(ctx, environmentID, req, serviceName, buildRecordID, err, user)
+	}
+
 	return result, err
+}
+
+func (s *BuildService) logBuildFailureEventInternal(ctx context.Context, environmentID string, req imagetypes.BuildRequest, serviceName, buildRecordID string, err error, user *models.User) {
+	if s.eventService == nil || err == nil {
+		return
+	}
+
+	resourceName := firstNonEmptyStringInternal(req.Tags...)
+	if resourceName == "" {
+		resourceName = strings.TrimSpace(serviceName)
+	}
+	if resourceName == "" {
+		resourceName = sanitizeBuildContextForEventInternal(req.ContextDir)
+	}
+
+	userID := ""
+	username := ""
+	if user != nil {
+		userID = user.ID
+		username = user.Username
+	}
+
+	metadata := models.JSON{
+		"action":     "build",
+		"provider":   s.effectiveBuildProviderInternal(req.Provider),
+		"contextDir": sanitizeBuildContextForEventInternal(req.ContextDir),
+		"dockerfile": req.Dockerfile,
+		"tags":       append([]string(nil), req.Tags...),
+	}
+	if service := strings.TrimSpace(serviceName); service != "" {
+		metadata["serviceName"] = service
+	}
+	if buildRecordID != "" {
+		metadata["buildRecordId"] = buildRecordID
+	}
+
+	s.eventService.LogErrorEvent(ctx, models.EventTypeImageError, "image", "", resourceName, userID, username, environmentID, err, metadata)
+}
+
+func sanitizeBuildContextForEventInternal(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+
+	base, fragment, hasFragment := strings.Cut(trimmed, "#")
+	parsed, err := url.Parse(base)
+	if err != nil {
+		if strings.Contains(base, "@") {
+			return "[unparseable URL]"
+		}
+		return trimmed
+	}
+	if parsed.User == nil {
+		return trimmed
+	}
+
+	parsed.User = url.User("redacted")
+	sanitized := parsed.String()
+	if hasFragment {
+		sanitized += "#" + fragment
+	}
+	return sanitized
+}
+
+func (s *BuildService) effectiveBuildProviderInternal(provider string) string {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider != "" {
+		return provider
+	}
+	if s.settings != nil {
+		provider = strings.ToLower(strings.TrimSpace(s.settings.GetSettingsConfig().BuildProvider.Value))
+	}
+	if provider == "" {
+		return "local"
+	}
+	return provider
+}
+
+func firstNonEmptyStringInternal(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func (s *BuildService) resolveBuildRequestInternal(

--- a/backend/internal/services/build_service_test.go
+++ b/backend/internal/services/build_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -327,13 +328,78 @@ func TestBuildService_BuildImage_PreservesRemoteSourceInHistory(t *testing.T) {
 	assert.Equal(t, req.ContextDir, record.ContextDir)
 }
 
+func TestBuildService_BuildImage_FailureRecordsHistoryAndEvent(t *testing.T) {
+	db, err := setupBuildHistoryTestDB()
+	require.NoError(t, err)
+
+	buildErr := errors.New("BuildKit could not load the image with the docker exporter")
+	svc := &BuildService{
+		db:           db,
+		eventService: NewEventService(db, nil, nil),
+		builder: testBuildRecorder{
+			err: buildErr,
+		},
+	}
+	user := &models.User{
+		BaseModel: models.BaseModel{ID: "user-1"},
+		Username:  "tester",
+	}
+
+	req := image.BuildRequest{
+		ContextDir: "/builds/demo",
+		Dockerfile: "Dockerfile",
+		Tags:       []string{"arcane.local/demo:test"},
+		Provider:   "local",
+		Load:       true,
+	}
+
+	_, err = svc.BuildImage(context.Background(), "0", req, nil, "web", user)
+	require.ErrorIs(t, err, buildErr)
+
+	var record models.ImageBuild
+	require.NoError(t, db.WithContext(context.Background()).First(&record).Error)
+	assert.Equal(t, models.ImageBuildStatusFailed, record.Status)
+	require.NotNil(t, record.ErrorMessage)
+	assert.Contains(t, *record.ErrorMessage, "docker exporter")
+
+	var event models.Event
+	require.NoError(t, db.WithContext(context.Background()).First(&event, "type = ?", models.EventTypeImageError).Error)
+	assert.Equal(t, models.EventSeverityError, event.Severity)
+	require.NotNil(t, event.ResourceName)
+	assert.Equal(t, "arcane.local/demo:test", *event.ResourceName)
+	assert.Equal(t, "build", event.Metadata["action"])
+	assert.Equal(t, "local", event.Metadata["provider"])
+	assert.Equal(t, "/builds/demo", event.Metadata["contextDir"])
+	assert.Contains(t, event.Metadata["error"], "docker exporter")
+	require.NotEmpty(t, event.Metadata["buildRecordId"])
+	assert.Equal(t, record.ID, event.Metadata["buildRecordId"])
+}
+
+func TestSanitizeBuildContextForEventInternal_RedactsURLCredentials(t *testing.T) {
+	assert.Equal(
+		t,
+		"https://redacted@github.com/zeroZshadow/secretproject.git#main:app",
+		sanitizeBuildContextForEventInternal("https://myaccesstoken@github.com/zeroZshadow/secretproject.git#main:app"),
+	)
+	assert.Equal(
+		t,
+		"[unparseable URL]",
+		sanitizeBuildContextForEventInternal("https://user:pass@[bad-host/repo.git"),
+	)
+	assert.Equal(t, "/builds/demo", sanitizeBuildContextForEventInternal("/builds/demo"))
+}
+
 type testBuildRecorder struct {
 	onBuild func(image.BuildRequest)
+	err     error
 }
 
 func (b testBuildRecorder) BuildImage(_ context.Context, req image.BuildRequest, _ io.Writer, _ string) (*image.BuildResult, error) {
 	if b.onBuild != nil {
 		b.onBuild(req)
+	}
+	if b.err != nil {
+		return nil, b.err
 	}
 	return &image.BuildResult{Provider: "local"}, nil
 }
@@ -343,7 +409,7 @@ func setupBuildHistoryTestDB() (*database.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := db.AutoMigrate(&models.ImageBuild{}); err != nil {
+	if err := db.AutoMigrate(&models.ImageBuild{}, &models.Event{}); err != nil {
 		return nil, err
 	}
 	return &database.DB{DB: db}, nil

--- a/backend/pkg/libarcane/libbuild/builder_buildkit.go
+++ b/backend/pkg/libarcane/libbuild/builder_buildkit.go
@@ -99,7 +99,7 @@ func normalizeEntitlementsInternal(entitlements []string, privileged bool) []str
 	return out
 }
 
-func (b *builder) buildSolveOptInternal(ctx context.Context, req imagetypes.BuildRequest) (buildkit.SolveOpt, <-chan error, func(), error) {
+func (b *builder) buildSolveOptInternal(ctx context.Context, req imagetypes.BuildRequest, providerName string) (buildkit.SolveOpt, <-chan error, func(), error) {
 	fsInput, err := prepareBuildFilesystemInputInternal(req)
 	if err != nil {
 		return buildkit.SolveOpt{}, nil, nil, err
@@ -157,7 +157,7 @@ func (b *builder) buildSolveOptInternal(ctx context.Context, req imagetypes.Buil
 
 	var loadErrCh chan error
 	exports := make([]buildkit.ExportEntry, 0, 2)
-	if req.Push {
+	if req.Push && providerName != "local" {
 		exports = append(exports, buildkit.ExportEntry{
 			Type: "image",
 			Attrs: map[string]string{
@@ -167,7 +167,20 @@ func (b *builder) buildSolveOptInternal(ctx context.Context, req imagetypes.Buil
 			},
 		})
 	}
-	if req.Load {
+
+	if providerName == "local" && (req.Load || req.Push) {
+		attrs := map[string]string{
+			"name":           strings.Join(req.Tags, ","),
+			"oci-mediatypes": "true",
+		}
+		if req.Push {
+			attrs["push"] = "true"
+		}
+		exports = append(exports, buildkit.ExportEntry{
+			Type:  "image",
+			Attrs: attrs,
+		})
+	} else if req.Load {
 		exportEntry, errCh, err := b.buildLoadExportInternal(ctx, req.Tags)
 		if err != nil {
 			cleanup()

--- a/backend/pkg/libarcane/libbuild/builder_buildkit_test.go
+++ b/backend/pkg/libarcane/libbuild/builder_buildkit_test.go
@@ -2,11 +2,15 @@ package libbuild
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	imagetypes "github.com/getarcaneapp/arcane/types/image"
+	dockerclient "github.com/moby/moby/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +28,7 @@ func TestBuildSolveOptInternal_StagesInlineDockerfile(t *testing.T) {
 		},
 	}
 
-	solveOpt, loadErrCh, cleanup, err := b.buildSolveOptInternal(context.Background(), req)
+	solveOpt, loadErrCh, cleanup, err := b.buildSolveOptInternal(context.Background(), req, "local")
 	require.NoError(t, err)
 	defer cleanup()
 	assert.Nil(t, loadErrCh)
@@ -42,4 +46,98 @@ func TestBuildSolveOptInternal_StagesInlineDockerfile(t *testing.T) {
 	appContents, err := os.ReadFile(filepath.Join(contextPath, "app.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "hello\n", string(appContents))
+}
+
+func TestBuildSolveOptInternal_LocalLoadUsesImageExporter(t *testing.T) {
+	contextDir := createBuildkitTestContext(t)
+	b := &builder{}
+
+	solveOpt, loadErrCh, cleanup, err := b.buildSolveOptInternal(context.Background(), imagetypes.BuildRequest{
+		ContextDir: contextDir,
+		Dockerfile: "Dockerfile",
+		Tags:       []string{"arcane.local/app:test"},
+		Load:       true,
+	}, "local")
+	require.NoError(t, err)
+	defer cleanup()
+
+	require.Nil(t, loadErrCh)
+	require.Len(t, solveOpt.Exports, 1)
+	assert.Equal(t, "image", solveOpt.Exports[0].Type)
+	assert.Equal(t, "arcane.local/app:test", solveOpt.Exports[0].Attrs["name"])
+	assert.NotContains(t, solveOpt.Exports[0].Attrs, "push")
+	assert.Nil(t, solveOpt.Exports[0].Output)
+}
+
+func TestBuildSolveOptInternal_LocalPushAndLoadUsesSingleImageExporter(t *testing.T) {
+	contextDir := createBuildkitTestContext(t)
+	b := &builder{}
+
+	solveOpt, loadErrCh, cleanup, err := b.buildSolveOptInternal(context.Background(), imagetypes.BuildRequest{
+		ContextDir: contextDir,
+		Dockerfile: "Dockerfile",
+		Tags:       []string{"registry.example.com/app:test"},
+		Push:       true,
+		Load:       true,
+	}, "local")
+	require.NoError(t, err)
+	defer cleanup()
+
+	require.Nil(t, loadErrCh)
+	require.Len(t, solveOpt.Exports, 1)
+	assert.Equal(t, "image", solveOpt.Exports[0].Type)
+	assert.Equal(t, "registry.example.com/app:test", solveOpt.Exports[0].Attrs["name"])
+	assert.Equal(t, "true", solveOpt.Exports[0].Attrs["push"])
+}
+
+func TestBuildSolveOptInternal_NonLocalLoadKeepsDockerExporter(t *testing.T) {
+	contextDir := createBuildkitTestContext(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1.54/images/load" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		_, _ = w.Write([]byte("{}\n"))
+	}))
+	defer server.Close()
+
+	client, err := dockerclient.NewClientWithOpts(dockerclient.WithHost(server.URL), dockerclient.WithVersion("1.54"))
+	require.NoError(t, err)
+
+	b := &builder{dockerClientProvider: testDockerClientProvider{client: client}}
+	solveOpt, loadErrCh, cleanup, err := b.buildSolveOptInternal(context.Background(), imagetypes.BuildRequest{
+		ContextDir: contextDir,
+		Dockerfile: "Dockerfile",
+		Tags:       []string{"arcane.local/app:test"},
+		Load:       true,
+	}, "depot")
+	require.NoError(t, err)
+	defer cleanup()
+
+	require.NotNil(t, loadErrCh)
+	require.Len(t, solveOpt.Exports, 1)
+	assert.Equal(t, "docker", solveOpt.Exports[0].Type)
+	require.NotNil(t, solveOpt.Exports[0].Output)
+
+	output, err := solveOpt.Exports[0].Output(nil)
+	require.NoError(t, err)
+	require.NoError(t, output.Close())
+	require.NoError(t, <-loadErrCh)
+}
+
+func createBuildkitTestContext(t *testing.T) string {
+	t.Helper()
+	contextDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(contextDir, "Dockerfile"), []byte("FROM alpine:3.20\n"), 0o644))
+	return contextDir
+}
+
+type testDockerClientProvider struct {
+	client *dockerclient.Client
+}
+
+func (p testDockerClientProvider) GetClient(context.Context) (*dockerclient.Client, error) {
+	return p.client, nil
 }

--- a/backend/pkg/libarcane/libbuild/builder_core.go
+++ b/backend/pkg/libarcane/libbuild/builder_core.go
@@ -110,7 +110,7 @@ func (b *builder) buildWithBuildkitSessionInternal(
 		}
 	}()
 
-	solveOpt, loadErrCh, cleanupSolveOpt, err := b.buildSolveOptInternal(ctx, req)
+	solveOpt, loadErrCh, cleanupSolveOpt, err := b.buildSolveOptInternal(ctx, req, providerName)
 	if err != nil {
 		buildErr = err
 		return nil, err
@@ -136,9 +136,10 @@ func (b *builder) buildWithBuildkitSessionInternal(
 	})
 
 	resp, err := session.Client.Solve(ctx, nil, solveOpt, statusCh)
-	buildErr = err
 
 	if err != nil {
+		err = wrapBuildkitSolveErrorInternal(err, providerName)
+		buildErr = err
 		writeProgressEventInternal(progressWriter, imagetypes.ProgressEvent{
 			Type:    "build",
 			Service: serviceName,
@@ -182,6 +183,18 @@ func (b *builder) buildWithBuildkitSessionInternal(
 		Tags:     req.Tags,
 		Digest:   digest,
 	}, nil
+}
+
+func wrapBuildkitSolveErrorInternal(err error, providerName string) error {
+	if err == nil {
+		return nil
+	}
+
+	if strings.Contains(err.Error(), `exporter "docker" could not be found`) {
+		return fmt.Errorf("BuildKit could not load the image with the docker exporter for provider %s; the builder does not expose that exporter: %w", providerName, err)
+	}
+
+	return err
 }
 
 func buildkitAuthConfigProviderInternal(defaultProvider authprovider.AuthConfigProvider, registryAuthProvider buildtypes.RegistryAuthProvider) authprovider.AuthConfigProvider {

--- a/backend/pkg/libarcane/libbuild/builder_core_test.go
+++ b/backend/pkg/libarcane/libbuild/builder_core_test.go
@@ -98,3 +98,12 @@ func TestBuildkitAuthConfigProvider_FallsBackToDefaultProvider(t *testing.T) {
 		assert.Equal(t, defaultCfg, cfg)
 	})
 }
+
+func TestWrapBuildkitSolveErrorInternal_LeavesGenericErrorsUnchanged(t *testing.T) {
+	err := errors.New("failed to solve: Dockerfile parse error on line 3")
+
+	wrapped := wrapBuildkitSolveErrorInternal(err, "local")
+
+	require.ErrorIs(t, wrapped, err)
+	assert.Equal(t, err.Error(), wrapped.Error())
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2465

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes BuildKit failing to load images into the local Docker daemon by switching from the `docker` exporter (unavailable on many BuildKit configurations) to the `image` exporter when `providerName == "local"`. It also adds failure event logging via `EventService`, URL-credential sanitization for event metadata, a targeted `wrapBuildkitSolveErrorInternal` helper for the docker-exporter-not-found case, and fixes two compile errors (`new(err.Error())` and `new(completedAt.Sub(...).Milliseconds())` in the base branch).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — core logic is correct and well-tested; only a P2 naming convention finding.

All changed code paths are covered by new tests. The exporter-selection logic is straightforward and the test matrix (local load, local push+load, non-local load) validates the branching correctly. No P0/P1 issues found.

No files require special attention beyond the minor naming nit in builder_buildkit_test.go.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fbuildkit-context%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fbuildkit-context%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fpkg%2Flibarcane%2Flibbuild%2Fbuilder_buildkit_test.go%3A130-133%0A**Missing%20%22Internal%22%20suffix%20on%20unexported%20helper**%0A%0APer%20the%20repo%20convention%2C%20all%20unexported%20functions%20must%20end%20with%20the%20%60Internal%60%20suffix.%20%60createBuildkitTestContext%60%20should%20be%20renamed%20to%20%60createBuildkitTestContextInternal%60.%0A%0A%60%60%60suggestion%0Afunc%20createBuildkitTestContextInternal%28t%20*testing.T%29%20string%20%7B%0A%09t.Helper%28%29%0A%09contextDir%20%3A%3D%20t.TempDir%28%29%0A%09require.NoError%28t%2C%20os.WriteFile%28filepath.Join%28contextDir%2C%20%22Dockerfile%22%29%2C%20%5B%5Dbyte%28%22FROM%20alpine%3A3.20%5Cn%22%29%2C%200o644%29%29%0A%09return%20contextDir%0A%7D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fpkg%2Flibarcane%2Flibbuild%2Fbuilder_buildkit_test.go%3A130-133%0A**Missing%20%22Internal%22%20suffix%20on%20unexported%20helper**%0A%0APer%20the%20repo%20convention%2C%20all%20unexported%20functions%20must%20end%20with%20the%20%60Internal%60%20suffix.%20%60createBuildkitTestContext%60%20should%20be%20renamed%20to%20%60createBuildkitTestContextInternal%60.%0A%0A%60%60%60suggestion%0Afunc%20createBuildkitTestContextInternal%28t%20*testing.T%29%20string%20%7B%0A%09t.Helper%28%29%0A%09contextDir%20%3A%3D%20t.TempDir%28%29%0A%09require.NoError%28t%2C%20os.WriteFile%28filepath.Join%28contextDir%2C%20%22Dockerfile%22%29%2C%20%5B%5Dbyte%28%22FROM%20alpine%3A3.20%5Cn%22%29%2C%200o644%29%29%0A%09return%20contextDir%0A%7D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A&repo=getarcaneapp%2Farcane&pr=2469&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/libarcane/libbuild/builder_buildkit_test.go
Line: 130-133

Comment:
**Missing "Internal" suffix on unexported helper**

Per the repo convention, all unexported functions must end with the `Internal` suffix. `createBuildkitTestContext` should be renamed to `createBuildkitTestContextInternal`.

```suggestion
func createBuildkitTestContextInternal(t *testing.T) string {
	t.Helper()
	contextDir := t.TempDir()
	require.NoError(t, os.WriteFile(filepath.Join(contextDir, "Dockerfile"), []byte("FROM alpine:3.20\n"), 0o644))
	return contextDir
}
```

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: buildkit not using the image export..."](https://github.com/getarcaneapp/arcane/commit/62dc17443123ba54fa5c733d43edee0c0105a1e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30128054)</sub>

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->