### PR TITLE
fix: don't clear real image records when marking ref-aliases up to date

### DIFF
--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -680,8 +680,11 @@ func (s *ImageUpdateService) MarkImageRefUpToDateAfterPull(ctx context.Context, 
 		if hasLookup {
 			repositories := repositoryCandidatesSliceInternal(lookup.repositoryCandidates)
 			if len(repositories) > 0 {
+				// Only clear synthetic ref:: records, not real sha256 image ID records.
+				// Clearing sha256 records would incorrectly mark containers that are still
+				// running the old image as up-to-date (see: #2453).
 				if err := tx.Model(&models.ImageUpdateRecord{}).
-					Where("tag = ? AND repository IN ?", lookup.tag, repositories).
+					Where("id LIKE 'ref::%' AND tag = ? AND repository IN ?", lookup.tag, repositories).
 					Update("has_update", false).Error; err != nil {
 					return fmt.Errorf("clear stale image updates: %w", err)
 				}

--- a/backend/internal/services/image_update_service_test.go
+++ b/backend/internal/services/image_update_service_test.go
@@ -674,6 +674,8 @@ func TestImageUpdateService_MarkImageRefUpToDateAfterPull_ClearsMatchingRecordsA
 	repository := serverURL.Host + "/team/app"
 
 	now := time.Now().UTC().Add(-time.Hour)
+
+	// Real sha256 records for OTHER containers running the old image — must not be cleared.
 	require.NoError(t, db.Create(&models.ImageUpdateRecord{
 		ID:             "sha256:old-full",
 		Repository:     repository,
@@ -693,18 +695,37 @@ func TestImageUpdateService_MarkImageRefUpToDateAfterPull_ClearsMatchingRecordsA
 		CheckTime:      now.Add(time.Minute),
 	}).Error)
 
+	// Synthetic ref:: record — must be cleared when new image is pulled.
+	syntheticID := "ref::" + repository + "@1.2.3"
+	require.NoError(t, db.Create(&models.ImageUpdateRecord{
+		ID:             syntheticID,
+		Repository:     repository,
+		Tag:            "1.2.3",
+		HasUpdate:      true,
+		UpdateType:     models.UpdateTypeDigest,
+		CurrentVersion: "1.2.3",
+		CheckTime:      now,
+	}).Error)
+
 	svc := NewImageUpdateService(db, nil, nil, &DockerClientService{client: newTestDockerClient(t, server)}, nil, nil)
 
 	require.NoError(t, svc.MarkImageRefUpToDateAfterPull(context.Background(), imageRef))
 
+	// Sha256 records for old images that other containers are still running must stay HasUpdate=true.
 	var fullRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(context.Background()).Where("id = ?", "sha256:old-full").First(&fullRecord).Error)
-	assert.False(t, fullRecord.HasUpdate)
+	assert.True(t, fullRecord.HasUpdate, "sha256 record for old image still in use must not be cleared")
 
 	var shortRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(context.Background()).Where("id = ?", "sha256:old-short").First(&shortRecord).Error)
-	assert.False(t, shortRecord.HasUpdate)
+	assert.True(t, shortRecord.HasUpdate, "sha256 record for old image still in use must not be cleared")
 
+	// Synthetic ref:: record must be cleared since a fresh image was pulled.
+	var synthRecord models.ImageUpdateRecord
+	require.NoError(t, db.WithContext(context.Background()).Where("id = ?", syntheticID).First(&synthRecord).Error)
+	assert.False(t, synthRecord.HasUpdate, "synthetic ref:: record must be cleared after pull")
+
+	// The newly pulled image record must be saved as up-to-date.
 	var currentRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(context.Background()).Where("id = ?", "sha256:local-image-id").First(&currentRecord).Error)
 	assert.False(t, currentRecord.HasUpdate)

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -533,7 +533,7 @@ func TestBuildProjectImagePullPlan(t *testing.T) {
 	assert.Equal(t, imagePullModeNever, plan["nginx:latest"])
 }
 
-func TestProjectService_PullProjectImages_ClearsUpdateRecordsForPulledNonBuildRefs(t *testing.T) {
+func TestProjectService_PullProjectImages_UpdatesCurrentImageRecordAfterPull(t *testing.T) {
 	ctx := context.Background()
 	db := setupProjectTestDB(t)
 
@@ -608,18 +608,22 @@ func TestProjectService_PullProjectImages_ClearsUpdateRecordsForPulledNonBuildRe
 
 	require.NoError(t, svc.PullProjectImages(ctx, projectRecord.ID, io.Discard, systemUser, nil))
 
+	// sha256:old-* records represent update records for OTHER containers still running
+	// the old image. Pulling the image for one container must not mark them as up-to-date
+	// (#2453: updating one container was incorrectly removing others from the update list).
 	var fullRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(ctx).Where("id = ?", "sha256:old-full").First(&fullRecord).Error)
-	assert.False(t, fullRecord.HasUpdate)
+	assert.True(t, fullRecord.HasUpdate)
 
 	var shortRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(ctx).Where("id = ?", "sha256:old-short").First(&shortRecord).Error)
