### PR TITLE
fix: show loading state immediately on swarm service actions

### DIFF
--- a/frontend/src/routes/(app)/swarm/services/[serviceId]/+page.svelte
+++ b/frontend/src/routes/(app)/swarm/services/[serviceId]/+page.svelte
@@ -212,6 +212,7 @@
 
 	async function handleUpdate(payload: { spec: Record<string, unknown>; options?: Record<string, unknown> }) {
 		if (!service?.id) return;
+		isLoading.update = true;
 		handleApiResultWithCallbacks({
 			result: await tryCatch(swarmService.updateService(service.id, { version: editVersion, ...payload })),
 			message: m.common_update_failed({ resource: `${m.swarm_service()} "${serviceName}"` }),
@@ -232,6 +233,7 @@
 				label: m.swarm_service_rollback(),
 				destructive: false,
 				action: async () => {
+					isLoading.rollback = true;
 					handleApiResultWithCallbacks({
 						result: await tryCatch(swarmService.rollbackService(service.id)),
 						message: m.swarm_service_rollback_failed({ name: serviceName }),
@@ -254,6 +256,7 @@
 				label: m.common_delete(),
 				destructive: true,
 				action: async () => {
+					isLoading.remove = true;
 					handleApiResultWithCallbacks({
 						result: await tryCatch(swarmService.removeService(service.id)),
 						message: m.common_delete_failed({ resource: `${m.swarm_service()} "${serviceName}"` }),
@@ -271,6 +274,7 @@
 	async function handleScale() {
 		if (!service?.id || !canScaleService) return;
 		const replicas = Math.max(0, Number(scaleReplicas) || 0);
+		isLoading.scale = true;
 		handleApiResultWithCallbacks({
 			result: await tryCatch(swarmService.scaleService(service.id, { replicas })),
 			message: m.common_update_failed({ resource: `${m.swarm_service()} "${serviceName}"` }),


### PR DESCRIPTION
## Summary

- In the swarm service detail page, the loading indicator only appeared **after** the API call completed because `setLoadingState(true)` was called inside `handleApiResultWithCallbacks`, which runs after `await tryCatch(...)` resolves
- For slow API calls (update, rollback, scale, delete) the button appeared unresponsive for the full duration of the request
- Set `isLoading.<action> = true` **before** each `await tryCatch(...)` call so the button disables and shows a spinner immediately on click

Fixes #2375

## Test plan

- [ ] Click Edit / Rollback / Delete / Scale on a swarm service — the button should disable instantly, not after the API responds
- [ ] On success or error the loading state resets correctly

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `isLoading.<action> = true` before each `await tryCatch(...)` call in the swarm service detail page, ensuring buttons disable and show a spinner immediately on click rather than waiting for the API to respond.

- The four `handleApiResultWithCallbacks(...)` calls (`update`, `rollback`, `remove`, `scale`) are async but not `await`-ed, meaning their internal `setLoadingState(false)`, `onSuccess`, and `onError` run in floating, untracked promises — any error thrown there (e.g. inside `refreshData`) becomes a silent unhandled rejection, and callers that `await` the wrapping handler (e.g. `ServiceEditorDialog.onSubmit`) resolve before side-effects complete.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for the UX fix, but the floating-promise pattern on handleApiResultWithCallbacks silently swallows errors and may leave callers out of sync.

The loading-state fix itself is correct and minimal. The P1 finding — non-awaited async calls on all four action handlers — means errors from onSuccess/onError are silently dropped and any consumer that awaits the handler resolves prematurely. This was a pre-existing pattern, but the PR touches all four sites without addressing it, and the description implies the loading lifecycle is now correctly managed end-to-end.

frontend/src/routes/(app)/swarm/services/[serviceId]/+page.svelte — all four handleApiResultWithCallbacks call sites
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/routes/(app)/swarm/services/[serviceId]/+page.svelte`, line 216-226 ([link](https://github.com/getarcaneapp/arcane/blob/417cea6b158edd03cca8a217a6dcacb10f43aaec/frontend/src/routes/(app)/swarm/services/[serviceId]/+page.svelte#L216-L226)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`handleApiResultWithCallbacks` not awaited**

   `handleApiResultWithCallbacks` is an `async` function but is never `await`-ed across all four call sites (`handleUpdate`, the rollback action, the delete action, `handleScale`). Because the result is already resolved before it's passed in, the function's own `try/finally` — including `setLoadingState(false)` and both `onSuccess`/`onError` — runs in a floating promise. Any exception thrown inside (e.g. inside `onSuccess → refreshData`) becomes an unhandled rejection that is silently swallowed, and callers (like `ServiceEditorDialog`'s `onSubmit`) that `await handleUpdate(payload)` will resolve before the API side-effects complete. Consider adding `await` before each `handleApiResultWithCallbacks(...)` call.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/routes/(app)/swarm/services/[serviceId]/+page.svelte
   Line: 216-226

   Comment:
   **`handleApiResultWithCallbacks` not awaited**

   `handleApiResultWithCallbacks` is an `async` function but is never `await`-ed across all four call sites (`handleUpdate`, the rollback action, the delete action, `handleScale`). Because the result is already resolved before it's passed in, the function's own `try/finally` — including `setLoadingState(false)` and both `onSuccess`/`onError` — runs in a floating promise. Any exception thrown inside (e.g. inside `onSuccess → refreshData`) becomes an unhandled rejection that is silently swallowed, and callers (like `ServiceEditorDialog`'s `onSubmit`) that `await handleUpdate(payload)` will resolve before the API side-effects complete. Consider adding `await` before each `handleApiResultWithCallbacks(...)` call.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2F2375-swarm-service-update-loading%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F2375-swarm-service-update-loading%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20frontend%2Fsrc%2Froutes%2F%28app%29%2Fswarm%2Fservices%2F%5BserviceId%5D%2F%2Bpage.svelte%0ALine%3A%20216-226%0A%0AComment%3A%0A**%60handleApiResultWithCallbacks%60%20not%20awaited**%0A%0A%60handleApiResultWithCallbacks%60%20is%20an%20%60async%60%20function%20but%20is%20never%20%60await%60-ed%20across%20all%20four%20call%20sites%20%28%60handleUpdate%60%2C%20the%20rollback%20action%2C%20the%20delete%20action%2C%20%60handleScale%60%29.%20Because%20the%20result%20is%20already%20resolved%20before%20it's%20passed%20in%2C%20the%20function's%20own%20%60try%2Ffinally%60%20%E2%80%94%20including%20%60setLoadingState%28false%29%60%20and%20both%20%60onSuccess%60%2F%60onError%60%20%E2%80%94%20runs%20in%20a%20floating%20promise.%20Any%20exception%20thrown%20inside%20%28e.g.%20inside%20%60onSuccess%20%E2%86%92%20refreshData%60%29%20becomes%20an%20unhandled%20rejection%20that%20is%20silently%20swallowed%2C%20and%20callers%20%28like%20%60ServiceEditorDialog%60's%20%60onSubmit%60%29%20that%20%60await%20handleUpdate%28payload%29%60%20will%20resolve%20before%20the%20API%20side-effects%20complete.%20Consider%20adding%20%60await%60%20before%20each%20%60handleApiResultWithCallbacks%28...%29%60%20call.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2F2375-swarm-service-update-loading%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F2375-swarm-service-update-loading%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fswarm%2Fservices%2F%5BserviceId%5D%2F%2Bpage.svelte%3A216-226%0A**%60handleApiResultWithCallbacks%60%20not%20awaited**%0A%0A%60handleApiResultWithCallbacks%60%20is%20an%20%60async%60%20function%20but%20is%20never%20%60await%60-ed%20across%20all%20four%20call%20sites%20%28%60handleUpdate%60%2C%20the%20rollback%20action%2C%20the%20delete%20action%2C%20%60handleScale%60%29.%20Because%20the%20result%20is%20already%20resolved%20before%20it's%20passed%20in%2C%20the%20function's%20own%20%60try%2Ffinally%60%20%E2%80%94%20including%20%60setLoadingState%28false%29%60%20and%20both%20%60onSuccess%60%2F%60onError%60%20%E2%80%94%20runs%20in%20a%20floating%20promise.%20Any%20exception%20thrown%20inside%20%28e.g.%20inside%20%60onSuccess%20%E2%86%92%20refreshData%60%29%20becomes%20an%20unhandled%20rejection%20that%20is%20silently%20swallowed%2C%20and%20callers%20%28like%20%60ServiceEditorDialog%60's%20%60onSubmit%60%29%20that%20%60await%20handleUpdate%28payload%29%60%20will%20resolve%20before%20the%20API%20side-effects%20complete.%20Consider%20adding%20%60await%60%20before%20each%20%60handleApiResultWithCallbacks%28...%29%60%20call.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
frontend/src/routes/(app)/swarm/services/[serviceId]/+page.svelte:216-226
**`handleApiResultWithCallbacks` not awaited**

`handleApiResultWithCallbacks` is an `async` function but is never `await`-ed across all four call sites (`handleUpdate`, the rollback action, the delete action, `handleScale`). Because the result is already resolved before it's passed in, the function's own `try/finally` — including `setLoadingState(false)` and both `onSuccess`/`onError` — runs in a floating promise. Any exception thrown inside (e.g. inside `onSuccess → refreshData`) becomes an unhandled rejection that is silently swallowed, and callers (like `ServiceEditorDialog`'s `onSubmit`) that `await handleUpdate(payload)` will resolve before the API side-effects complete. Consider adding `await` before each `handleApiResultWithCallbacks(...)` call.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: show loading state during swarm ser..."](https://github.com/getarcaneapp/arcane/commit/417cea6b158edd03cca8a217a6dcacb10f43aaec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30298915)</sub>

<!-- /greptile_comment -->