### PR TITLE
fix: image update checks fail on mobile due to incorrect id

### DIFF
--- a/frontend/src/routes/(app)/containers/container-table.svelte
+++ b/frontend/src/routes/(app)/containers/container-table.svelte
@@ -563,7 +563,7 @@
 							<div class="mt-1">
 								<ImageUpdateItem
 									updateInfo={item.updateInfo}
-									imageId={item.id}
+									imageId={item.imageId}
 									repo={imageRef.repo}
 									tag={imageRef.tag}
 									onUpdateContainer={() => handleUpdateContainer(item)}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2498

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The mobile card in `container-table.svelte` was passing `item.id` (the container ID) to `ImageUpdateItem`'s `imageId` prop instead of `item.imageId`. This caused image update checks to fail on mobile because the wrong ID was being used. The fix brings the mobile path in line with the desktop `UpdatesCell` snippet, which already used `item.imageId`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-character fix to a prop value that brings the mobile card in line with the already-correct desktop rendering path.

The change is a minimal, targeted correction to a single prop in the mobile card. It mirrors the desktop snippet's existing behavior and has no side effects on other logic.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: image update checks fail on mobile ..."](https://github.com/getarcaneapp/arcane/commit/c699cd2b58589cdfc29faeccd8d6bafc584cbc38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30772050)</sub>

<!-- /greptile_comment -->