### PR TITLE
fix: remove double verification of mTLS certificates

### DIFF
--- a/backend/internal/bootstrap/bootstrap_test.go
+++ b/backend/internal/bootstrap/bootstrap_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/getarcaneapp/arcane/backend/internal/config"
@@ -159,6 +158,5 @@ func TestPrepareServerTLSInternal_AllowsExternalMTLSTermination(t *testing.T) {
 	assert.Equal(t, "required", edgeCfg.EdgeMTLSMode)
 	require.FileExists(t, edgeCfg.EdgeMTLSCAFile)
 	require.FileExists(t, assetsDir+"/ca.crt")
-	_, statErr := os.Stat(assetsDir + "/ca.key")
-	require.NoError(t, statErr)
+	require.FileExists(t, assetsDir+"/ca.key")
 }

--- a/backend/pkg/libarcane/edge/poll_control.go
+++ b/backend/pkg/libarcane/edge/poll_control.go
@@ -266,17 +266,14 @@ func (s *TunnelServer) pollStatusInternal(envID string) TunnelPollResponse {
 func (s *TunnelServer) HandlePoll(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	if err := s.requireClientCertificateInternal(c.Request); err != nil {
-		slog.WarnContext(ctx, "Rejected edge poll request without required client certificate", "error", err)
-		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
-		return
-	}
-
 	if _, err := decodeTunnelPollRequestInternal(c); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid poll payload"})
 		return
 	}
 
+	// In proxy-terminated mTLS deployments, the client certificate is consumed
+	// by the TLS terminator before this request reaches Arcane. The token is
+	// still needed as the poll protocol's environment lookup claim.
 	token := c.GetHeader(HeaderAgentToken)
 	if token == "" {
 		token = c.GetHeader(HeaderAPIKey)
@@ -293,7 +290,7 @@ func (s *TunnelServer) HandlePoll(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid agent token"})
 		return
 	}
-	if err := s.requireCertificateIdentityInternal(c.Request.TLS, envID); err != nil {
+	if err := s.requireRequestCertificateIdentityInternal(c.Request, envID); err != nil {
 		slog.WarnContext(ctx, "Rejected edge poll request with mismatched client certificate", "environment_id", envID, "error", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
 		return

--- a/backend/pkg/libarcane/edge/poll_control_test.go
+++ b/backend/pkg/libarcane/edge/poll_control_test.go
@@ -75,6 +75,34 @@ func TestTunnelServer_HandlePoll(t *testing.T) {
 	assert.Equal(t, EdgeTransportGRPC, resp.ActiveTransport)
 }
 
+func TestTunnelServer_HandlePoll_AcceptsTokenAfterProxyTerminatedMTLS(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := NewTunnelServerWithRegistry(NewTunnelRegistry(), func(ctx context.Context, token string) (string, error) {
+		if token != "valid-token" {
+			return "", errors.New("invalid token")
+		}
+		return "env-proxy-mtls", nil
+	}, nil)
+	server.SetConfig(&Config{
+		EdgeMTLSMode: EdgeMTLSModeRequired,
+		AppURL:       "https://manager.example.com",
+	})
+
+	router := gin.New()
+	router.POST("/api/tunnel/poll", server.HandlePoll)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tunnel/poll", bytes.NewBufferString(`{"transport":"poll"}`))
+	req.Header.Set(HeaderAgentToken, "valid-token")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp TunnelPollResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, TunnelStatusIdle, resp.Status)
+}
+
 func TestPollRuntimeRegistryGetExpiresStaleState(t *testing.T) {
 	r := NewPollRuntimeRegistry()
 	now := time.Now()

--- a/backend/pkg/libarcane/edge/server.go
+++ b/backend/pkg/libarcane/edge/server.go
@@ -136,12 +136,6 @@ func (s *TunnelServer) HandleConnect(c *gin.Context) {
 	ctx := c.Request.Context()
 	callbackCtx := context.WithoutCancel(ctx)
 
-	if err := s.requireClientCertificateInternal(c.Request); err != nil {
-		slog.WarnContext(ctx, "Rejected websocket edge tunnel without required client certificate", "error", err)
-		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
-		return
-	}
-
 	// Upgrade to WebSocket.
 	conn, err := tunnelUpgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
@@ -165,9 +159,9 @@ func (s *TunnelServer) HandleConnect(c *gin.Context) {
 	token := tokenFromHeadersInternal(c.Request)
 	if token == "" {
 		// Header auth can be unavailable after the WebSocket upgrade path, so
-		// the register message remains a fallback token source. Treat it only
-		// as an auth claim; mTLS identity is verified separately below against
-		// the environment resolved from this token.
+		// the register message remains a fallback environment lookup claim.
+		// In proxy-terminated mTLS deployments, the client certificate is the
+		// auth credential and is consumed before the request reaches Arcane.
 		token = strings.TrimSpace(firstMsg.AgentToken)
 	}
 	if token == "" {
@@ -184,7 +178,7 @@ func (s *TunnelServer) HandleConnect(c *gin.Context) {
 		_ = tunnelConn.Close()
 		return
 	}
-	if err := s.requireCertificateIdentityInternal(c.Request.TLS, envID); err != nil {
+	if err := s.requireRequestCertificateIdentityInternal(c.Request, envID); err != nil {
 		slog.WarnContext(ctx, "Rejected websocket edge tunnel with mismatched client certificate", "environment_id", envID, "error", err)
 		_ = tunnelConn.Send(&TunnelMessage{Type: MessageTypeRegisterResponse, Accepted: false, Error: "client certificate does not match environment"})
 		_ = tunnelConn.Close()
@@ -272,6 +266,8 @@ func (s *TunnelServer) HandleMTLSEnroll(c *gin.Context) {
 	}
 	if assets.Reenrolled {
 		slog.WarnContext(ctx, "Edge mTLS certificate assets re-enrolled", "environment_id", envID, "remote_addr", c.ClientIP(), "cert_issued", assets.CertIssued)
+	} else {
+		slog.InfoContext(ctx, "Edge mTLS certificate assets enrolled", "environment_id", envID, "remote_addr", c.ClientIP(), "cert_issued", assets.CertIssued)
 	}
 
 	if s.enrollmentCallback != nil {
@@ -589,10 +585,6 @@ func (s *TunnelServer) authStreamInterceptorInternal(ctx context.Context) grpc.S
 			return handler(srv, ss)
 		}
 
-		if err := s.requireClientCertificateFromContextInternal(ss.Context()); err != nil {
-			return status.Error(codes.Unauthenticated, err.Error())
-		}
-
 		token := tokenFromMetadata(ss.Context())
 		envID, err := s.resolveEnvironment(ss.Context(), token)
 		if err != nil {
@@ -668,35 +660,18 @@ func resolvedEnvironmentIDFromContextInternal(ctx context.Context) (string, bool
 	return envID, true
 }
 
-func (s *TunnelServer) requireClientCertificateInternal(req *http.Request) error {
-	if NormalizeEdgeMTLSMode(s.edgeMTLSModeInternal()) != EdgeMTLSModeRequired {
-		return nil
-	}
-	if req != nil && req.TLS != nil && hasVerifiedPeerCertificateInternal(req.TLS) {
-		return nil
-	}
-	return errors.New("verified client certificate required")
-}
-
-func (s *TunnelServer) requireClientCertificateFromContextInternal(ctx context.Context) error {
-	if NormalizeEdgeMTLSMode(s.edgeMTLSModeInternal()) != EdgeMTLSModeRequired {
-		return nil
-	}
-
-	p, ok := peer.FromContext(ctx)
-	if ok {
-		if tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo); ok && hasVerifiedPeerCertificateInternal(&tlsInfo.State) {
-			return nil
-		}
-	}
-	return errors.New("verified client certificate required")
-}
-
 func (s *TunnelServer) requireCertificateIdentityInternal(state *tls.ConnectionState, envID string) error {
 	if NormalizeEdgeMTLSMode(s.edgeMTLSModeInternal()) == EdgeMTLSModeDisabled {
 		return nil
 	}
 	return verifiedPeerCertificateEnvironmentIDMatchesInternal(state, envID, edgeMTLSTrustDomainInternal(s.cfg))
+}
+
+func (s *TunnelServer) requireRequestCertificateIdentityInternal(req *http.Request, envID string) error {
+	if req == nil || req.TLS == nil || !hasVerifiedPeerCertificateInternal(req.TLS) {
+		return nil
+	}
+	return s.requireCertificateIdentityInternal(req.TLS, envID)
 }
 
 func (s *TunnelServer) requireCertificateIdentityFromContextInternal(ctx context.Context, envID string) error {

--- a/backend/pkg/libarcane/edge/server_test.go
+++ b/backend/pkg/libarcane/edge/server_test.go
@@ -170,6 +170,55 @@ func TestTunnelServer_HandleConnect(t *testing.T) {
 	reg.Unregister("env-connected")
 }
 
+func TestTunnelServer_HandleConnect_AcceptsTokenAfterProxyTerminatedMTLS(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := NewTunnelServer(func(ctx context.Context, token string) (string, error) {
+		if token == "valid-token" {
+			return "env-proxy-mtls", nil
+		}
+		return "", errors.New("invalid token")
+	}, nil)
+	server.SetConfig(&Config{
+		EdgeMTLSMode: EdgeMTLSModeRequired,
+		AppURL:       "https://manager.example.com",
+	})
+
+	router := gin.New()
+	router.GET("/connect", server.HandleConnect)
+
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	url := "ws" + strings.TrimPrefix(ts.URL, "http") + "/connect"
+	headers := http.Header{}
+	headers.Set(HeaderAgentToken, "valid-token")
+
+	conn, resp, err := websocket.DefaultDialer.Dial(url, headers)
+	require.NoError(t, err)
+	if resp != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+	defer func() { _ = conn.Close() }()
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+
+	err = conn.WriteJSON(&TunnelMessage{
+		Type:          MessageTypeRegister,
+		AgentToken:    "valid-token",
+		AgentInstance: "agent-proxy-mtls",
+	})
+	require.NoError(t, err)
+
+	var registerResp TunnelMessage
+	err = conn.ReadJSON(&registerResp)
+	require.NoError(t, err)
+	require.Equal(t, MessageTypeRegisterResponse, registerResp.Type)
+	require.True(t, registerResp.Accepted)
+	require.Equal(t, "token", registerResp.SecurityMode)
+
+	GetRegistry().Unregister("env-proxy-mtls")
+}
+
 func TestTunnelServer_HandleConnect_InvalidToken(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/pkg/libarcane/edge/tls.go
+++ b/backend/pkg/libarcane/edge/tls.go
@@ -88,11 +88,12 @@ func BuildManagerServerTLSConfig(cfg *Config) (*tls.Config, error) {
 	}
 
 	// ClientAuth is intentionally VerifyClientCertIfGiven even when
-	// EdgeMTLSMode is "required". Enforcement of "required" mode is done
-	// per-request at the application layer (see TunnelServer.requireClientCertificate*
-	// in server.go) so that the mTLS enrollment endpoint, which agents must
-	// reach before they own a client certificate, remains accessible. If the
-	// handshake were set to RequireAndVerifyClientCert, bootstrap would fail.
+	// EdgeMTLSMode is "required". Enforcement of certificate identity is done
+	// per-request at the application layer so that the mTLS enrollment endpoint,
+	// which agents must reach before they own a client certificate, remains
+	// accessible. In proxy-terminated deployments the TLS state is not visible
+	// here; identity is enforced by the upstream proxy.
+	// If the handshake were set to RequireAndVerifyClientCert, bootstrap would fail.
 	// TODO: reload ClientCAs when CA rotation support is added.
 	return &tls.Config{
 		MinVersion: tls.VersionTLS12,
@@ -465,11 +466,14 @@ func ValidateManagerMTLSConfig(cfg *Config) error {
 	}
 
 	if strings.TrimSpace(cfg.EdgeMTLSCAFile) == "" {
-		return fmt.Errorf("EDGE_MTLS_MODE=%s requires EDGE_MTLS_CA_FILE on the manager", mode)
+		return nil
 	}
 
-	_, err := BuildManagerServerTLSConfig(cfg)
-	return err
+	_, err := loadCertPoolInternal(cfg.EdgeMTLSCAFile)
+	if err != nil {
+		return fmt.Errorf("failed to load edge mTLS CA file: %w", err)
+	}
+	return nil
 }
 
 func loadCertPoolInternal(caFile string) (*x509.CertPool, error) {
@@ -582,15 +586,17 @@ func setAgentMTLSAssetPathsInternal(cfg *Config, assetsDir string) {
 }
 
 func requestSecurityModeInternal(req *http.Request) string {
-	if req == nil || req.TLS == nil {
-		return "token"
-	}
-
-	if hasVerifiedPeerCertificateInternal(req.TLS) {
+	if hasVerifiedEdgeMTLSRequestInternal(req) {
 		return "mtls"
 	}
-
 	return "token"
+}
+
+func hasVerifiedEdgeMTLSRequestInternal(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	return req.TLS != nil && hasVerifiedPeerCertificateInternal(req.TLS)
 }
 
 func grpcContextSecurityModeInternal(pctx peer.Peer) string {

--- a/backend/pkg/libarcane/edge/tls_test.go
+++ b/backend/pkg/libarcane/edge/tls_test.go
@@ -281,6 +281,10 @@ func TestTunnelServerRequireCertificateIdentityInternal_RejectsWrongEnvironmentU
 }
 
 func TestValidateManagerMTLSConfig_DoesNotRequireArcaneTLSTermination(t *testing.T) {
+	require.NoError(t, ValidateManagerMTLSConfig(&Config{
+		EdgeMTLSMode: EdgeMTLSModeRequired,
+	}))
+
 	assetsDir := t.TempDir()
 	caPath, _, _, err := ensureManagerCAInternal(context.Background(), assetsDir)
 	require.NoError(t, err)
@@ -315,7 +319,7 @@ func TestValidateManagerMTLSConfig_RejectsMissingOrMalformedCAFile(t *testing.T)
 	})
 }
 
-func TestTunnelServerRequiredMTLS_RejectsRequestWithoutTLSState(t *testing.T) {
+func TestTunnelServerRequiredMTLS_AllowsHTTPRequestsWithoutVisibleTLSState(t *testing.T) {
 	server := NewTunnelServer(nil, nil)
 	server.SetConfig(&Config{
 		EdgeMTLSMode: EdgeMTLSModeRequired,
@@ -323,30 +327,80 @@ func TestTunnelServerRequiredMTLS_RejectsRequestWithoutTLSState(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/tunnel/connect", nil)
-	require.ErrorContains(t, server.requireClientCertificateInternal(req), "verified client certificate required")
-	require.NoError(t, server.requireCertificateIdentityInternal(nil, "env-a"))
+	require.NoError(t, server.requireRequestCertificateIdentityInternal(req, "env-a"))
 }
 
-func TestTunnelServerRequiredMTLS_RejectsGRPCContextsWithoutVerifiedPeerCertificate(t *testing.T) {
+func TestTunnelServerRequiredMTLS_DetectsOnlyDirectTLSForRequestSecurityMode(t *testing.T) {
+	server := NewTunnelServer(nil, nil)
+	server.SetConfig(&Config{
+		EdgeMTLSMode: EdgeMTLSModeRequired,
+		AppURL:       "https://manager.example.com",
+	})
+
+	cert := &x509.Certificate{}
+	req := httptest.NewRequest(http.MethodGet, "/api/tunnel/connect", nil)
+	req.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{cert},
+		VerifiedChains:   [][]*x509.Certificate{{cert}},
+	}
+	require.Equal(t, "mtls", requestSecurityModeInternal(req))
+
+	req = httptest.NewRequest(http.MethodGet, "/api/tunnel/connect", nil)
+	req.Header.Set("X-SSL-Client-Verify", "SUCCESS")
+	require.Equal(t, "token", requestSecurityModeInternal(req))
+	require.NoError(t, server.requireRequestCertificateIdentityInternal(req, "env-a"))
+}
+
+func TestTunnelServerRequiredMTLS_IgnoresProxyVerificationHeaders(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "empty", value: ""},
+		{name: "success", value: "SUCCESS"},
+		{name: "true", value: "true"},
+		{name: "none", value: "NONE"},
+		{name: "failed", value: "FAILED"},
+		{name: "unknown", value: "probably"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/tunnel/connect", nil)
+			req.Header.Set("X-SSL-Client-Verify", tt.value)
+
+			require.Equal(t, "token", requestSecurityModeInternal(req))
+		})
+	}
+}
+
+func TestTunnelServerRequiredMTLS_AllowsGRPCContextsWithoutVisibleTLSState(t *testing.T) {
 	server := NewTunnelServer(nil, nil)
 	server.SetConfig(&Config{EdgeMTLSMode: EdgeMTLSModeRequired})
 
 	t.Run("missing peer", func(t *testing.T) {
-		require.ErrorContains(t, server.requireClientCertificateFromContextInternal(context.Background()), "verified client certificate required")
+		require.NoError(t, server.requireCertificateIdentityFromContextInternal(context.Background(), "env-a"))
 	})
 
 	t.Run("non tls peer", func(t *testing.T) {
 		ctx := peer.NewContext(context.Background(), &peer.Peer{AuthInfo: testAuthInfo{}})
-		require.ErrorContains(t, server.requireClientCertificateFromContextInternal(ctx), "verified client certificate required")
+		require.NoError(t, server.requireCertificateIdentityFromContextInternal(ctx, "env-a"))
 	})
 
-	t.Run("verified tls peer", func(t *testing.T) {
-		cert := &x509.Certificate{}
+	t.Run("verified tls peer checks identity", func(t *testing.T) {
+		uriSAN, err := url.Parse("spiffe://manager.example.com/edge/env-a")
+		require.NoError(t, err)
+		cert := &x509.Certificate{URIs: []*url.URL{uriSAN}}
 		ctx := peer.NewContext(context.Background(), &peer.Peer{AuthInfo: credentials.TLSInfo{State: tls.ConnectionState{
 			PeerCertificates: []*x509.Certificate{cert},
 			VerifiedChains:   [][]*x509.Certificate{{cert}},
 		}}})
-		require.NoError(t, server.requireClientCertificateFromContextInternal(ctx))
+		server.SetConfig(&Config{
+			EdgeMTLSMode: EdgeMTLSModeRequired,
+			AppURL:       "https://manager.example.com",
+		})
+		require.NoError(t, server.requireCertificateIdentityFromContextInternal(ctx, "env-a"))
+		require.Error(t, server.requireCertificateIdentityFromContextInternal(ctx, "env-b"))
 	})
 }
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the redundant "certificate presence" gate (`requireClientCertificateInternal` / `requireClientCertificateFromContextInternal`) from the WebSocket, poll, and gRPC connection paths, replacing it with `requireRequestCertificateIdentityInternal`. The new helper skips the cert check entirely when no TLS state is visible — supporting proxy-terminated mTLS — and enforces SPIFFE identity only when a direct TLS cert is present. `ValidateManagerMTLSConfig` now accepts an empty CA file in required mode, and `requestSecurityModeInternal` is refactored to only inspect `req.TLS` (never proxy headers). Test coverage is thorough, including explicit assertions that `X-SSL-Client-Verify` headers are ignored.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all connection paths remain protected by mandatory token validation; cert identity is verified as defense-in-depth when a direct TLS cert is visible.

All three connection handlers still require a valid agent token; requireRequestCertificateIdentityInternal enforces SPIFFE identity when a cert is directly present and intentionally skips the check for proxy-terminated deployments. Tests explicitly cover proxy header rejection, direct TLS identity enforcement, and mTLS-required mode without visible TLS state. No authentication bypass is introduced.

No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/pkg/libarcane/edge/tls.go`, line 90-96 ([link](https://github.com/getarcaneapp/arcane/blob/e3a0d450dc2c8533033d677c15364a55e405d1af/backend/pkg/libarcane/edge/tls.go#L90-L96)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> Stale comment references removed functions. `requireClientCertificate*` was deleted by this PR, so the comment now misleads anyone reading the TLS config about where "required" mode is enforced.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/pkg/libarcane/edge/tls.go
   Line: 90-96

   Comment:
   Stale comment references removed functions. `requireClientCertificate*` was deleted by this PR, so the comment now misleads anyone reading the TLS config about where "required" mode is enforced.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fmtls-double-verify%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fmtls-double-verify%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Flibarcane%2Fedge%2Ftls.go%0ALine%3A%2090-96%0A%0AComment%3A%0AStale%20comment%20references%20removed%20functions.%20%60requireClientCertificate*%60%20was%20deleted%20by%20this%20PR%2C%20so%20the%20comment%20now%20misleads%20anyone%20reading%20the%20TLS%20config%20about%20where%20%22required%22%20mode%20is%20enforced.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20ClientAuth%20is%20intentionally%20VerifyClientCertIfGiven%20even%20when%0A%09%2F%2F%20EdgeMTLSMode%20is%20%22required%22.%20Enforcement%20of%20certificate%20identity%20is%20done%0A%09%2F%2F%20per-request%20at%20the%20application%20layer%20so%20that%20the%20mTLS%20enrollment%20endpoint%2C%0A%09%2F%2F%20which%20agents%20must%20reach%20before%20they%20own%20a%20client%20certificate%2C%20remains%0A%09%2F%2F%20accessible.%20In%20proxy-terminated%20deployments%20the%20TLS%20state%20is%20not%20visible%0A%09%2F%2F%20here%3B%20identity%20is%20enforced%20by%20the%20upstream%20proxy.%0A%09%2F%2F%20If%20the%20handshake%20were%20set%20to%20RequireAndVerifyClientCert%2C%20bootstrap%20would%20fail.%0A%09%2F%2F%20TODO%3A%20reload%20ClientCAs%20when%20CA%20rotation%20support%20is%20added.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Flibarcane%2Fedge%2Ftls.go%0ALine%3A%2090-96%0A%0AComment%3A%0AStale%20comment%20references%20removed%20functions.%20%60requireClientCertificate*%60%20was%20deleted%20by%20this%20PR%2C%20so%20the%20comment%20now%20misleads%20anyone%20reading%20the%20TLS%20config%20about%20where%20%22required%22%20mode%20is%20enforced.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20ClientAuth%20is%20intentionally%20VerifyClientCertIfGiven%20even%20when%0A%09%2F%2F%20EdgeMTLSMode%20is%20%22required%22.%20Enforcement%20of%20certificate%20identity%20is%20done%0A%09%2F%2F%20per-request%20at%20the%20application%20layer%20so%20that%20the%20mTLS%20enrollment%20endpoint%2C%0A%09%2F%2F%20which%20agents%20must%20reach%20before%20they%20own%20a%20client%20certificate%2C%20remains%0A%09%2F%2F%20accessible.%20In%20proxy-terminated%20deployments%20the%20TLS%20state%20is%20not%20visible%0A%09%2F%2F%20here%3B%20identity%20is%20enforced%20by%20the%20upstream%20proxy.%0A%09%2F%2F%20If%20the%20handshake%20were%20set%20to%20RequireAndVerifyClientCert%2C%20bootstrap%20would%20fail.%0A%09%2F%2F%20TODO%3A%20reload%20ClientCAs%20when%20CA%20rotation%20support%20is%20added.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2505&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: remove double verification of mTLS ..."](https://github.com/getarcaneapp/arcane/commit/53364bf9ba59d3f9fe14e3b988167e504c2e5701) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30768606)</sub>

<!-- /greptile_comment -->