### PR TITLE
fix: add registry.gitlab.com to trustedAuthDelegations

### DIFF
--- a/backend/pkg/utils/distribution/distribution.go
+++ b/backend/pkg/utils/distribution/distribution.go
@@ -23,8 +23,9 @@ const dockerHubRateLimitRepository = "ratelimitpreview/test"
 // Some registries serve images under their own domain but delegate token auth to a
 // separate host (e.g. lscr.io delegates to ghcr.io).
 var trustedAuthDelegations = map[string]string{
-	"docker.io": "auth.docker.io",
-	"lscr.io":   "ghcr.io",
+	"docker.io":           "auth.docker.io",
+	"lscr.io":             "ghcr.io",
+	"registry.gitlab.com": "gitlab.com",
 }
 
 type Credentials struct {

--- a/backend/pkg/utils/distribution/distribution_test.go
+++ b/backend/pkg/utils/distribution/distribution_test.go
@@ -334,6 +334,11 @@ func TestValidateAuthRealmInternal(t *testing.T) {
 			realm:        "https://ghcr.io/token",
 		},
 		{
+			name:         "registry.gitlab.com delegates auth to gitlab.com",
+			registryHost: "registry.gitlab.com",
+			realm:        "https://gitlab.com/jwt/auth",
+		},
+		{
 			name:         "non https realm rejected",
 			registryHost: "registry.example.com",
 			realm:        "http://registry.example.com/token",


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2497

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `registry.gitlab.com` → `gitlab.com` to the `trustedAuthDelegations` allowlist in `distribution.go`, enabling token-auth flows where GitLab's container registry redirects auth challenges to `https://gitlab.com/jwt/auth`. A matching unit test case is added alongside existing delegation tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is a one-line addition to a hardcoded allowlist with a corresponding unit test — no logic paths are altered and the new entry accurately reflects GitLab's published auth delegation.

The `trustedAuthDelegations` map is only consulted inside `validateAuthRealmInternal`, which already enforces HTTPS and rejects any host not in the map or matching the registry itself. Adding `registry.gitlab.com` → `gitlab.com` follows the exact same pattern as the existing `lscr.io` → `ghcr.io` entry and is covered by a new table-driven test case. No edge cases are introduced.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add registry.gitlab.com to trustedA..."](https://github.com/getarcaneapp/arcane/commit/87ce1cb417f1bb28936d5a5821c87a5180361048) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30772923)</sub>

<!-- /greptile_comment -->