### PR TITLE
fix: allow mtls when tls is not managed by arcane

### DIFF
--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -400,7 +400,7 @@ func prepareServerTLSInternal(ctx context.Context, cfg *config.Config) (bool, st
 	}
 
 	if edge.NormalizeEdgeMTLSMode(cfg.EdgeMTLSMode) != edge.EdgeMTLSModeDisabled {
-		if err := edge.ValidateManagerMTLSConfig(edgeCfg, useTLS); err != nil {
+		if err := edge.ValidateManagerMTLSConfig(edgeCfg); err != nil {
 			return false, "", "", nil, err
 		}
 	}

--- a/backend/internal/bootstrap/bootstrap_test.go
+++ b/backend/internal/bootstrap/bootstrap_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/getarcaneapp/arcane/backend/internal/config"
+	libcrypto "github.com/getarcaneapp/arcane/backend/pkg/libarcane/crypto"
 	tunnelpb "github.com/getarcaneapp/arcane/backend/pkg/libarcane/edge/proto/tunnel/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -132,4 +134,31 @@ func TestPrepareServerTLSInternal_AgentModeSkipsManagerMTLSValidation(t *testing
 	assert.Empty(t, tlsKeyFile)
 	require.NotNil(t, edgeCfg)
 	assert.Equal(t, "required", edgeCfg.EdgeMTLSMode)
+}
+
+func TestPrepareServerTLSInternal_AllowsExternalMTLSTermination(t *testing.T) {
+	libcrypto.InitEncryption(&libcrypto.Config{
+		EncryptionKey: "test-encryption-key-for-edge-mtls-32bytes-min",
+		Environment:   "test",
+	})
+
+	assetsDir := t.TempDir()
+	cfg := &config.Config{
+		TLSEnabled:        false,
+		EdgeMTLSMode:      "required",
+		EdgeMTLSAssetsDir: assetsDir,
+		EncryptionKey:     "test-encryption-key-for-edge-mtls-32bytes-min",
+	}
+
+	useTLS, tlsCertFile, tlsKeyFile, edgeCfg, err := prepareServerTLSInternal(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.False(t, useTLS)
+	assert.Empty(t, tlsCertFile)
+	assert.Empty(t, tlsKeyFile)
+	require.NotNil(t, edgeCfg)
+	assert.Equal(t, "required", edgeCfg.EdgeMTLSMode)
+	require.FileExists(t, edgeCfg.EdgeMTLSCAFile)
+	require.FileExists(t, assetsDir+"/ca.crt")
+	_, statErr := os.Stat(assetsDir + "/ca.key")
+	require.NoError(t, statErr)
 }

--- a/backend/pkg/libarcane/edge/server.go
+++ b/backend/pkg/libarcane/edge/server.go
@@ -672,7 +672,7 @@ func (s *TunnelServer) requireClientCertificateInternal(req *http.Request) error
 	if NormalizeEdgeMTLSMode(s.edgeMTLSModeInternal()) != EdgeMTLSModeRequired {
 		return nil
 	}
-	if hasVerifiedPeerCertificateInternal(req.TLS) {
+	if req != nil && req.TLS != nil && hasVerifiedPeerCertificateInternal(req.TLS) {
 		return nil
 	}
 	return errors.New("verified client certificate required")
@@ -684,11 +684,10 @@ func (s *TunnelServer) requireClientCertificateFromContextInternal(ctx context.C
 	}
 
 	p, ok := peer.FromContext(ctx)
-	if !ok {
-		return errors.New("verified client certificate required")
-	}
-	if tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo); ok && hasVerifiedPeerCertificateInternal(&tlsInfo.State) {
-		return nil
+	if ok {
+		if tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo); ok && hasVerifiedPeerCertificateInternal(&tlsInfo.State) {
+			return nil
+		}
 	}
 	return errors.New("verified client certificate required")
 }