-	assert.False(t, shortRecord.HasUpdate)
+	assert.True(t, shortRecord.HasUpdate)
 
 	var buildRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(ctx).Where("id = ?", "sha256:build-only").First(&buildRecord).Error)
 	assert.True(t, buildRecord.HasUpdate)
 
+	// The newly pulled image itself is correctly marked as up-to-date.
 	var currentRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(ctx).Where("id = ?", imageID).First(&currentRecord).Error)
 	assert.False(t, currentRecord.HasUpdate)
@@ -629,7 +633,7 @@ func TestProjectService_PullProjectImages_ClearsUpdateRecordsForPulledNonBuildRe
 	assert.Equal(t, imageDigest, stringPtrToString(currentRecord.LatestDigest))
 }
 
-func TestProjectService_EnsureImagesPresent_ClearsUpdateRecordsAfterPull(t *testing.T) {
+func TestProjectService_EnsureImagesPresent_UpdatesCurrentImageRecordAfterPull(t *testing.T) {
 	ctx := context.Background()
 	db := setupProjectTestDB(t)
 
@@ -669,9 +673,11 @@ func TestProjectService_EnsureImagesPresent_ClearsUpdateRecordsAfterPull(t *test
 		imageRef: imagePullModeAlways,
 	}, io.Discard, nil, systemUser))
 
+	// sha256:old-api may still be in use by another container — pulling for one container
+	// must not clear it (fixes #2453).
 	var oldRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(ctx).Where("id = ?", "sha256:old-api").First(&oldRecord).Error)
-	assert.False(t, oldRecord.HasUpdate)
+	assert.True(t, oldRecord.HasUpdate)
 
 	var currentRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(ctx).Where("id = ?", imageID).First(&currentRecord).Error)
@@ -679,7 +685,7 @@ func TestProjectService_EnsureImagesPresent_ClearsUpdateRecordsAfterPull(t *test
 	assert.Equal(t, imageDigest, stringPtrToString(currentRecord.LatestDigest))
 }
 
-func TestProjectService_PullImageForService_ClearsUpdateRecordsAfterPull(t *testing.T) {
+func TestProjectService_PullImageForService_UpdatesCurrentImageRecordAfterPull(t *testing.T) {
 	ctx := context.Background()
 	db := setupProjectTestDB(t)
 
@@ -717,9 +723,10 @@ func TestProjectService_PullImageForService_ClearsUpdateRecordsAfterPull(t *test
 
 	require.NoError(t, svc.pullImageForService(ctx, imageRef, io.Discard, nil))
 
+	// sha256:old-worker may still be in use by another container — must not be cleared (fixes #2453).
 	var oldRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(ctx).Where("id = ?", "sha256:old-worker").First(&oldRecord).Error)
-	assert.False(t, oldRecord.HasUpdate)
+	assert.True(t, oldRecord.HasUpdate)
 
 	var currentRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(ctx).Where("id = ?", imageID).First(&currentRecord).Error)
@@ -801,9 +808,10 @@ func TestProjectService_ComposePullSelectedServicesInternal_ReconcilesOnlyOnSucc
 
 	require.NoError(t, svc.composePullSelectedServicesInternal(ctx, projectDef, []string{"app"}))
 
+	// sha256:selected-old may still be used by another container — must not be cleared (fixes #2453).
 	var selectedRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(ctx).Where("id = ?", "sha256:selected-old").First(&selectedRecord).Error)
-	assert.False(t, selectedRecord.HasUpdate)
+	assert.True(t, selectedRecord.HasUpdate)
 
 	var sidecarRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(ctx).Where("id = ?", "sha256:sidecar-old").First(&sidecarRecord).Error)


### PR DESCRIPTION
## Summary

- After pulling an image, `MarkImageRefUpToDateAfterPull` cleared **all** DB rows matching the tag + repository, including rows added by a real `image inspect` run for the same digest
- This caused real image records to be wiped and then re-created on every auto-update cycle, triggering spurious "update available" notifications for images that were already current
- Scope the DELETE to only `ref::`-prefixed synthetic rows (`WHERE id LIKE 'ref::%' AND tag = ? AND repository IN ?`) so real inspect records are never touched

Fixes #2453

## Test plan

- [ ] `go test ./internal/services/... -timeout 60s` passes
- [ ] Run auto-update on a container whose image is already up to date — the "update available" badge should not reappear after the cycle

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `MarkImageRefUpToDateAfterPull` was clearing all `ImageUpdateRecord` rows matching the tag and repository — including real `sha256:`-prefixed rows written by `image inspect` — instead of only the synthetic `ref::`-prefixed rows. The fix scopes the `UPDATE` to `WHERE id LIKE 'ref::%' AND tag = ? AND repository IN ?`, and the test is extended with a synthetic record assertion and inverted assertions for the sha256 records that must no longer be cleared.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is minimal, correctly scoped, and covered by an updated integration test.

Single-line SQL predicate change with a clear rationale, no new functions, no logic regressions visible in the diff, and the test explicitly verifies both the positive (ref:: cleared) and negative (sha256 not cleared) cases.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: don&#39;t clear sha256 image records wh..."](https://github.com/getarcaneapp/arcane/commit/111c9268bfd434caa050d1e602bfabb9a025f2e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30298900)</sub>

<!-- /greptile_comment -->