### PR TITLE
fix: restrict git repository management to admins and block credential reuse on URL changes

### DIFF
--- a/backend/internal/huma/handlers/git_repositories.go
+++ b/backend/internal/huma/handlers/git_repositories.go
@@ -273,6 +273,10 @@ func (h *GitRepositoryHandler) CreateRepository(ctx context.Context, input *Crea
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
+	if err := checkAdmin(ctx); err != nil {
+		return nil, err
+	}
+
 	actor := models.User{}
 	if currentUser, exists := humamw.GetCurrentUserFromContext(ctx); exists && currentUser != nil {
 		actor = *currentUser
@@ -328,6 +332,10 @@ func (h *GitRepositoryHandler) UpdateRepository(ctx context.Context, input *Upda
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
+	if err := checkAdmin(ctx); err != nil {
+		return nil, err
+	}
+
 	actor := models.User{}
 	if currentUser, exists := humamw.GetCurrentUserFromContext(ctx); exists && currentUser != nil {
 		actor = *currentUser
@@ -358,6 +366,10 @@ func (h *GitRepositoryHandler) DeleteRepository(ctx context.Context, input *Dele
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
+	if err := checkAdmin(ctx); err != nil {
+		return nil, err
+	}
+
 	actor := models.User{}
 	if currentUser, exists := humamw.GetCurrentUserFromContext(ctx); exists && currentUser != nil {
 		actor = *currentUser
@@ -382,6 +394,10 @@ func (h *GitRepositoryHandler) DeleteRepository(ctx context.Context, input *Dele
 func (h *GitRepositoryHandler) TestRepository(ctx context.Context, input *TestGitRepositoryInput) (*TestGitRepositoryOutput, error) {
 	if h.repoService == nil {
 		return nil, huma.Error500InternalServerError("service not available")
+	}
+
+	if err := checkAdmin(ctx); err != nil {
+		return nil, err
 	}
 
 	actor := models.User{}

--- a/backend/internal/huma/handlers/git_repositories_test.go
+++ b/backend/internal/huma/handlers/git_repositories_test.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/getarcaneapp/arcane/backend/internal/services"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitRepositoryHandlers_RequireAdmin(t *testing.T) {
+	handler := &GitRepositoryHandler{repoService: &services.GitRepositoryService{}}
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "create repository",
+			call: func() error {
+				_, err := handler.CreateRepository(context.Background(), &CreateGitRepositoryInput{})
+				return err
+			},
+		},
+		{
+			name: "update repository",
+			call: func() error {
+				_, err := handler.UpdateRepository(context.Background(), &UpdateGitRepositoryInput{ID: "repo-1"})
+				return err
+			},
+		},
+		{
+			name: "delete repository",
+			call: func() error {
+				_, err := handler.DeleteRepository(context.Background(), &DeleteGitRepositoryInput{ID: "repo-1"})
+				return err
+			},
+		},
+		{
+			name: "test repository",
+			call: func() error {
+				_, err := handler.TestRepository(context.Background(), &TestGitRepositoryInput{ID: "repo-1", Branch: "main"})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			require.Error(t, err)
+
+			var statusErr huma.StatusError
+			require.ErrorAs(t, err, &statusErr)
+			require.Equal(t, http.StatusForbidden, statusErr.GetStatus())
+			require.Contains(t, statusErr.Error(), "admin access required")
+		})
+	}
+}

--- a/backend/internal/services/git_repository_service.go
+++ b/backend/internal/services/git_repository_service.go
@@ -182,6 +182,10 @@ func (s *GitRepositoryService) UpdateRepository(ctx context.Context, id string, 
 		return nil, err
 	}
 
+	if err := validateGitRepositoryCredentialChangeInternal(repository, req); err != nil {
+		return nil, err
+	}
+
 	updates := make(map[string]any)
 
 	if req.Name != nil {
@@ -250,6 +254,42 @@ func (s *GitRepositoryService) UpdateRepository(ctx context.Context, id string, 
 	}
 
 	return s.GetRepositoryByID(ctx, id)
+}
+
+func validateGitRepositoryCredentialChangeInternal(repository *models.GitRepository, req models.UpdateGitRepositoryRequest) error {
+	if repository == nil || req.URL == nil || *req.URL == repository.URL {
+		return nil
+	}
+
+	missingFields := make([]string, 0, 2)
+	missingCredentialLabels := make([]string, 0, 2)
+
+	if repository.Token != "" && req.Token == nil {
+		missingFields = append(missingFields, "token")
+		missingCredentialLabels = append(missingCredentialLabels, "token")
+	}
+
+	if repository.SSHKey != "" && req.SSHKey == nil {
+		missingFields = append(missingFields, "sshKey")
+		missingCredentialLabels = append(missingCredentialLabels, "SSH key")
+	}
+
+	if len(missingFields) == 0 {
+		return nil
+	}
+
+	if len(missingFields) == 1 {
+		field := missingFields[0]
+		return &models.ValidationError{Field: field, Message: fmt.Sprintf("Changing repository URL requires re-supplying or clearing the %s", missingCredentialLabels[0])}
+	}
+
+	return models.NewValidationError(
+		fmt.Sprintf(
+			"Changing repository URL requires re-supplying or clearing all stored credentials: %s",
+			strings.Join(missingCredentialLabels, " and "),
+		),
+		map[string]any{"fields": missingFields},
+	)
 }
 
 func (s *GitRepositoryService) DeleteRepository(ctx context.Context, id string, actor models.User) error {

--- a/backend/internal/services/git_repository_service_test.go
+++ b/backend/internal/services/git_repository_service_test.go
@@ -1,0 +1,203 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	glsqlite "github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/getarcaneapp/arcane/backend/internal/config"
+	"github.com/getarcaneapp/arcane/backend/internal/database"
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/crypto"
+)
+
+func setupGitRepositoryServiceTestInternal(t *testing.T) (*GitRepositoryService, *database.DB) {
+	t.Helper()
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.NewReplacer("/", "_", " ", "_").Replace(t.Name()))
+	db, err := gorm.Open(glsqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.GitRepository{},
+		&models.GitOpsSync{},
+		&models.Event{},
+		&models.SettingVariable{},
+	))
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+
+	crypto.InitEncryption(&crypto.Config{
+		EncryptionKey: "test-encryption-key-for-git-repos-32bytes-min",
+		Environment:   "test",
+	})
+
+	wrappedDB := &database.DB{DB: db}
+	settingsService, err := NewSettingsService(context.Background(), wrappedDB)
+	require.NoError(t, err)
+
+	eventService := NewEventService(wrappedDB, &config.Config{}, nil)
+
+	return NewGitRepositoryService(wrappedDB, t.TempDir(), eventService, settingsService), wrappedDB
+}
+
+func createGitRepositoryServiceTestRepoInternal(t *testing.T, svc *GitRepositoryService, req models.CreateGitRepositoryRequest) *models.GitRepository {
+	t.Helper()
+
+	repo, err := svc.CreateRepository(context.Background(), req, models.User{
+		BaseModel: models.BaseModel{ID: "admin-1"},
+		Username:  "admin",
+	})
+	require.NoError(t, err)
+	return repo
+}
+
+func gitRepositoryStringPtrInternal(value string) *string {
+	return &value
+}
+
+func TestGitRepositoryService_UpdateRepository_RejectsURLChangeWhenStoredTokenWouldBeReused(t *testing.T) {
+	svc, _ := setupGitRepositoryServiceTestInternal(t)
+	repo := createGitRepositoryServiceTestRepoInternal(t, svc, models.CreateGitRepositoryRequest{
+		Name:     "prod-repo",
+		URL:      "https://github.com/acme/private.git",
+		AuthType: "http",
+		Username: "deploy",
+		Token:    "ghp_old_token",
+	})
+
+	_, err := svc.UpdateRepository(context.Background(), repo.ID, models.UpdateGitRepositoryRequest{
+		URL: gitRepositoryStringPtrInternal("https://attacker.tld/repo.git"),
+	}, models.User{})
+	require.Error(t, err)
+
+	var validationErr *models.ValidationError
+	require.ErrorAs(t, err, &validationErr)
+	assert.Equal(t, "token", validationErr.Field)
+	assert.Contains(t, validationErr.Message, "re-supplying or clearing the token")
+
+	stored, loadErr := svc.GetRepositoryByID(context.Background(), repo.ID)
+	require.NoError(t, loadErr)
+	assert.Equal(t, "https://github.com/acme/private.git", stored.URL)
+	assert.Equal(t, repo.Token, stored.Token)
+}
+
+func TestGitRepositoryService_UpdateRepository_RejectsURLChangeWhenStoredSSHKeyWouldBeReused(t *testing.T) {
+	svc, _ := setupGitRepositoryServiceTestInternal(t)
+	repo := createGitRepositoryServiceTestRepoInternal(t, svc, models.CreateGitRepositoryRequest{
+		Name:     "infra-repo",
+		URL:      "git@github.com:acme/private.git",
+		AuthType: "ssh",
+		SSHKey:   "-----BEGIN OPENSSH PRIVATE KEY-----\nkey-material\n-----END OPENSSH PRIVATE KEY-----",
+	})
+
+	_, err := svc.UpdateRepository(context.Background(), repo.ID, models.UpdateGitRepositoryRequest{
+		URL: gitRepositoryStringPtrInternal("git@attacker.tld:acme/private.git"),
+	}, models.User{})
+	require.Error(t, err)
+
+	var validationErr *models.ValidationError
+	require.ErrorAs(t, err, &validationErr)
+	assert.Equal(t, "sshKey", validationErr.Field)
+	assert.Contains(t, validationErr.Message, "re-supplying or clearing the SSH key")
+
+	stored, loadErr := svc.GetRepositoryByID(context.Background(), repo.ID)
+	require.NoError(t, loadErr)
+	assert.Equal(t, "git@github.com:acme/private.git", stored.URL)
+	assert.Equal(t, repo.SSHKey, stored.SSHKey)
+}
+
+func TestGitRepositoryService_UpdateRepository_RejectsURLChangeWhenStoredTokenAndSSHKeyWouldBeReused(t *testing.T) {
+	svc, _ := setupGitRepositoryServiceTestInternal(t)
+	repo := createGitRepositoryServiceTestRepoInternal(t, svc, models.CreateGitRepositoryRequest{
+		Name:     "hybrid-repo",
+		URL:      "https://github.com/acme/private.git",
+		AuthType: "http",
+		Username: "deploy",
+		Token:    "ghp_old_token",
+		SSHKey:   "-----BEGIN OPENSSH PRIVATE KEY-----\nkey-material\n-----END OPENSSH PRIVATE KEY-----",
+	})
+
+	_, err := svc.UpdateRepository(context.Background(), repo.ID, models.UpdateGitRepositoryRequest{
+		URL: gitRepositoryStringPtrInternal("https://attacker.tld/repo.git"),
+	}, models.User{})
+	require.Error(t, err)
+
+	var apiErr *models.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, models.APIErrorCodeValidationError, apiErr.Code)
+	assert.Contains(t, apiErr.Message, "token and SSH key")
+	assert.Equal(t, map[string]any{"fields": []string{"token", "sshKey"}}, apiErr.Details)
+}
+
+func TestGitRepositoryService_UpdateRepository_AllowsURLChangeWhenTokenIsResupplied(t *testing.T) {
+	svc, _ := setupGitRepositoryServiceTestInternal(t)
+	repo := createGitRepositoryServiceTestRepoInternal(t, svc, models.CreateGitRepositoryRequest{
+		Name:     "prod-repo",
+		URL:      "https://github.com/acme/private.git",
+		AuthType: "http",
+		Username: "deploy",
+		Token:    "ghp_old_token",
+	})
+
+	updated, err := svc.UpdateRepository(context.Background(), repo.ID, models.UpdateGitRepositoryRequest{
+		URL:   gitRepositoryStringPtrInternal("https://github.com/acme/private-rotated.git"),
+		Token: gitRepositoryStringPtrInternal("ghp_new_token"),
+	}, models.User{})
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://github.com/acme/private-rotated.git", updated.URL)
+	decryptedToken, decryptErr := crypto.Decrypt(updated.Token)
+	require.NoError(t, decryptErr)
+	assert.Equal(t, "ghp_new_token", decryptedToken)
+}
+
+func TestGitRepositoryService_UpdateRepository_AllowsURLChangeWhenTokenIsCleared(t *testing.T) {
+	svc, _ := setupGitRepositoryServiceTestInternal(t)
+	repo := createGitRepositoryServiceTestRepoInternal(t, svc, models.CreateGitRepositoryRequest{
+		Name:     "prod-repo",
+		URL:      "https://github.com/acme/private.git",
+		AuthType: "http",
+		Username: "deploy",
+		Token:    "ghp_old_token",
+	})
+
+	updated, err := svc.UpdateRepository(context.Background(), repo.ID, models.UpdateGitRepositoryRequest{
+		URL:   gitRepositoryStringPtrInternal("https://github.com/acme/public.git"),
+		Token: gitRepositoryStringPtrInternal(""),
+	}, models.User{})
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://github.com/acme/public.git", updated.URL)
+	assert.Empty(t, updated.Token)
+}
+
+func TestGitRepositoryService_UpdateRepository_AllowsSameURLWithoutCredentialResupply(t *testing.T) {
+	svc, _ := setupGitRepositoryServiceTestInternal(t)
+	repo := createGitRepositoryServiceTestRepoInternal(t, svc, models.CreateGitRepositoryRequest{
+		Name:     "prod-repo",
+		URL:      "https://github.com/acme/private.git",
+		AuthType: "http",
+		Username: "deploy",
+		Token:    "ghp_old_token",
+	})
+
+	updated, err := svc.UpdateRepository(context.Background(), repo.ID, models.UpdateGitRepositoryRequest{
+		URL:      gitRepositoryStringPtrInternal("https://github.com/acme/private.git"),
+		Username: gitRepositoryStringPtrInternal("deploy-bot"),
+	}, models.User{})
+	require.NoError(t, err)
+
+	assert.Equal(t, "deploy-bot", updated.Username)
+	decryptedToken, decryptErr := crypto.Decrypt(updated.Token)
+	require.NoError(t, decryptErr)
+	assert.Equal(t, "ghp_old_token", decryptedToken)
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds admin-only enforcement to all mutating git repository endpoints (`CreateRepository`, `UpdateRepository`, `DeleteRepository`, `TestRepository`) and introduces a credential-reuse guard in the update service layer that blocks URL changes when stored credentials (token or SSH key) are not explicitly re-supplied or cleared. Both features are well-covered by new unit and integration tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

PR is safe to merge — all changes are additive security controls with no behavioural regressions on existing paths.

No P0 or P1 issues found. Admin guards are correctly positioned and tested. The credential-change validation is logically sound: it distinguishes single vs. multi-credential cases, returns appropriate error types for both, and the test suite covers the full matrix of scenarios (token-only, SSH-only, combined, resupply, clear, same-URL).

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: restrict git repository management ..."](https://github.com/getarcaneapp/arcane/commit/5d5a94447450dc7d4cb6b5764d2efe312ffe3448) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30739936)</sub>

<!-- /greptile_comment -->