--- a/backend/pkg/libarcane/edge/tls.go
+++ b/backend/pkg/libarcane/edge/tls.go
@@ -454,7 +454,7 @@ func ValidateAgentMTLSConfig(cfg *Config) error {
 
 // ValidateManagerMTLSConfig validates the manager-side mTLS configuration used
 // by edge tunnel endpoints.
-func ValidateManagerMTLSConfig(cfg *Config, managerTLSEnabled bool) error {
+func ValidateManagerMTLSConfig(cfg *Config) error {
 	if cfg == nil {
 		return nil
 	}
@@ -462,9 +462,6 @@ func ValidateManagerMTLSConfig(cfg *Config, managerTLSEnabled bool) error {
 	mode := NormalizeEdgeMTLSMode(cfg.EdgeMTLSMode)
 	if mode == EdgeMTLSModeDisabled {
 		return nil
-	}
-	if !managerTLSEnabled {
-		return fmt.Errorf("EDGE_MTLS_MODE requires TLS_ENABLED=true on the manager")
 	}
 
 	if strings.TrimSpace(cfg.EdgeMTLSCAFile) == "" {

--- a/backend/pkg/libarcane/edge/tls_test.go
+++ b/backend/pkg/libarcane/edge/tls_test.go
@@ -22,7 +22,13 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/common"
 	libcrypto "github.com/getarcaneapp/arcane/backend/pkg/libarcane/crypto"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
 )
+
+type testAuthInfo struct{}
+
+func (testAuthInfo) AuthType() string { return "test" }
 
 func TestMain(m *testing.M) {
 	libcrypto.InitEncryption(&libcrypto.Config{
@@ -272,6 +278,76 @@ func TestTunnelServerRequireCertificateIdentityInternal_RejectsWrongEnvironmentU
 
 	require.NoError(t, server.requireCertificateIdentityInternal(state, "env-a"))
 	require.Error(t, server.requireCertificateIdentityInternal(state, "env-b"))
+}
+
+func TestValidateManagerMTLSConfig_DoesNotRequireArcaneTLSTermination(t *testing.T) {
+	assetsDir := t.TempDir()
+	caPath, _, _, err := ensureManagerCAInternal(context.Background(), assetsDir)
+	require.NoError(t, err)
+
+	err = ValidateManagerMTLSConfig(&Config{
+		EdgeMTLSMode:   EdgeMTLSModeRequired,
+		EdgeMTLSCAFile: caPath,
+	})
+	require.NoError(t, err)
+}
+
+func TestValidateManagerMTLSConfig_RejectsMissingOrMalformedCAFile(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		err := ValidateManagerMTLSConfig(&Config{
+			EdgeMTLSMode:   EdgeMTLSModeRequired,
+			EdgeMTLSCAFile: filepath.Join(t.TempDir(), "missing-ca.crt"),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to load edge mTLS CA file")
+	})
+
+	t.Run("malformed file", func(t *testing.T) {
+		caPath := filepath.Join(t.TempDir(), "ca.crt")
+		require.NoError(t, os.WriteFile(caPath, []byte("not a pem"), 0o600))
+
+		err := ValidateManagerMTLSConfig(&Config{
+			EdgeMTLSMode:   EdgeMTLSModeRequired,
+			EdgeMTLSCAFile: caPath,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to load edge mTLS CA file")
+	})
+}
+
+func TestTunnelServerRequiredMTLS_RejectsRequestWithoutTLSState(t *testing.T) {
+	server := NewTunnelServer(nil, nil)
+	server.SetConfig(&Config{
+		EdgeMTLSMode: EdgeMTLSModeRequired,
+		AppURL:       "https://manager.example.com",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tunnel/connect", nil)
+	require.ErrorContains(t, server.requireClientCertificateInternal(req), "verified client certificate required")
+	require.NoError(t, server.requireCertificateIdentityInternal(nil, "env-a"))
+}
+
+func TestTunnelServerRequiredMTLS_RejectsGRPCContextsWithoutVerifiedPeerCertificate(t *testing.T) {
+	server := NewTunnelServer(nil, nil)
+	server.SetConfig(&Config{EdgeMTLSMode: EdgeMTLSModeRequired})
+
+	t.Run("missing peer", func(t *testing.T) {
+		require.ErrorContains(t, server.requireClientCertificateFromContextInternal(context.Background()), "verified client certificate required")
+	})
+
+	t.Run("non tls peer", func(t *testing.T) {
+		ctx := peer.NewContext(context.Background(), &peer.Peer{AuthInfo: testAuthInfo{}})
+		require.ErrorContains(t, server.requireClientCertificateFromContextInternal(ctx), "verified client certificate required")
+	})
+
+	t.Run("verified tls peer", func(t *testing.T) {
+		cert := &x509.Certificate{}
+		ctx := peer.NewContext(context.Background(), &peer.Peer{AuthInfo: credentials.TLSInfo{State: tls.ConnectionState{
+			PeerCertificates: []*x509.Certificate{cert},
+			VerifiedChains:   [][]*x509.Certificate{{cert}},
+		}}})
+		require.NoError(t, server.requireClientCertificateFromContextInternal(ctx))
+	})
 }
 
 func TestAgentMTLSAssetsNeedEnrollmentInternal_RenewsExpiredCertificate(t *testing.T) {

--- a/backend/pkg/libarcane/edge/transport.go
+++ b/backend/pkg/libarcane/edge/transport.go
@@ -92,7 +92,8 @@ const (
 	EdgeMTLSModeDisabled = "disabled"
 	// EdgeMTLSModeOptional enables edge tunnel mTLS when certificates are configured.
 	EdgeMTLSModeOptional = "optional"
-	// EdgeMTLSModeRequired requires a verified client certificate on edge tunnel endpoints.
+	// EdgeMTLSModeRequired requires a verified client certificate on edge tunnel endpoints
+	// when Arcane terminates TLS; external TLS terminators must enforce mTLS before proxying.
 	EdgeMTLSModeRequired = "required"
 )
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the startup enforcement that `TLS_ENABLED=true` is required when `EDGE_MTLS_MODE` is set, allowing deployments where TLS is terminated externally (e.g., by a load balancer or ingress). `ValidateManagerMTLSConfig` loses its `managerTLSEnabled bool` parameter and the associated guard, while the CA-file existence/parse check is preserved through the existing `BuildManagerServerTLSConfig` call. Runtime enforcement in `requireClientCertificateInternal` and `requireClientCertificateFromContextInternal` is logically unchanged — requests without a verified peer certificate are still rejected.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the three security concerns raised in previous review rounds have been fully addressed in the current revision.

No P0 or P1 issues remain. The HTTP-side check (req.TLS == nil → error) and the gRPC-side check (no valid peer → error) are logically equivalent to the pre-PR behaviour. CA-file validation is preserved through the BuildManagerServerTLSConfig call. Tests cover the missing/malformed CA file, the no-TLS-state rejection, and the no-peer/non-TLS-peer rejection paths.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: allow mtls when tls is not managed ..."](https://github.com/getarcaneapp/arcane/commit/21f070236f173069def0c2955c374a1d75ba2790) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30731843)</sub>

<!-- /greptile_comment -->